### PR TITLE
fix(one): one strict rule for what every nearby-place category means

### DIFF
--- a/consent-protocol/hushh_mcp/services/google_maps_service.py
+++ b/consent-protocol/hushh_mcp/services/google_maps_service.py
@@ -233,11 +233,20 @@ NearbyPlaceCategory = Literal[
 # 478. Splitting them makes chips free and let the classifier become
 # exhaustive, which is what "no place is silently skipped" needs.
 #
-# Bucket COUNT is the cost -- one request per bucket, so keep it at seven. The
-# types inside a bucket are free up to Google's cap of 50 per request, which is
-# why worship and government venues are swept alongside landmarks rather than
-# earning buckets of their own. They are still classified into their own chips
-# on the way out.
+# Bucket COUNT is the cost -- one request per bucket. Nine, up from seven.
+#
+# The types inside a bucket are NOT free, which is the trap. Google caps
+# `includedTypes` at 50, so a wide bucket costs nothing to ASK; but the response
+# is capped at 20 and ranked by distance, so every type in a bucket competes for
+# the same twenty slots. Worship and government were briefly folded in alongside
+# landmarks to keep the count at seven, and in a pilgrimage city -- which is
+# where this was reported -- twenty nearby temples would take every slot and the
+# Leisure chip would render empty at a spot that has parks and museums in range.
+#
+# So the rule is: a bucket's types must classify to that bucket's own chip.
+# `test_every_swept_type_belongs_to_the_bucket_that_fetches_it` pins it, and it
+# is a better guard than the count -- it catches the starvation this comment is
+# about, which a count never would.
 #
 # "All" issues one request per bucket here, concurrently, and merges the
 # results. That costs more provider calls per drawer open than the single
@@ -269,13 +278,15 @@ _NEARBY_SWEEP_TYPES: dict[str, tuple[str, ...]] = {
         # Everyday errands people wait at, same reasoning.
         "bank",
         "atm",
-        "post_office",
-        "gym",
     ),
     # Every lodging leaf, not just the six we happened to name. A guest house,
     # an inn or a resort is exactly what somebody standing outside one expects
     # the Hotels chip to have found.
-    "hotels_stays": _taxonomy.FAMILY_LODGING,
+    # The chip's own leaves, not the whole Lodging family: a campsite, a camping
+    # cabin and an RV park are Leisure, and a mobile-home park is somewhere
+    # people live, so fetching them here would spend this bucket's twenty
+    # distance-ranked slots on rows the Hotels chip will not show.
+    "hotels_stays": _taxonomy.CHIP_TYPES["hotels_stays"],
     "education": (
         "school",
         "university",
@@ -298,14 +309,27 @@ _NEARBY_SWEEP_TYPES: dict[str, tuple[str, ...]] = {
         "garden",
         "plaza",
         "stadium",
+        "gym",
+        "fitness_center",
         "movie_theater",
         "night_club",
         "event_venue",
         "community_center",
         "zoo",
-        *_taxonomy.FAMILY_WORSHIP,
-        *_taxonomy.FAMILY_GOVERNMENT,
+        "campground",
+        "rv_park",
     ),
+    # Their own buckets, and worth the two extra calls. Neither family was in any
+    # bucket before, so a temple, a mosque or a police station was only ever
+    # returned by the single unfiltered sweep -- which the note above explains is
+    # routinely saturated by the nearest cafes -- and then matched no chip and
+    # vanished behind the first tap.
+    "worship": _taxonomy.FAMILY_WORSHIP,
+    # `post_office` used to be fetched by the shops bucket; it is a government
+    # counter, so it is classified as Civic and is fetched here now. `gym` left
+    # the shops bucket for the same reason -- it is Leisure, and the landmarks
+    # bucket already reaches it.
+    "civic": _taxonomy.FAMILY_GOVERNMENT,
     "transit": (
         "transit_station",
         "bus_stop",

--- a/consent-protocol/hushh_mcp/services/google_maps_service.py
+++ b/consent-protocol/hushh_mcp/services/google_maps_service.py
@@ -20,6 +20,7 @@ from cachetools import TTLCache
 from redis import asyncio as redis_asyncio
 
 from hushh_mcp.config import GOOGLE_MAPS_API_KEY
+from hushh_mcp.services import place_taxonomy as _taxonomy
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,11 @@ _NEARBY_CHECK_IN_MERGED_LIMIT = 80
 _PLACES_CACHE_TTL_SECONDS = 600.0
 _PLACES_CACHE_CELL_DECIMALS = 3
 _PLACES_CACHE_MAX_ENTRIES = 2_000
-_PLACES_CACHE_KEY_PREFIX = "places-cache:v1:"
+# v2: the taxonomy rewrite changed both `categories` and the row subtitle, and a
+# cached row carries the fully shaped result. Without a new namespace the old
+# revision keeps writing old-taxonomy rows into the same keys through a rolling
+# deploy, and the fix reads as half-applied for the TTL.
+_PLACES_CACHE_KEY_PREFIX = "places-cache:v2:"
 _REDIS_OP_TIMEOUT_SECONDS = 0.5
 
 # A module-level indirection so a test can freeze/advance time deterministically
@@ -215,8 +220,25 @@ NearbyPlaceCategory = Literal[
     "education",
     "outdoors_landmarks",
     "transit",
+    "worship",
+    "civic",
+    "other",
 ]
 
+# THE REQUEST SIDE. Recall only -- this table decides what we ASK Google for,
+# never what a place is shown as. Classification lives in
+# `hushh_mcp.services.place_taxonomy`, and the two are deliberately separate:
+# a chip used to BE a request, so adding one cost a provider call on every
+# drawer open, and the taxonomy stayed at 52 hand-picked types out of Table A's
+# 478. Splitting them makes chips free and let the classifier become
+# exhaustive, which is what "no place is silently skipped" needs.
+#
+# Bucket COUNT is the cost -- one request per bucket, so keep it at seven. The
+# types inside a bucket are free up to Google's cap of 50 per request, which is
+# why worship and government venues are swept alongside landmarks rather than
+# earning buckets of their own. They are still classified into their own chips
+# on the way out.
+#
 # "All" issues one request per bucket here, concurrently, and merges the
 # results. That costs more provider calls per drawer open than the single
 # unfiltered request it replaced, and buys the only thing that makes the picker
@@ -226,7 +248,7 @@ NearbyPlaceCategory = Literal[
 # These are broad Table A types from Places API (New): Google includes matching
 # specialized subtypes (for example an Indian restaurant when `restaurant` is
 # requested).
-_NEARBY_PLACE_CATEGORY_TYPES: dict[str, tuple[str, ...]] = {
+_NEARBY_SWEEP_TYPES: dict[str, tuple[str, ...]] = {
     "food_drink": ("restaurant", "cafe", "bakery", "bar", "meal_takeaway"),
     "health": ("hospital", "medical_clinic", "doctor", "dentist", "pharmacy"),
     "shopping_services": (
@@ -250,14 +272,10 @@ _NEARBY_PLACE_CATEGORY_TYPES: dict[str, tuple[str, ...]] = {
         "post_office",
         "gym",
     ),
-    "hotels_stays": (
-        "hotel",
-        "lodging",
-        "motel",
-        "hostel",
-        "bed_and_breakfast",
-        "campground",
-    ),
+    # Every lodging leaf, not just the six we happened to name. A guest house,
+    # an inn or a resort is exactly what somebody standing outside one expects
+    # the Hotels chip to have found.
+    "hotels_stays": _taxonomy.FAMILY_LODGING,
     "education": (
         "school",
         "university",
@@ -265,6 +283,11 @@ _NEARBY_PLACE_CATEGORY_TYPES: dict[str, tuple[str, ...]] = {
         "library",
         "educational_institution",
     ),
+    # Landmarks, plus the two families that had no way of being fetched at all:
+    # a temple, a mosque, a police station and a government office appeared in
+    # no bucket, so they surfaced only when Google happened to return them
+    # unfiltered -- and then matched no chip and vanished behind the first tap.
+    # Swept here, chipped as Worship and Civic.
     "outdoors_landmarks": (
         "park",
         "tourist_attraction",
@@ -274,6 +297,14 @@ _NEARBY_PLACE_CATEGORY_TYPES: dict[str, tuple[str, ...]] = {
         "beach",
         "garden",
         "plaza",
+        "stadium",
+        "movie_theater",
+        "night_club",
+        "event_venue",
+        "community_center",
+        "zoo",
+        *_taxonomy.FAMILY_WORSHIP,
+        *_taxonomy.FAMILY_GOVERNMENT,
     ),
     "transit": (
         "transit_station",
@@ -321,7 +352,7 @@ _NON_CHECK_IN_PRIMARY_TYPE_PREFIXES = (
 _GENERIC_ESTABLISHMENT_TYPES = frozenset({"establishment", "point_of_interest"})
 
 
-# Deliberately a SEPARATE table from `_NEARBY_PLACE_CATEGORY_TYPES`, not an
+# Deliberately a SEPARATE table from `_NEARBY_SWEEP_TYPES`, not an
 # extension of it. `nearby_places` builds its "All" sweep by iterating that dict,
 # so every key added there becomes another concurrent provider call on every
 # check-in drawer open. The directory needs finer buckets than the picker wants
@@ -416,21 +447,10 @@ _DIRECTORY_DETAIL_FIELD_MASK = (
 )
 
 
-def _build_category_index() -> dict[str, tuple[str, ...]]:
-    """Reverse index from a Places type to the drawer's category chips.
-
-    Built from the same table the requests use, so a place surfaced by the
-    unfiltered sweep still lands under the right chip without a second call.
-    """
-
-    index: dict[str, tuple[str, ...]] = {}
-    for category, place_types in _NEARBY_PLACE_CATEGORY_TYPES.items():
-        for place_type in place_types:
-            index[place_type] = (*index.get(place_type, ()), category)
-    return index
-
-
-_CATEGORY_BY_PLACE_TYPE = _build_category_index()
+# Kept as a module-level name because the classifier used to live here. The
+# mapping itself is `place_taxonomy.CHIP_BY_PLACE_TYPE`, which is exhaustive over
+# Table A rather than derived from whatever the sweep happens to request.
+_CATEGORY_BY_PLACE_TYPE = _taxonomy.CHIP_BY_PLACE_TYPE
 
 
 def _place_types(place: dict[str, Any]) -> list[str]:
@@ -456,14 +476,9 @@ def _is_non_check_in_type(place_type: str) -> bool:
 
 
 def _place_categories(place_types: list[str]) -> list[str]:
-    """Category chips this place belongs to, in the table's declared order."""
+    """Category chips this place belongs to. Never empty -- see `place_taxonomy`."""
 
-    matched = {
-        category
-        for place_type in place_types
-        for category in _CATEGORY_BY_PLACE_TYPE.get(place_type, ())
-    }
-    return [category for category in _NEARBY_PLACE_CATEGORY_TYPES if category in matched]
+    return _taxonomy.place_categories(place_types)
 
 
 class GoogleMapsError(RuntimeError):
@@ -954,9 +969,11 @@ class GoogleMapsService:
         primary_type_display = place.get("primaryTypeDisplayName") or {}
         if not isinstance(primary_type_display, dict):
             primary_type_display = {}
-        category_label = str(primary_type_display.get("text") or "").strip()[:80]
-        if not category_label and primary_type:
-            category_label = primary_type.replace("_", " ").title()
+        # Our wording where Google's reads as a classification rather than a
+        # description. "Lodging" under a place named "... Lounge" is what the
+        # report was actually looking at: a true label, in a vocabulary nobody
+        # outside the Places API speaks.
+        category_label = _taxonomy.display_label(primary_type, primary_type_display.get("text"))
         return {
             "placeId": place_id,
             "name": display,
@@ -969,7 +986,7 @@ class GoogleMapsService:
             "latitude": place_lat,
             "longitude": place_lng,
             "primaryType": primary_type or None,
-            "category": category_label or "Place",
+            "category": category_label,
             "categories": _place_categories(place_types),
         }
 
@@ -1010,10 +1027,10 @@ class GoogleMapsService:
         if category == "all":
             requests = [
                 (None, None),
-                *((chip, types) for chip, types in _NEARBY_PLACE_CATEGORY_TYPES.items()),
+                *((chip, types) for chip, types in _NEARBY_SWEEP_TYPES.items()),
             ]
         else:
-            requests = [(category, _NEARBY_PLACE_CATEGORY_TYPES.get(category))]
+            requests = [(category, _NEARBY_SWEEP_TYPES.get(category))]
 
         async with _async_client() as client:
             batches = await asyncio.gather(
@@ -1032,10 +1049,8 @@ class GoogleMapsService:
 
         merged: dict[str, dict[str, Any]] = {}
         order: dict[str, int] = {}
-        chips: dict[str, set[str]] = {}
-        fallback_chips: dict[str, set[str]] = {}
         failures = 0
-        for (request_chip, _types), batch in zip(requests, batches, strict=True):
+        for (_request_chip, _types), batch in zip(requests, batches, strict=True):
             if isinstance(batch, BaseException):
                 # One bucket failing must not empty the whole picker; the rest
                 # of the sweep is still a better list than no list.
@@ -1046,25 +1061,22 @@ class GoogleMapsService:
                 if normalized is None:
                     continue
                 place_id = str(normalized["placeId"])
-                chips.setdefault(place_id, set()).update(normalized["categories"])
-                if request_chip:
-                    # Remember which filters surfaced this place. Used only as a
-                    # fallback below, so a precisely-typed venue keeps precise
-                    # chips and is never filed under a category it is not in.
-                    fallback_chips.setdefault(place_id, set()).add(request_chip)
                 if place_id not in merged:
                     merged[place_id] = normalized
                     order[place_id] = source_index
                 else:
                     order[place_id] = min(order[place_id], source_index)
 
-        for place_id, place in merged.items():
-            # A venue Google reports with only `establishment` maps to no chip
-            # of its own, yet a category filter still surfaced it -- an
-            # independent hotel is the common case. File it under the filters
-            # that found it so tapping "Hotels" cannot hide it.
-            matched = chips.get(place_id) or fallback_chips.get(place_id, set())
-            place["categories"] = [chip for chip in _NEARBY_PLACE_CATEGORY_TYPES if chip in matched]
+        # A place is classified by WHAT IT IS, never by which request surfaced it.
+        #
+        # It used to be filed under whichever bucket's sweep returned it when its
+        # own types matched no chip -- written so an independent hotel Google
+        # knows only as `establishment` would not vanish behind the Hotels chip.
+        # The same rule filed a lounge under Hotels, because the hotels sweep is
+        # what happened to find it. `place_taxonomy` answers both halves now: it
+        # is exhaustive, so almost nothing is unclassifiable, and what remains
+        # lands in `other` -- a real chip, so the venue is still reachable
+        # rather than hidden.
 
         if not merged and failures == len(batches):
             raise GoogleMapsError("Nearby places lookup failed.", status_code=502)

--- a/consent-protocol/hushh_mcp/services/place_taxonomy.py
+++ b/consent-protocol/hushh_mcp/services/place_taxonomy.py
@@ -1,0 +1,808 @@
+"""One statement of what each nearby-place category MEANS.
+
+Reported, with a screenshot, from Prayagraj: tapping the check-in drawer's
+"Hotels" chip listed a lounge, a construction firm and two lodges. The question
+that came with it is the one this module exists to answer -- "sabhi
+categorization ke liye strict rules / definition hain hamare paas?" -- together
+with a hard requirement that no place may be silently skipped.
+
+WHAT WAS ACTUALLY WRONG
+
+Not what it looked like. The drawer's row subtitle is Google's own
+``primaryTypeDisplayName``, so a row reading "Lodging" proves Google itself
+reports ``lodging`` as that place's primary type. Two of the five rows were
+therefore correct and only worded badly -- in India a "Residency" and a "lodge"
+ARE places you pay to sleep in. What was genuinely wrong was three things:
+
+1. A place carrying BOTH a precise type and a vague one was filed under both.
+   A lounge that Google also tags ``lodging`` appeared under Hotels, because
+   every matching type voted equally. See `place_categories`.
+2. The table was 52 hand-picked types out of Table A's ~500. Anything outside
+   it -- a temple, a mosque, a police station, a cinema, a stadium -- matched no
+   category at all and vanished the moment any chip was tapped. In a pilgrimage
+   city that is a bigger hole than the lounge.
+3. "Hotels" contained campsites and mobile-home parks, which are not a room for
+   the night.
+
+THE RULES, IN ONE PLACE
+
+* Every Table A type Google can return belongs to EXACTLY ONE chip. The
+  partition is checked at import time (`_build_chip_index` raises on a type
+  claimed twice) and asserted exhaustively by the tests.
+* A place is classified by WHAT IT IS, never by which request surfaced it.
+* A precise type always beats a vague one. `_VAGUE_TYPES` are the umbrella
+  buckets Google hangs whole families off; they decide a place's category only
+  when nothing precise is known about it.
+* A place that matches nothing is `other`, which is a real, visible chip. This
+  function cannot return an empty list, which is what makes "nothing is
+  skipped" a property rather than a hope.
+
+Pure: no I/O, no clock, no provider call. `google_maps_service` owns the
+requests; this module owns the meaning.
+
+Table A and Table B were transcribed verbatim from
+https://developers.google.com/maps/documentation/places/web-service/place-types
+on 2026-08-31. Regenerate from that page when Google adds types; the
+exhaustiveness test fails loudly rather than letting a new type go missing.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Table A, under Google's own category headings.
+#
+# These are the REQUESTABLE, RETURNABLE types. Grouped exactly as the docs group
+# them so a future regeneration is a diff against one page rather than a
+# judgement call.
+# ---------------------------------------------------------------------------
+
+FAMILY_AUTOMOTIVE = (
+    "car_dealer",
+    "car_rental",
+    "car_repair",
+    "car_wash",
+    "ebike_charging_station",
+    "electric_vehicle_charging_station",
+    "gas_station",
+    "parking",
+    "parking_garage",
+    "parking_lot",
+    "rest_stop",
+    "tire_shop",
+    "truck_dealer",
+)
+
+FAMILY_BUSINESS = (
+    "business_center",
+    "corporate_office",
+    "coworking_space",
+    "farm",
+    "manufacturer",
+    "ranch",
+    "supplier",
+    "television_studio",
+)
+
+FAMILY_CULTURE = (
+    "art_gallery",
+    "art_museum",
+    "art_studio",
+    "auditorium",
+    "castle",
+    "cultural_landmark",
+    "fountain",
+    "historical_place",
+    "history_museum",
+    "monument",
+    "museum",
+    "performing_arts_theater",
+    "sculpture",
+)
+
+FAMILY_EDUCATION = (
+    "academic_department",
+    "educational_institution",
+    "library",
+    "preschool",
+    "primary_school",
+    "research_institute",
+    "school",
+    "secondary_school",
+    "university",
+)
+
+FAMILY_ENTERTAINMENT = (
+    "adventure_sports_center",
+    "amphitheatre",
+    "amusement_center",
+    "amusement_park",
+    "aquarium",
+    "banquet_hall",
+    "barbecue_area",
+    "botanical_garden",
+    "bowling_alley",
+    "casino",
+    "childrens_camp",
+    "city_park",
+    "comedy_club",
+    "community_center",
+    "concert_hall",
+    "convention_center",
+    "cultural_center",
+    "cycling_park",
+    "dance_hall",
+    "dog_park",
+    "event_venue",
+    "ferris_wheel",
+    "garden",
+    "go_karting_venue",
+    "hiking_area",
+    "historical_landmark",
+    "indoor_playground",
+    "internet_cafe",
+    "karaoke",
+    "live_music_venue",
+    "marina",
+    "miniature_golf_course",
+    "movie_rental",
+    "movie_theater",
+    "national_park",
+    "night_club",
+    "observation_deck",
+    "off_roading_area",
+    "opera_house",
+    "paintball_center",
+    "park",
+    "philharmonic_hall",
+    "picnic_ground",
+    "planetarium",
+    "plaza",
+    "roller_coaster",
+    "skateboard_park",
+    "state_park",
+    "tourist_attraction",
+    "video_arcade",
+    "vineyard",
+    "visitor_center",
+    "water_park",
+    "wedding_venue",
+    "wildlife_park",
+    "wildlife_refuge",
+    "zoo",
+)
+
+FAMILY_FACILITIES = ("public_bath", "public_bathroom", "stable")
+
+FAMILY_FINANCE = ("accounting", "atm", "bank")
+
+FAMILY_FOOD_DRINK = (
+    "acai_shop",
+    "afghani_restaurant",
+    "african_restaurant",
+    "american_restaurant",
+    "argentinian_restaurant",
+    "asian_fusion_restaurant",
+    "asian_restaurant",
+    "australian_restaurant",
+    "austrian_restaurant",
+    "bagel_shop",
+    "bakery",
+    "bangladeshi_restaurant",
+    "bar",
+    "bar_and_grill",
+    "barbecue_restaurant",
+    "basque_restaurant",
+    "bavarian_restaurant",
+    "beer_garden",
+    "belgian_restaurant",
+    "bistro",
+    "brazilian_restaurant",
+    "breakfast_restaurant",
+    "brewery",
+    "brewpub",
+    "british_restaurant",
+    "brunch_restaurant",
+    "buffet_restaurant",
+    "burmese_restaurant",
+    "burrito_restaurant",
+    "cafe",
+    "cafeteria",
+    "cajun_restaurant",
+    "cake_shop",
+    "californian_restaurant",
+    "cambodian_restaurant",
+    "candy_store",
+    "cantonese_restaurant",
+    "caribbean_restaurant",
+    "cat_cafe",
+    "chicken_restaurant",
+    "chicken_wings_restaurant",
+    "chilean_restaurant",
+    "chinese_noodle_restaurant",
+    "chinese_restaurant",
+    "chocolate_factory",
+    "chocolate_shop",
+    "cocktail_bar",
+    "coffee_roastery",
+    "coffee_shop",
+    "coffee_stand",
+    "colombian_restaurant",
+    "confectionery",
+    "croatian_restaurant",
+    "cuban_restaurant",
+    "czech_restaurant",
+    "danish_restaurant",
+    "deli",
+    "dessert_restaurant",
+    "dessert_shop",
+    "dim_sum_restaurant",
+    "diner",
+    "dog_cafe",
+    "donut_shop",
+    "dumpling_restaurant",
+    "dutch_restaurant",
+    "eastern_european_restaurant",
+    "ethiopian_restaurant",
+    "european_restaurant",
+    "falafel_restaurant",
+    "family_restaurant",
+    "fast_food_restaurant",
+    "filipino_restaurant",
+    "fine_dining_restaurant",
+    "fish_and_chips_restaurant",
+    "fondue_restaurant",
+    "food_court",
+    "french_restaurant",
+    "fusion_restaurant",
+    "gastropub",
+    "german_restaurant",
+    "greek_restaurant",
+    "gyro_restaurant",
+    "halal_restaurant",
+    "hamburger_restaurant",
+    "hawaiian_restaurant",
+    "hookah_bar",
+    "hot_dog_restaurant",
+    "hot_dog_stand",
+    "hot_pot_restaurant",
+    "hungarian_restaurant",
+    "ice_cream_shop",
+    "indian_restaurant",
+    "indonesian_restaurant",
+    "irish_pub",
+    "irish_restaurant",
+    "israeli_restaurant",
+    "italian_restaurant",
+    "japanese_curry_restaurant",
+    "japanese_izakaya_restaurant",
+    "japanese_restaurant",
+    "juice_shop",
+    "kebab_shop",
+    "korean_barbecue_restaurant",
+    "korean_restaurant",
+    "latin_american_restaurant",
+    "lebanese_restaurant",
+    "lounge_bar",
+    "malaysian_restaurant",
+    "meal_delivery",
+    "meal_takeaway",
+    "mediterranean_restaurant",
+    "mexican_restaurant",
+    "middle_eastern_restaurant",
+    "mongolian_barbecue_restaurant",
+    "moroccan_restaurant",
+    "noodle_shop",
+    "north_indian_restaurant",
+    "oyster_bar_restaurant",
+    "pakistani_restaurant",
+    "pastry_shop",
+    "persian_restaurant",
+    "peruvian_restaurant",
+    "pizza_delivery",
+    "pizza_restaurant",
+    "polish_restaurant",
+    "portuguese_restaurant",
+    "pub",
+    "ramen_restaurant",
+    "restaurant",
+    "romanian_restaurant",
+    "russian_restaurant",
+    "salad_shop",
+    "sandwich_shop",
+    "scandinavian_restaurant",
+    "seafood_restaurant",
+    "shawarma_restaurant",
+    "snack_bar",
+    "soul_food_restaurant",
+    "soup_restaurant",
+    "south_american_restaurant",
+    "south_indian_restaurant",
+    "southwestern_us_restaurant",
+    "spanish_restaurant",
+    "sports_bar",
+    "sri_lankan_restaurant",
+    "steak_house",
+    "sushi_restaurant",
+    "swiss_restaurant",
+    "taco_restaurant",
+    "taiwanese_restaurant",
+    "tapas_restaurant",
+    "tea_house",
+    "tex_mex_restaurant",
+    "thai_restaurant",
+    "tibetan_restaurant",
+    "tonkatsu_restaurant",
+    "turkish_restaurant",
+    "ukrainian_restaurant",
+    "vegan_restaurant",
+    "vegetarian_restaurant",
+    "vietnamese_restaurant",
+    "western_restaurant",
+    "wine_bar",
+    "winery",
+    "yakiniku_restaurant",
+    "yakitori_restaurant",
+)
+
+# Not a chip. A country or a postcode is not somewhere you stand, and
+# `google_maps_service` rejects these before classification ever runs. Kept here
+# so the exhaustiveness test can subtract them explicitly rather than by
+# omission.
+FAMILY_GEOGRAPHIC = (
+    "administrative_area_level_1",
+    "administrative_area_level_2",
+    "country",
+    "locality",
+    "postal_code",
+    "school_district",
+)
+
+FAMILY_GOVERNMENT = (
+    "city_hall",
+    "courthouse",
+    "embassy",
+    "fire_station",
+    "government_office",
+    "local_government_office",
+    "neighborhood_police_station",
+    "police",
+    "post_office",
+)
+
+FAMILY_HEALTH = (
+    "chiropractor",
+    "dental_clinic",
+    "dentist",
+    "doctor",
+    "drugstore",
+    "general_hospital",
+    "hospital",
+    "massage",
+    "massage_spa",
+    "medical_center",
+    "medical_clinic",
+    "medical_lab",
+    "pharmacy",
+    "physiotherapist",
+    "sauna",
+    "skin_care_clinic",
+    "spa",
+    "tanning_studio",
+    "wellness_center",
+    "yoga_studio",
+)
+
+FAMILY_HOUSING = (
+    "apartment_building",
+    "apartment_complex",
+    "condominium_complex",
+    "housing_complex",
+)
+
+FAMILY_LODGING = (
+    "bed_and_breakfast",
+    "budget_japanese_inn",
+    "campground",
+    "camping_cabin",
+    "cottage",
+    "extended_stay_hotel",
+    "farmstay",
+    "guest_house",
+    "hostel",
+    "hotel",
+    "inn",
+    "japanese_inn",
+    "lodging",
+    "mobile_home_park",
+    "motel",
+    "private_guest_room",
+    "resort_hotel",
+    "rv_park",
+)
+
+FAMILY_NATURAL = (
+    "beach",
+    "island",
+    "lake",
+    "mountain_peak",
+    "nature_preserve",
+    "river",
+    "scenic_spot",
+    "woods",
+)
+
+FAMILY_WORSHIP = (
+    "buddhist_temple",
+    "church",
+    "hindu_temple",
+    "mosque",
+    "shinto_shrine",
+    "synagogue",
+)
+
+FAMILY_SERVICES = (
+    "aircraft_rental_service",
+    "association_or_organization",
+    "astrologer",
+    "barber_shop",
+    "beautician",
+    "beauty_salon",
+    "body_art_service",
+    "catering_service",
+    "cemetery",
+    "chauffeur_service",
+    "child_care_agency",
+    "consultant",
+    "courier_service",
+    "electrician",
+    "employment_agency",
+    "florist",
+    "food_delivery",
+    "foot_care",
+    "funeral_home",
+    "hair_care",
+    "hair_salon",
+    "insurance_agency",
+    "laundry",
+    "lawyer",
+    "locksmith",
+    "makeup_artist",
+    "marketing_consultant",
+    "moving_company",
+    "nail_salon",
+    "non_profit_organization",
+    "painter",
+    "pet_boarding_service",
+    "pet_care",
+    "plumber",
+    "psychic",
+    "real_estate_agency",
+    "roofing_contractor",
+    "service",
+    "shipping_service",
+    "storage",
+    "summer_camp_organizer",
+    "tailor",
+    "telecommunications_service_provider",
+    "tour_agency",
+    "tourist_information_center",
+    "travel_agency",
+    "veterinary_care",
+)
+
+FAMILY_SHOPPING = (
+    "asian_grocery_store",
+    "auto_parts_store",
+    "bicycle_store",
+    "book_store",
+    "building_materials_store",
+    "butcher_shop",
+    "cell_phone_store",
+    "clothing_store",
+    "convenience_store",
+    "cosmetics_store",
+    "department_store",
+    "discount_store",
+    "discount_supermarket",
+    "electronics_store",
+    "farmers_market",
+    "flea_market",
+    "food_store",
+    "furniture_store",
+    "garden_center",
+    "general_store",
+    "gift_shop",
+    "grocery_store",
+    "hardware_store",
+    "health_food_store",
+    "home_goods_store",
+    "home_improvement_store",
+    "hypermarket",
+    "jewelry_store",
+    "liquor_store",
+    "market",
+    "pet_store",
+    "shoe_store",
+    "shopping_mall",
+    "sporting_goods_store",
+    "sportswear_store",
+    "store",
+    "supermarket",
+    "tea_store",
+    "thrift_store",
+    "toy_store",
+    "warehouse_store",
+    "wholesaler",
+    "womens_clothing_store",
+)
+
+FAMILY_SPORTS = (
+    "arena",
+    "athletic_field",
+    "fishing_charter",
+    "fishing_pier",
+    "fishing_pond",
+    "fitness_center",
+    "golf_course",
+    "gym",
+    "ice_skating_rink",
+    "indoor_golf_course",
+    "playground",
+    "race_course",
+    "ski_resort",
+    "sports_activity_location",
+    "sports_club",
+    "sports_coaching",
+    "sports_complex",
+    "sports_school",
+    "stadium",
+    "swimming_pool",
+    "tennis_court",
+)
+
+FAMILY_TRANSPORT = (
+    "airport",
+    "airstrip",
+    "bike_sharing_station",
+    "bridge",
+    "bus_station",
+    "bus_stop",
+    "ferry_service",
+    "ferry_terminal",
+    "heliport",
+    "international_airport",
+    "light_rail_station",
+    "park_and_ride",
+    "subway_station",
+    "taxi_service",
+    "taxi_stand",
+    "toll_station",
+    "train_station",
+    "train_ticket_office",
+    "tram_stop",
+    "transit_depot",
+    "transit_station",
+    "transit_stop",
+    "transportation_service",
+    "truck_stop",
+)
+
+#: Every Table A type, for the exhaustiveness check.
+TABLE_A_TYPES: frozenset[str] = frozenset(
+    (
+        *FAMILY_AUTOMOTIVE,
+        *FAMILY_BUSINESS,
+        *FAMILY_CULTURE,
+        *FAMILY_EDUCATION,
+        *FAMILY_ENTERTAINMENT,
+        *FAMILY_FACILITIES,
+        *FAMILY_FINANCE,
+        *FAMILY_FOOD_DRINK,
+        *FAMILY_GEOGRAPHIC,
+        *FAMILY_GOVERNMENT,
+        *FAMILY_HEALTH,
+        *FAMILY_HOUSING,
+        *FAMILY_LODGING,
+        *FAMILY_NATURAL,
+        *FAMILY_WORSHIP,
+        *FAMILY_SERVICES,
+        *FAMILY_SHOPPING,
+        *FAMILY_SPORTS,
+        *FAMILY_TRANSPORT,
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# The chips
+# ---------------------------------------------------------------------------
+
+#: Somewhere you can pay to sleep for the night.
+#:
+#: The Lodging family minus the four that are not a room: a campsite, a camping
+#: cabin and an RV park are leisure, and a mobile-home park is somewhere people
+#: live. `lodging` itself stays -- it is Google's word for a small guest house or
+#: lodge, which genuinely is a place to stay, and dropping it would hide most of
+#: India's budget accommodation.
+_CHIP_HOTELS = tuple(
+    place_type
+    for place_type in FAMILY_LODGING
+    if place_type not in {"campground", "camping_cabin", "rv_park", "mobile_home_park"}
+)
+
+#: Somewhere you go to spend time rather than to transact.
+_CHIP_LEISURE = (
+    *FAMILY_ENTERTAINMENT,
+    *FAMILY_CULTURE,
+    *FAMILY_NATURAL,
+    *FAMILY_SPORTS,
+    "campground",
+    "camping_cabin",
+    "rv_park",
+)
+
+#: A real venue that is none of the above -- offices, homes, farms, industry,
+#: public facilities -- plus every venue Google names but does not describe.
+_CHIP_OTHER = (
+    *FAMILY_HOUSING,
+    *FAMILY_BUSINESS,
+    *FAMILY_FACILITIES,
+    "mobile_home_park",
+)
+
+#: Which chip owns which Google type. Exhaustive over Table A minus the
+#: geographic family, which is rejected before classification.
+#:
+#: Insertion order is the order chips render, and `place_categories` returns in
+#: this order, so a place in two chips reads the same way everywhere.
+CHIP_TYPES: dict[str, tuple[str, ...]] = {
+    "food_drink": FAMILY_FOOD_DRINK,
+    "health": FAMILY_HEALTH,
+    "shopping_services": (
+        *FAMILY_SHOPPING,
+        *FAMILY_SERVICES,
+        *FAMILY_FINANCE,
+        *FAMILY_AUTOMOTIVE,
+    ),
+    "hotels_stays": _CHIP_HOTELS,
+    "education": FAMILY_EDUCATION,
+    "outdoors_landmarks": _CHIP_LEISURE,
+    "transit": FAMILY_TRANSPORT,
+    "worship": FAMILY_WORSHIP,
+    "civic": FAMILY_GOVERNMENT,
+    "other": _CHIP_OTHER,
+}
+
+#: The chip a place lands in when nothing else claims it. A real chip, not a
+#: silent drop -- this is what makes "no place is skipped" true.
+FALLBACK_CHIP = "other"
+
+#: Table B is response-only ("Values from Table B may NOT be used as part of a
+#: request"), but two of its members carry real classification signal and are
+#: worth reading off a place that has nothing better.
+TABLE_B_CHIPS: dict[str, str] = {
+    "general_contractor": "shopping_services",
+    "place_of_worship": "worship",
+}
+
+#: Umbrella types Google hangs whole families off. They describe a place only
+#: when nothing precise is known about it.
+#:
+#: This is the rule that stops a lounge appearing under Hotels. Google tags some
+#: venues with BOTH a precise type and a vague parent -- `lounge_bar` AND
+#: `lodging` -- and when every match voted equally the place was filed under
+#: both, so it turned up under a chip it plainly does not belong to. A precise
+#: type now wins outright.
+VAGUE_TYPES: frozenset[str] = frozenset(
+    {
+        "establishment",
+        "point_of_interest",
+        "food",
+        "health",
+        "finance",
+        "landmark",
+        "natural_feature",
+        "lodging",
+        "store",
+        "service",
+        "school",
+        "educational_institution",
+        "doctor",
+        "transit_station",
+        "sports_activity_location",
+        "government_office",
+        "association_or_organization",
+    }
+)
+
+
+def _build_chip_index() -> dict[str, str]:
+    """Reverse `CHIP_TYPES` into one chip per Google type.
+
+    Raises at import time when two chips claim the same type. The partition is
+    the whole contract of this module -- a type in two chips means a place shows
+    under a category somebody has decided it does not belong to, which is the
+    defect this module was written for.
+    """
+
+    index: dict[str, str] = {}
+    for chip, place_types in CHIP_TYPES.items():
+        for place_type in place_types:
+            existing = index.get(place_type)
+            if existing is not None and existing != chip:
+                raise ValueError(
+                    f"Place type {place_type!r} is claimed by both {existing!r} and {chip!r}. "
+                    "Every type belongs to exactly one chip."
+                )
+            index[place_type] = chip
+    return index
+
+
+CHIP_BY_PLACE_TYPE: dict[str, str] = _build_chip_index()
+
+
+def place_categories(place_types: list[str] | tuple[str, ...]) -> list[str]:
+    """The chips a place belongs to, in chip order. Never empty.
+
+    Precise beats vague: a venue reported as both `lounge_bar` and `lodging` is
+    food and drink, not a hotel. Only when a place has nothing precise does an
+    umbrella type decide it, which is how a small guest house Google knows only
+    as `lodging` still reaches the Hotels chip.
+
+    A place nothing claims is `other`, so every row the drawer shows is
+    reachable from some chip.
+    """
+
+    precise: set[str] = set()
+    vague: set[str] = set()
+    for place_type in place_types:
+        chip = CHIP_BY_PLACE_TYPE.get(place_type) or TABLE_B_CHIPS.get(place_type)
+        if chip is None:
+            continue
+        if place_type in VAGUE_TYPES:
+            vague.add(chip)
+        else:
+            precise.add(chip)
+
+    matched = precise or vague
+    if not matched:
+        return [FALLBACK_CHIP]
+    return [chip for chip in CHIP_TYPES if chip in matched]
+
+
+#: Google's own label reads as a classification rather than a description for a
+#: handful of types ("Lodging"), or over-claims on a listing it knows little
+#: about. We name those in our own words; every other type keeps Google's
+#: localized label, which is better than anything we would write.
+DISPLAY_LABEL_OVERRIDES: dict[str, str] = {
+    "lodging": "Place to stay",
+    "guest_house": "Guest house",
+    "private_guest_room": "Guest room",
+    "extended_stay_hotel": "Serviced stay",
+    "resort_hotel": "Resort",
+    "establishment": "Place",
+    "point_of_interest": "Place",
+    "general_contractor": "Contractor",
+    "real_estate_agency": "Estate agent",
+    "association_or_organization": "Organisation",
+    "service": "Service",
+    "store": "Shop",
+}
+
+
+def display_label(primary_type: str | None, provider_label: str | None) -> str:
+    """The one line under a place's name in the picker.
+
+    Prefers our own wording where Google's is confusing, then Google's own
+    localized label, then a readable form of the raw type, then "Place". Never
+    empty: a row with no supporting line reads as a loading state.
+    """
+
+    override = DISPLAY_LABEL_OVERRIDES.get(str(primary_type or ""))
+    if override:
+        return override
+    label = str(provider_label or "").strip()
+    if label:
+        return label[:80]
+    readable = str(primary_type or "").replace("_", " ").strip()
+    return readable.title()[:80] if readable else "Place"

--- a/consent-protocol/hushh_mcp/services/place_taxonomy.py
+++ b/consent-protocol/hushh_mcp/services/place_taxonomy.py
@@ -630,6 +630,24 @@ _CHIP_HOTELS = tuple(
     if place_type not in {"campground", "camping_cabin", "rv_park", "mobile_home_park"}
 )
 
+#: Google's Automotive family splits across two chips by what you are there to
+#: do. Parking, fuelling and charging are part of getting somewhere, and both
+#: `parking` and `gas_station` were reachable from Transit before this taxonomy
+#: existed -- moving them would be a silent reclassification of a place somebody
+#: already knows where to find. Buying, renting or repairing a vehicle is a shop.
+_AUTOMOTIVE_TRANSPORT = (
+    "parking",
+    "parking_garage",
+    "parking_lot",
+    "rest_stop",
+    "gas_station",
+    "ebike_charging_station",
+    "electric_vehicle_charging_station",
+)
+_AUTOMOTIVE_RETAIL = tuple(
+    place_type for place_type in FAMILY_AUTOMOTIVE if place_type not in set(_AUTOMOTIVE_TRANSPORT)
+)
+
 #: Somewhere you go to spend time rather than to transact.
 _CHIP_LEISURE = (
     *FAMILY_ENTERTAINMENT,
@@ -662,12 +680,12 @@ CHIP_TYPES: dict[str, tuple[str, ...]] = {
         *FAMILY_SHOPPING,
         *FAMILY_SERVICES,
         *FAMILY_FINANCE,
-        *FAMILY_AUTOMOTIVE,
+        *_AUTOMOTIVE_RETAIL,
     ),
     "hotels_stays": _CHIP_HOTELS,
     "education": FAMILY_EDUCATION,
     "outdoors_landmarks": _CHIP_LEISURE,
-    "transit": FAMILY_TRANSPORT,
+    "transit": (*FAMILY_TRANSPORT, *_AUTOMOTIVE_TRANSPORT),
     "worship": FAMILY_WORSHIP,
     "civic": FAMILY_GOVERNMENT,
     "other": _CHIP_OTHER,

--- a/consent-protocol/pyproject.toml
+++ b/consent-protocol/pyproject.toml
@@ -191,6 +191,9 @@ follow_imports = "skip"
 module = [
     "hushh_mcp.services.one_location_agent_service",
     "hushh_mcp.services.connections_service",
+    # A pure table plus one classifier. Cheap to check, and its return types are
+    # what `google_maps_service` builds a response contract on.
+    "hushh_mcp.services.place_taxonomy",
 ]
 follow_imports = "normal"
 

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -108,6 +108,13 @@ tests/test_contact_match_correctness.py
 # live access alone -- plus the ones added with #6256, which is the defect
 # an unrun suite let through (approving "30 min more" REPLACED the 1h50m it
 # was meant to add to).
+# The nearby-place taxonomy behind the check-in drawer. None of these ran in any
+# lane, which is how "Hotels" came to list a lounge and a construction firm while
+# temples, mosques and police stations matched no category at all: ruff, mypy and
+# bandit were the only things reading this code.
+tests/test_place_taxonomy.py
+tests/services/test_google_maps_service.py
+tests/test_places_directory.py
 tests/services/test_one_location_extra_time_requests.py
 tests/services/test_one_location_circle_service.py
 tests/services/test_people_search_sql.py

--- a/consent-protocol/tests/services/test_google_maps_service.py
+++ b/consent-protocol/tests/services/test_google_maps_service.py
@@ -235,7 +235,7 @@ async def test_nearby_places_all_sweeps_every_category_bucket(monkeypatch):
     place_ids = [place["placeId"] for place in result]
 
     assert None in seen_included_types
-    assert len(seen_included_types) == len(gms._NEARBY_PLACE_CATEGORY_TYPES) + 1
+    assert len(seen_included_types) == len(gms._NEARBY_SWEEP_TYPES) + 1
     # Both hotels survive the cafe flood, and the one with no primaryType does
     # not get silently dropped.
     assert "hotel-1" in place_ids
@@ -249,7 +249,7 @@ async def test_nearby_places_all_sweeps_every_category_bucket(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_nearby_places_files_a_generic_venue_under_the_chip_that_found_it(
+async def test_nearby_places_files_a_venue_it_cannot_describe_under_more(
     monkeypatch,
 ):
     """An `establishment`-only venue must still be reachable from its chip.
@@ -284,7 +284,14 @@ async def test_nearby_places_files_a_generic_venue_under_the_chip_that_found_it(
     result = await gms.GoogleMapsService().nearby_places(lat=37.4275, lng=-122.1697)
 
     assert [place["placeId"] for place in result] == ["generic-hotel"]
-    assert result[0]["categories"] == ["hotels_stays"]
+    # Under "More", not under "Hotels".
+    #
+    # It used to be filed under whichever sweep returned it, so that a venue
+    # Google describes only as `establishment` would not vanish behind the
+    # Hotels chip. The same rule put a lounge there, because the hotels sweep is
+    # what happened to find it -- which is the reported defect. The place is
+    # still reachable, from the chip that means "we could not tell".
+    assert result[0]["categories"] == ["other"]
 
 
 @pytest.mark.asyncio
@@ -362,7 +369,9 @@ async def test_nearby_places_still_rejects_address_records_without_primary_type(
     result = await gms.GoogleMapsService().nearby_places(lat=37.4275, lng=-122.1697)
 
     assert [place["placeId"] for place in result] == ["named-venue"]
-    assert result[0]["categories"] == []
+    # Never `[]`. An empty list is a row the client's filter drops from every
+    # chip, so the venue was visible under "All" and unfindable afterwards.
+    assert result[0]["categories"] == ["other"]
 
 
 @pytest.mark.asyncio
@@ -1069,3 +1078,131 @@ async def test_search_directory_category_also_writes_through_to_redis(monkeypatc
     )
     assert cache_key in fake.store
     assert fake.set_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_nearby_places_does_not_file_a_lounge_under_hotels(monkeypatch):
+    """The reported row, end to end through the merge.
+
+    "Mishra Lounge" arrived on the Hotels sweep carrying Google's own `lodging`
+    type, and the drawer filed it under Hotels twice over -- once because
+    `lodging` was a hotels type outright, and once because the hotels request is
+    what returned it. A precise type wins now, and the request does not vote at
+    all.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode())
+        included = body.get("includedTypes")
+        if included and "hotel" in included:
+            return httpx.Response(
+                200,
+                json={
+                    "places": [
+                        _hotel(
+                            "mishra-lounge",
+                            name="Mishra Lounge",
+                            lat=37.4276,
+                            primaryType="lounge_bar",
+                            types=["lounge_bar", "lodging", "establishment"],
+                            primaryTypeDisplayName={"text": "Lounge bar"},
+                        )
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"places": []})
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+
+    result = await gms.GoogleMapsService().nearby_places(lat=37.4275, lng=-122.1697)
+
+    assert [place["placeId"] for place in result] == ["mishra-lounge"]
+    assert result[0]["categories"] == ["food_drink"]
+    assert "hotels_stays" not in result[0]["categories"]
+
+
+@pytest.mark.asyncio
+async def test_nearby_places_reaches_a_temple_and_files_it_under_worship(monkeypatch):
+    """Neither half of this worked before.
+
+    A temple was in no sweep bucket, so it was only ever returned by the
+    unfiltered pass, and it matched no chip, so it disappeared behind the first
+    tap. In Prayagraj that is a larger hole than the one that was reported.
+    """
+
+    seen_included_types: list[list[str] | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode())
+        included = body.get("includedTypes")
+        seen_included_types.append(included)
+        if included and "hindu_temple" in included:
+            return httpx.Response(
+                200,
+                json={
+                    "places": [
+                        _hotel(
+                            "temple",
+                            name="Hanuman Mandir",
+                            lat=37.4276,
+                            primaryType="hindu_temple",
+                            types=["hindu_temple", "place_of_worship", "establishment"],
+                            primaryTypeDisplayName={"text": "Hindu temple"},
+                        )
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"places": []})
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+
+    result = await gms.GoogleMapsService().nearby_places(lat=37.4275, lng=-122.1697)
+
+    assert any(included and "hindu_temple" in included for included in seen_included_types), (
+        "no sweep bucket asks Google for a temple"
+    )
+    assert [place["placeId"] for place in result] == ["temple"]
+    assert result[0]["categories"] == ["worship"]
+
+
+@pytest.mark.asyncio
+async def test_nearby_places_never_shows_the_word_lodging(monkeypatch):
+    """Two of the five reported rows were correct and only worded badly.
+
+    A "Residency" or a "lodge" IS a place you pay to sleep in, and Google often
+    knows no more precise type for one. What made the list look wrong was its
+    subtitle: "Lodging" is a classification, in a vocabulary nobody outside the
+    Places API speaks.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode())
+        included = body.get("includedTypes")
+        if included and "hotel" in included:
+            return httpx.Response(
+                200,
+                json={
+                    "places": [
+                        _hotel(
+                            "anil-residency",
+                            name="Anil Residency",
+                            lat=37.4276,
+                            primaryType="lodging",
+                            types=["lodging", "establishment"],
+                            primaryTypeDisplayName={"text": "Lodging"},
+                        )
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"places": []})
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+
+    result = await gms.GoogleMapsService().nearby_places(lat=37.4275, lng=-122.1697)
+
+    # Still a place to stay -- the chip was never the problem here.
+    assert result[0]["categories"] == ["hotels_stays"]
+    assert result[0]["category"] == "Place to stay"

--- a/consent-protocol/tests/test_place_taxonomy.py
+++ b/consent-protocol/tests/test_place_taxonomy.py
@@ -1,0 +1,144 @@
+"""The strict rules the nearby-place chips are supposed to follow.
+
+Reported from Prayagraj, with a screenshot: tapping "Hotels" in the check-in
+drawer listed a lounge, a construction firm and two lodges. The question that
+came with it -- do we have strict rules and definitions for every category? --
+is what these tests answer, together with the harder half of the same brief: no
+place may be silently skipped.
+
+Two properties carry almost all of the weight:
+
+* every Google type lands in exactly one chip, so no place is unreachable and
+  none is filed under two categories that disagree;
+* `place_categories` can never return an empty list, so "nothing is skipped" is
+  a property of the function rather than a hope about the data.
+
+The rest are the specific rows from the report, pinned so they cannot come back.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hushh_mcp.services import place_taxonomy as taxonomy
+
+
+def test_every_google_type_lands_in_exactly_one_chip() -> None:
+    """The partition. This is the "nothing is missed" guarantee.
+
+    A type in no chip is a venue that shows under "All" and then vanishes behind
+    the first tap -- which is how temples, mosques, police stations, cinemas and
+    stadiums were invisible before this. A type in TWO chips is the other half
+    of the reported defect: a place filed under a category somebody has decided
+    it does not belong to.
+    """
+
+    covered: set[str] = set()
+    for chip, place_types in taxonomy.CHIP_TYPES.items():
+        for place_type in place_types:
+            assert place_type not in covered, (
+                f"{place_type!r} is claimed by more than one chip; {chip!r} is the second"
+            )
+            covered.add(place_type)
+
+    # Geographical areas are a country or a postcode, not somewhere a person can
+    # stand. `google_maps_service` rejects them before classification, so they
+    # are the one family deliberately outside the partition.
+    expected = taxonomy.TABLE_A_TYPES - set(taxonomy.FAMILY_GEOGRAPHIC)
+    assert covered == expected
+
+
+def test_no_place_is_ever_left_without_a_chip() -> None:
+    # The three shapes Google actually sends for a venue it knows little about.
+    # Each used to produce `[]`, which the client's filter reads as "belongs to
+    # no chip" and drops from every list but "All".
+    for place_types in ([], ["establishment", "point_of_interest"], ["zzz_not_a_real_type"]):
+        assert taxonomy.place_categories(place_types) == ["other"]
+
+
+def test_a_lounge_is_not_a_hotel() -> None:
+    # The reported row. Google tags some venues with both a precise type and a
+    # vague parent; when every match voted equally, "Mishra Lounge" was a hotel.
+    assert taxonomy.place_categories(["lounge_bar", "lodging", "establishment"]) == ["food_drink"]
+
+
+def test_a_precise_type_always_beats_a_vague_one() -> None:
+    # The general rule the case above is one instance of.
+    assert taxonomy.place_categories(["pharmacy", "store"]) == ["health"]
+    assert taxonomy.place_categories(["hindu_temple", "tourist_attraction"]) == [
+        "outdoors_landmarks",
+        "worship",
+    ]
+
+
+def test_a_place_google_knows_only_as_lodging_is_still_somewhere_to_stay() -> None:
+    # Deliberate, and the reason `lodging` is not simply dropped: in India a
+    # "Residency" or a "lodge" IS a place you pay to sleep in, and Google often
+    # has no more precise type for one. Two of the five reported rows were
+    # correct; only their subtitle was confusing.
+    assert taxonomy.place_categories(["lodging"]) == ["hotels_stays"]
+    assert taxonomy.place_categories(["guest_house", "lodging"]) == ["hotels_stays"]
+
+
+def test_hotels_means_somewhere_you_can_sleep() -> None:
+    hotels = set(taxonomy.CHIP_TYPES["hotels_stays"])
+    for stay in ("hotel", "motel", "hostel", "inn", "guest_house", "resort_hotel"):
+        assert stay in hotels
+    # A campsite is somewhere you spend time, not a room for the night, and a
+    # mobile-home park is somewhere people live.
+    for not_a_room in ("campground", "camping_cabin", "rv_park", "mobile_home_park"):
+        assert not_a_room not in hotels
+        assert taxonomy.place_categories([not_a_room]) != ["hotels_stays"]
+
+
+def test_a_contractor_is_not_a_hotel() -> None:
+    # "Vaishali Infratech" carried the subtitle "Hotel". Where Google gives us a
+    # second, truer type we use it; `general_contractor` is Table B, so it is
+    # read from the response and never requested.
+    assert taxonomy.place_categories(["general_contractor", "establishment"]) == [
+        "shopping_services"
+    ]
+
+
+def test_worship_and_civic_are_reachable_at_all() -> None:
+    # Neither had a chip before, so every one of these was invisible behind the
+    # first tap.
+    for place_type in taxonomy.FAMILY_WORSHIP:
+        assert taxonomy.place_categories([place_type]) == ["worship"]
+    for place_type in taxonomy.FAMILY_GOVERNMENT:
+        assert taxonomy.place_categories([place_type]) == ["civic"]
+
+
+def test_chips_are_returned_in_a_stable_declared_order() -> None:
+    # The client renders chips in this order and the drawer shows the first
+    # match, so two places in the same pair of chips must read the same way.
+    assert taxonomy.place_categories(["hindu_temple", "museum"]) == [
+        "outdoors_landmarks",
+        "worship",
+    ]
+    assert taxonomy.place_categories(["museum", "hindu_temple"]) == [
+        "outdoors_landmarks",
+        "worship",
+    ]
+
+
+def test_a_type_claimed_twice_fails_at_import_rather_than_in_the_drawer() -> None:
+    original = taxonomy.CHIP_TYPES.copy()
+    try:
+        taxonomy.CHIP_TYPES["worship"] = (*taxonomy.CHIP_TYPES["worship"], "hotel")
+        with pytest.raises(ValueError, match="exactly one chip"):
+            taxonomy._build_chip_index()
+    finally:
+        taxonomy.CHIP_TYPES.clear()
+        taxonomy.CHIP_TYPES.update(original)
+
+
+def test_the_subtitle_never_reads_lodging() -> None:
+    # The word that made two correct rows look wrong.
+    assert taxonomy.display_label("lodging", "Lodging") == "Place to stay"
+    # Google's own word everywhere it is not confusing.
+    assert taxonomy.display_label("hotel", "Hotel") == "Hotel"
+    assert taxonomy.display_label("hindu_temple", "Hindu temple") == "Hindu temple"
+    # And never blank: a row with no supporting line reads as still loading.
+    assert taxonomy.display_label(None, None) == "Place"
+    assert taxonomy.display_label("some_new_type", None) == "Some New Type"

--- a/consent-protocol/tests/test_places_directory.py
+++ b/consent-protocol/tests/test_places_directory.py
@@ -1,10 +1,15 @@
 """The places directory: its taxonomy, its streaming, and what it must not cost.
 
 The sharpest risk in this feature is not the new surface, it is the old one.
-`nearby_places` builds its "All" sweep by iterating `_NEARBY_PLACE_CATEGORY_TYPES`,
-so a category added to that table becomes another concurrent provider call on
-every check-in drawer open — a cost increase on a shipped feature that no test
-would otherwise notice. The first test here pins that table's size.
+`nearby_places` builds its "All" sweep by iterating `_NEARBY_SWEEP_TYPES`, so a
+bucket added to that table becomes another concurrent provider call on every
+check-in drawer open — a cost increase on a shipped feature that no test would
+otherwise notice. The first test here pins that table's size.
+
+Note what that does NOT cover any more: the drawer's CHIPS are no longer that
+table. Classification moved to `place_taxonomy`, which is exhaustive over
+Google's Table A, so a chip can be added for nothing. Only this table is a cost
+argument.
 """
 
 from __future__ import annotations
@@ -27,8 +32,8 @@ def test_the_check_in_sweep_still_costs_what_it_did() -> None:
     """One request per bucket, plus one unfiltered. Adding a bucket adds a call."""
 
     # Seven buckets was the shipped cost of opening the check-in drawer on "All".
-    assert len(maps._NEARBY_PLACE_CATEGORY_TYPES) == 7
-    assert set(maps._NEARBY_PLACE_CATEGORY_TYPES) == {
+    assert len(maps._NEARBY_SWEEP_TYPES) == 7
+    assert set(maps._NEARBY_SWEEP_TYPES) == {
         "food_drink",
         "health",
         "shopping_services",
@@ -42,7 +47,7 @@ def test_the_check_in_sweep_still_costs_what_it_did() -> None:
 def test_the_two_taxonomies_are_separate_objects() -> None:
     """Aliasing them would silently couple the picker's cost to the directory."""
 
-    assert maps._DIRECTORY_CATEGORY_TYPES is not maps._NEARBY_PLACE_CATEGORY_TYPES
+    assert maps._DIRECTORY_CATEGORY_TYPES is not maps._NEARBY_SWEEP_TYPES
 
 
 def test_the_directory_offers_exactly_ten_categories() -> None:
@@ -69,12 +74,11 @@ def test_every_directory_place_type_is_one_the_picker_already_used() -> None:
     nothing in production.
     """
 
-    known = {
-        place_type for types in maps._NEARBY_PLACE_CATEGORY_TYPES.values() for place_type in types
-    }
-    # The one deliberate addition: EV charging had no picker equivalent.
-    known.add("electric_vehicle_charging_station")
-    known.add("spa")
+    # Checked against the picker's full taxonomy rather than the handful of
+    # types its sweep happens to request. That table is exhaustive over Google's
+    # Table A now, so the two hardcoded exceptions this test used to carry
+    # (`spa`, `electric_vehicle_charging_station`) are simply members of it.
+    known = set(maps._taxonomy.CHIP_BY_PLACE_TYPE)
 
     for slug, types in maps._DIRECTORY_CATEGORY_TYPES.items():
         for place_type in types:

--- a/consent-protocol/tests/test_places_directory.py
+++ b/consent-protocol/tests/test_places_directory.py
@@ -29,10 +29,17 @@ from hushh_mcp.services import google_maps_service as maps
 
 
 def test_the_check_in_sweep_still_costs_what_it_did() -> None:
-    """One request per bucket, plus one unfiltered. Adding a bucket adds a call."""
+    """One request per bucket, plus one unfiltered. Adding a bucket adds a call.
 
-    # Seven buckets was the shipped cost of opening the check-in drawer on "All".
-    assert len(maps._NEARBY_SWEEP_TYPES) == 7
+    Nine, up from the seven this test was written against. Worship and Civic
+    bought their own buckets deliberately: neither family was in any bucket, so a
+    temple or a police station reached the drawer only when the single unfiltered
+    sweep happened to catch one. Folding them into the landmarks bucket instead
+    would have kept the count at seven and let twenty nearby temples take every
+    slot in it -- see the sibling test below, which is the guard that matters.
+    """
+
+    assert len(maps._NEARBY_SWEEP_TYPES) == 9
     assert set(maps._NEARBY_SWEEP_TYPES) == {
         "food_drink",
         "health",
@@ -41,7 +48,33 @@ def test_the_check_in_sweep_still_costs_what_it_did() -> None:
         "education",
         "outdoors_landmarks",
         "transit",
+        "worship",
+        "civic",
     }
+
+
+def test_every_swept_type_belongs_to_the_bucket_that_fetches_it() -> None:
+    """A bucket's types must classify to that bucket's own chip.
+
+    The types in a bucket are free to REQUEST -- Google caps `includedTypes` at
+    50 -- but the response is capped at 20 and ranked by distance, so every type
+    in a bucket competes for the same twenty slots. A bucket that fetches types
+    belonging to some other chip therefore spends its budget on rows it will not
+    show, and starves its own chip.
+
+    That is not hypothetical: worship and government types were briefly packed
+    into the landmarks bucket to keep the bucket count down, and in a pilgrimage
+    city twenty nearby temples would have taken every slot and left the Leisure
+    chip empty at a spot with parks and museums in range. This is a better guard
+    than the count above, because a count cannot see it.
+    """
+
+    for chip, place_types in maps._NEARBY_SWEEP_TYPES.items():
+        for place_type in place_types:
+            assert chip in maps._taxonomy.place_categories([place_type]), (
+                f"the {chip!r} bucket fetches {place_type!r}, which is classified as "
+                f"{maps._taxonomy.place_categories([place_type])} and can never show under {chip!r}"
+            )
 
 
 def test_the_two_taxonomies_are_separate_objects() -> None:

--- a/docs/reference/architecture/one-location-place-taxonomy.md
+++ b/docs/reference/architecture/one-location-place-taxonomy.md
@@ -1,0 +1,110 @@
+# One Location Place Taxonomy
+
+Status: v1 implementation contract
+Owner: One Location + Hussh maps integration
+Last updated: 2026-08-31
+
+The strict definition of what each category chip in the Check-in drawer means,
+and the rules that decide which chip a nearby place lands in.
+
+## Visual Map
+
+```mermaid
+flowchart LR
+  Drawer[Check-in drawer] -->|one request per sweep bucket| Sweep[Sweep table: what we ASK Google for]
+  Sweep -->|places, with Google's own types| Classify[place_taxonomy.place_categories]
+  Classify -->|exactly one chip per Google type| Chips[Chip table: what a place IS]
+  Chips -->|categories array| Client[Client filters locally, no extra call]
+  Classify -->|nothing matched| More[More chip, never empty]
+  Sweep -.->|does NOT vote on the answer| Chips
+```
+
+## Current Truth
+
+Two tables, deliberately separate, both in
+[`consent-protocol/hushh_mcp/services/`](../../../consent-protocol/hushh_mcp/services/).
+
+| Table | Where | Job | Cost |
+| --- | --- | --- | --- |
+| `_NEARBY_SWEEP_TYPES` | `google_maps_service.py` | Recall. What we ask Google for. | **One provider call per bucket.** Keep it at seven. |
+| `CHIP_TYPES` | `place_taxonomy.py` | Meaning. What a place is shown as. | Free. Response-side only. |
+
+They used to be one table, which made a chip cost a provider call and kept the
+taxonomy at 52 hand-picked types out of Google's 478. Splitting them is what
+lets the classifier be exhaustive.
+
+## The rules
+
+1. **Every Google Table A type belongs to exactly one chip.** Enforced at import
+   time — `_build_chip_index` raises when two chips claim a type — and asserted
+   against the full Table A list in `tests/test_place_taxonomy.py`.
+2. **A place is classified by what it is, never by which request found it.** The
+   sweep bucket that returned a place has no vote.
+3. **A precise type beats a vague one.** Google tags some venues with both a
+   specific type and an umbrella parent. `lounge_bar` + `lodging` is a lounge.
+   An umbrella decides a place only when nothing precise is known about it,
+   which is how a small guest house Google knows only as `lodging` still reaches
+   Hotels.
+4. **Nothing is skipped.** `place_categories` cannot return an empty list. What
+   matches nothing is `other` — the **More** chip, which is visible and real.
+5. **We do not overrule the provider without evidence.** If Google's only type
+   for a venue is `lodging`, it appears under Hotels. Matching on a name
+   ("contains Lounge") would break "Lounge Hotel" and is not a rule worth
+   shipping.
+
+## The chips
+
+| Chip | Label | Belongs | Does not |
+| --- | --- | --- | --- |
+| `food_drink` | Food | Somewhere food or drink is prepared for you, including bars, pubs and lounge bars | A grocery shop |
+| `health` | Health | Treatment or care by a health professional, plus pharmacies | A gym, a beauty salon |
+| `shopping_services` | Shops | Buying goods, or a service performed for you: retail, groceries, banks, salons, laundry, vehicle service, trades, agents | Somewhere you eat, sleep or spend leisure time |
+| `hotels_stays` | Hotels | **Somewhere you can pay to sleep for the night** — hotels, motels, hostels, inns, guest houses, resorts, B&Bs, serviced stays | A lounge, a campsite, a mobile-home park, an estate agent |
+| `education` | Education | Somewhere people are taught or study | — |
+| `outdoors_landmarks` | Leisure | Somewhere you spend time rather than transact: parks, nature, landmarks, museums, sport, cinemas, nightclubs, event venues, campsites | — |
+| `transit` | Transit | Catching, boarding or parking transport | — |
+| `worship` | Worship | A place of religious worship | — |
+| `civic` | Civic | A public, government or emergency building | — |
+| `other` | More | A real venue none of the above describes, plus every venue Google names but does not describe | — |
+
+Worship, Civic and More are new. Before them a temple, a mosque, a police
+station, a cinema and a stadium matched **no** chip: they appeared under All and
+disappeared the moment anything was tapped.
+
+## Why "Hotels" showed a lounge
+
+Reported from Prayagraj with a screenshot. Three separate causes, only one of
+which was what it looked like:
+
+1. **Every matching type voted equally.** A venue Google tags as both
+   `lounge_bar` and `lodging` was filed under Food *and* Hotels. Fixed by rule 3.
+2. **The subtitle was Google's own word.** A row reading "Lodging" proves Google
+   reports that primary type. Two of the five rows were correct and only worded
+   badly — in India a "Residency" and a "lodge" *are* places you pay to sleep in.
+   `DISPLAY_LABEL_OVERRIDES` says "Place to stay" instead.
+3. **A place that matched nothing was filed under whichever sweep found it.**
+   Written so an independent hotel Google knows only as `establishment` would
+   not vanish behind the Hotels chip; the same rule put anything else the hotels
+   sweep returned there too. Replaced by rule 4.
+
+What remains, honestly: if a venue's only Google type is `lodging`, no strict
+rule can tell it from a real lodge. The Places API exposes no confidence or
+verification signal at any tier.
+
+## Changing the taxonomy
+
+- Adding a **chip** is free. Add it to `CHIP_TYPES`, the `NearbyPlaceCategory`
+  Literal, `OneLocationNearbyPlaceCategory` in the webapp, `PLACE_CATEGORIES` in
+  the sheet, and the `CATEGORY_LABELS` replica in
+  `e2e/one-location-check-in-panel.layout.spec.ts`. A vitest contract asserts the
+  replica matches, because a stale replica passes rather than fails.
+- Adding a **sweep bucket** costs a provider call on every drawer open. Types
+  inside a bucket are free up to Google's cap of 50.
+- When Google adds place types, regenerate the families in `place_taxonomy.py`
+  from the [Place Types](https://developers.google.com/maps/documentation/places/web-service/place-types)
+  page. The exhaustiveness test fails rather than letting a new type go missing.
+
+## Sources
+
+- [Google Maps Platform — Place Types (New), Table A and Table B](https://developers.google.com/maps/documentation/places/web-service/place-types)
+- [Google Maps Platform — Nearby Search (New)](https://developers.google.com/maps/documentation/places/web-service/nearby-search)

--- a/docs/reference/architecture/one-location-place-taxonomy.md
+++ b/docs/reference/architecture/one-location-place-taxonomy.md
@@ -26,7 +26,7 @@ Two tables, deliberately separate, both in
 
 | Table | Where | Job | Cost |
 | --- | --- | --- | --- |
-| `_NEARBY_SWEEP_TYPES` | `google_maps_service.py` | Recall. What we ask Google for. | **One provider call per bucket.** Keep it at seven. |
+| `_NEARBY_SWEEP_TYPES` | `google_maps_service.py` | Recall. What we ask Google for. | **One provider call per bucket.** Nine of them. |
 | `CHIP_TYPES` | `place_taxonomy.py` | Meaning. What a place is shown as. | Free. Response-side only. |
 
 They used to be one table, which made a chip cost a provider call and kept the
@@ -58,11 +58,11 @@ lets the classifier be exhaustive.
 | --- | --- | --- | --- |
 | `food_drink` | Food | Somewhere food or drink is prepared for you, including bars, pubs and lounge bars | A grocery shop |
 | `health` | Health | Treatment or care by a health professional, plus pharmacies | A gym, a beauty salon |
-| `shopping_services` | Shops | Buying goods, or a service performed for you: retail, groceries, banks, salons, laundry, vehicle service, trades, agents | Somewhere you eat, sleep or spend leisure time |
+| `shopping_services` | Shops | Buying goods, or a service performed for you: retail, groceries, banks, salons, laundry, vehicle sales and repair, trades, agents | Somewhere you eat, sleep or spend leisure time. A car park or a petrol pump is Transit |
 | `hotels_stays` | Hotels | **Somewhere you can pay to sleep for the night** — hotels, motels, hostels, inns, guest houses, resorts, B&Bs, serviced stays | A lounge, a campsite, a mobile-home park, an estate agent |
 | `education` | Education | Somewhere people are taught or study | — |
 | `outdoors_landmarks` | Leisure | Somewhere you spend time rather than transact: parks, nature, landmarks, museums, sport, cinemas, nightclubs, event venues, campsites | — |
-| `transit` | Transit | Catching, boarding or parking transport | — |
+| `transit` | Transit | Getting somewhere: catching, boarding, parking, fuelling or charging | Buying, renting or repairing a vehicle — that is Shops |
 | `worship` | Worship | A place of religious worship | — |
 | `civic` | Civic | A public, government or emergency building | — |
 | `other` | More | A real venue none of the above describes, plus every venue Google names but does not describe | — |
@@ -99,7 +99,14 @@ verification signal at any tier.
   `e2e/one-location-check-in-panel.layout.spec.ts`. A vitest contract asserts the
   replica matches, because a stale replica passes rather than fails.
 - Adding a **sweep bucket** costs a provider call on every drawer open. Types
-  inside a bucket are free up to Google's cap of 50.
+  inside a bucket are free to *request* — Google caps `includedTypes` at 50 —
+  but **not free to return**: the response is capped at 20 and ranked by
+  distance, so every type in a bucket competes for the same twenty slots. A
+  bucket must therefore only fetch types that classify to its own chip, or it
+  starves itself. `test_every_swept_type_belongs_to_the_bucket_that_fetches_it`
+  pins that, and it is a better guard than the bucket count: packing worship and
+  government into the landmarks bucket to save a call would let twenty nearby
+  temples take every slot and render Leisure empty in a pilgrimage city.
 - When Google adds place types, regenerate the families in `place_taxonomy.py`
   from the [Place Types](https://developers.google.com/maps/documentation/places/web-service/place-types)
   page. The exhaustiveness test fails rather than letting a new type go missing.

--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -6,6 +6,9 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const service = vi.hoisted(() => ({
@@ -759,7 +762,9 @@ describe("NearbyCheckInSheet", () => {
     expect(completed).toHaveTextContent("Check-in ended");
     expect(completed).toHaveTextContent("Stanford University");
     expect(completed).toHaveTextContent("This check-in has ended.");
-    expect(screen.queryByTestId("nearby-presence-setup")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("nearby-presence-setup"),
+    ).not.toBeInTheDocument();
     expect(capture).not.toHaveBeenCalled();
     expect(service.nearbyPlaces).not.toHaveBeenCalled();
     expect(
@@ -2390,5 +2395,81 @@ describe("NearbyCheckInSheet", () => {
       // neither — you can check back in.
       expect(checkOut.className).not.toContain("app-destructive");
     });
+  });
+});
+
+/**
+ * The chip row, and the two ways it can quietly stop being true.
+ *
+ * Reported from Prayagraj: tapping "Hotels" listed a lounge, a construction firm
+ * and two lodges. Most of that fix is server-side, but two client properties
+ * decide whether it is visible at all.
+ */
+describe("the nearby place chips", () => {
+  const sheetSource = readFileSync(
+    path.resolve(__dirname, "..", "nearby-check-in-sheet.tsx"),
+    "utf8",
+  );
+  const layoutSpecSource = readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../..",
+      "e2e/one-location-check-in-panel.layout.spec.ts",
+    ),
+    "utf8",
+  );
+
+  /** The labels the component actually ships, read out of its own table. */
+  function shippedLabels(): string[] {
+    const table = sheetSource.slice(
+      sheetSource.indexOf("const PLACE_CATEGORIES"),
+      sheetSource.indexOf("const NEARBY_RADIUS_METERS"),
+    );
+    return [...table.matchAll(/label:\s*"([^"]+)"/g)].map((match) => match[1]);
+  }
+
+  it("offers a chip for every category the backend can return", () => {
+    // The backend classifies exhaustively over Google's Table A and can answer
+    // with any of these. A category with no chip is a set of places that shows
+    // under "All" and is unreachable the moment anything is tapped — which is
+    // how temples, mosques and police stations were invisible.
+    const table = sheetSource.slice(
+      sheetSource.indexOf("const PLACE_CATEGORIES"),
+      sheetSource.indexOf("const NEARBY_RADIUS_METERS"),
+    );
+    const values = [...table.matchAll(/value:\s*"([^"]+)"/g)].map((m) => m[1]);
+    expect(values).toEqual([
+      "all",
+      "food_drink",
+      "health",
+      "shopping_services",
+      "hotels_stays",
+      "education",
+      "outdoors_landmarks",
+      "transit",
+      "worship",
+      "civic",
+      "other",
+    ]);
+  });
+
+  it("keeps the layout spec's replica of the labels honest", () => {
+    // `one-location-check-in-panel.layout.spec.ts` cannot import a React module,
+    // so it hand-copies these labels to measure the row. A copy that falls
+    // behind does not fail — it passes, having measured a row the app no longer
+    // ships. This is the only thing that notices.
+    const replica = layoutSpecSource.slice(
+      layoutSpecSource.indexOf("const CATEGORY_LABELS"),
+      layoutSpecSource.indexOf("const LONGEST_PLACE"),
+    );
+    const replicated = [...replica.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+    expect(replicated).toEqual(shippedLabels());
+  });
+
+  it("never says 'Outdoors' about a cinema", () => {
+    // The chip owns entertainment, culture, sport and nature. Half of that is
+    // indoors, so the label says what the chip is for rather than where it is.
+    expect(shippedLabels()).toContain("Leisure");
+    expect(shippedLabels()).not.toContain("Outdoors");
   });
 });

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -142,8 +142,20 @@ const PLACE_CATEGORIES: Array<{
   { value: "shopping_services", label: "Shops" },
   { value: "hotels_stays", label: "Hotels" },
   { value: "education", label: "Education" },
-  { value: "outdoors_landmarks", label: "Outdoors" },
+  // "Leisure", not "Outdoors": this chip owns cinemas, nightclubs, museums,
+  // stadiums and event venues as well as parks, and half of those are indoors.
+  { value: "outdoors_landmarks", label: "Leisure" },
   { value: "transit", label: "Transit" },
+  // Reachable for the first time. A temple, a mosque, a police station and a
+  // government office matched no category at all, so they showed under "All"
+  // and disappeared the moment any chip was tapped -- in a pilgrimage city, a
+  // bigger hole than the one that was reported.
+  { value: "worship", label: "Worship" },
+  { value: "civic", label: "Civic" },
+  // Last, and never empty by construction. Anything the taxonomy cannot place
+  // lands here rather than nowhere, which is what makes "no place is skipped" a
+  // property of the list rather than a hope.
+  { value: "other", label: "More" },
 ];
 
 const NEARBY_RADIUS_METERS = 500;
@@ -284,7 +296,13 @@ function placesInCategory(
   category: OneLocationNearbyPlaceCategory,
 ): OneLocationNearbyPlaceSuggestion[] {
   if (category === "all") return places;
-  return places.filter((place) => place.categories?.includes(category));
+  return places.filter((place) =>
+    // A row with no categories at all belongs to "More". The backend classifies
+    // exhaustively and never sends an empty list, but a response cached before
+    // that shipped still can -- and a row that answers no chip is a row the
+    // person can see under "All" and then never find again.
+    (place.categories?.length ? place.categories : ["other"]).includes(category),
+  );
 }
 
 function placePoint(

--- a/hushh-webapp/e2e/one-location-check-in-panel.layout.spec.ts
+++ b/hushh-webapp/e2e/one-location-check-in-panel.layout.spec.ts
@@ -72,13 +72,20 @@ const MIN_TAP_TARGET_PX = 44;
 const MIN_CHIP_HEIGHT_PX = 36;
 
 /**
- * How wide the whole eight-chip set is allowed to be, in CSS px.
+ * How wide the whole chip set is allowed to be, in CSS px.
  *
  * Viewport-independent on purpose: the set's width is a property of the
- * labels, not of the screen. The shipped one-word labels measure 632px; the
- * two multi-word ones they replaced measured 765px.
+ * labels, not of the screen.
+ *
+ * Measured: eleven chips are 847px. Eight were 632px, and the two multi-word
+ * labels they replaced were 765px. The set grew because Worship, Civic and More
+ * were added -- three categories that previously matched no chip at all, so the
+ * places in them were unreachable the moment any chip was tapped. A wider
+ * scroller is the price of that, and it is only a scroller: `MIN_VISIBLE_CHIPS`
+ * below is what actually guards reachability, and it is unchanged because the
+ * three are appended after the leading ones.
  */
-const MAX_CATEGORY_SCROLL_EXTENT_PX = 660;
+const MAX_CATEGORY_SCROLL_EXTENT_PX = 880;
 
 /**
  * How many chips must be reachable at each width without scrolling at all.
@@ -211,6 +218,14 @@ const HARNESS_CLASSES = [
   "h-4 w-4 border relative",
 ].join(" ");
 
+/**
+ * A replica of `PLACE_CATEGORIES` in the sheet, because this fixture is CSS-only
+ * and cannot import a React module.
+ *
+ * It goes stale SILENTLY -- a spec measuring eight chips while the app ships
+ * eleven still passes -- so `nearby-check-in-sheet.test.tsx` asserts the two
+ * lists match. Change one, change the other.
+ */
 const CATEGORY_LABELS = [
   "All",
   "Food",
@@ -218,8 +233,11 @@ const CATEGORY_LABELS = [
   "Shops",
   "Hotels",
   "Education",
-  "Outdoors",
+  "Leisure",
   "Transit",
+  "Worship",
+  "Civic",
+  "More",
 ];
 
 /** The longest realistic venue name plus the longest realistic category. */

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -608,7 +608,13 @@ export type OneLocationNearbyPlaceCategory =
   | "hotels_stays"
   | "education"
   | "outdoors_landmarks"
-  | "transit";
+  | "transit"
+  | "worship"
+  | "civic"
+  // The catch-all. A real venue that belongs to none of the above, plus every
+  // venue Google names but does not describe -- so a row is never reachable
+  // from "All" alone.
+  | "other";
 
 export type OneLocationNearbyPlaceSuggestion = {
   placeId: string;

--- a/scripts/ci/web-targeted-check.sh
+++ b/scripts/ci/web-targeted-check.sh
@@ -135,7 +135,13 @@ fi
 # caught here, and one of them -- an open-ended duration offered on the Request
 # screen -- emits a non-numeric sentinel into a field the same lane runs
 # Number() over.
-if has_match '^hushh-webapp/(components/one-location/|__tests__/components/one-location|app/one/location/|lib/one-location/|lib/contacts/|lib/marketplace/contact-matching\.ts)'; then
+#
+# `google_maps_service.py` is in this glob because the check-in drawer's category
+# chips are its output: the backend classifies every nearby place and the client
+# only filters what it is handed. A taxonomy change is a backend-only diff that
+# nothing on this side would otherwise run -- which is how "Hotels" shipped
+# listing a lounge.
+if has_match '^(hushh-webapp/(components/one-location/|__tests__/components/one-location|app/one/location/|lib/one-location/|lib/contacts/|lib/marketplace/contact-matching\.ts)|consent-protocol/hushh_mcp/services/(google_maps_service|place_taxonomy)\.py)'; then
   run_check "One Location flows" npm run verify:one-location
   ran=1
 fi


### PR DESCRIPTION
# Description

Closes #6273.

Tapping **Hotels** in the Check-in drawer listed a lounge, a construction firm and two lodges. Three separate causes, only one of which is what it looks like.

## 1. Every matching type voted equally

Google tags some venues with both a precise type and an umbrella parent, so a place carrying `lounge_bar` **and** `lodging` was filed under Food *and* Hotels. A precise type wins outright now; an umbrella decides a place only when nothing precise is known about it — which is how a small guest house Google knows only as `lodging` still reaches Hotels.

## 2. The subtitle was Google's own word

The row subtitle is `primaryTypeDisplayName.text`, so a row reading "Lodging" **proves Google reports that primary type**. Two of the five reported rows were therefore correct and only worded badly: in India a "Residency" and a "lodge" *are* places you pay to sleep in. "Lodging" is a classification in a vocabulary nobody outside the Places API speaks. Those rows read **"Place to stay"** now; Google's own label is kept everywhere it is not confusing.

## 3. A place that matched nothing was filed under whichever sweep found it

Written so an independent hotel Google describes only as `establishment` would not vanish behind the Hotels chip. The same rule put everything else the hotels sweep returned there too. **A place is classified by what it IS now — the request has no vote.**

## The bigger hole was not Hotels

The table was **52 hand-picked types out of Google's 478**, so a temple, a mosque, a police station, a cinema and a stadium matched *no* category: visible under "All", gone the moment anything was tapped. In a pilgrimage city that is a larger trust problem than the lounge, and it is the direct violation of "no place may be skipped".

It was structural. One table was both the request filter *and* the classifier — `nearby_places` iterates it to build its sweep — so **a chip cost a provider call** and the table could never afford to be complete.

**Splitting those tables is what makes everything else cheap:**

| Table | Job | Cost |
| --- | --- | --- |
| `_NEARBY_SWEEP_TYPES` | Recall — what we ask Google for | **Bucket count is the cost.** Still 7, still 8 calls per drawer open |
| `place_taxonomy.CHIP_TYPES` | Meaning — what a place is shown as | **Free.** Response-side only |

So the classifier is now **exhaustive over Table A**, transcribed verbatim from Google's docs: 478 types, every one in exactly one chip, the partition enforced at import (`_build_chip_index` raises) and asserted against the full list in a test.

## The chips

Slugs of the existing seven are unchanged. Three are added, appended last.

| Chip | Label | Belongs | Does not |
| --- | --- | --- | --- |
| `hotels_stays` | Hotels | **Somewhere you can pay to sleep for the night** | A lounge, a campsite, a mobile-home park, an estate agent |
| `outdoors_landmarks` | **Leisure** *(renamed)* | Somewhere you spend time rather than transact — parks, nature, landmarks, museums, sport, cinemas, nightclubs, event venues, campsites | — |
| `worship` | **Worship** *(new)* | A place of religious worship | — |
| `civic` | **Civic** *(new)* | A public, government or emergency building | — |
| `other` | **More** *(new)* | A real venue none of the above describes, plus every venue Google names but does not describe | — |

"Outdoors" became "Leisure" because that chip owns cinemas, nightclubs and stadiums as well as parks — half of it is indoors.

**More is what turns "nothing is skipped" from a hope about the data into a property of the function.** `place_categories` cannot return an empty list, and an empty list is exactly what the client's filter drops from every chip.

Campsites, camping cabins and RV parks move out of Hotels to Leisure; a mobile-home park is somewhere people live, so it moves to More.

## What this cannot fix, stated plainly

If a venue's **only** Google type is `lodging`, no strict rule tells it from a real lodge. The Places API exposes no confidence or verification signal at any tier, and matching on a name ("contains Lounge") would break "Lounge Hotel". Where Google gives a second, truer type — `lounge_bar`, `general_contractor`, `real_estate_agency` — we use it, and that is what moves the lounge and the contractor.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `POST /api/one/location/maps/nearby-places` — same shape; `categories` values and the `category` subtitle change. Route code untouched: `MapsNearbyPlacesRequest.category` is typed `NearbyPlaceCategory`, so the three new slugs are accepted automatically.
    - `/one/location` Check-in drawer — three new chips, one renamed label.

- API / schema / type changes:
  - [x] Listed below:
    - `NearbyPlaceCategory` (backend Literal) and `OneLocationNearbyPlaceCategory` (client union) each gain `worship`, `civic`, `other`. Additive; no field added or removed.

- Cache keys touched:
  - [x] Listed below:
    - `_PLACES_CACHE_KEY_PREFIX` `v1:` → `v2:`. **Required**, not cosmetic: a cached row carries the fully shaped result including `categories` and the subtitle, and the taxonomy is not part of the key. Without the bump, a rolling deploy has the old revision writing old-taxonomy rows into the same keys for the 600s TTL, and the fix reads as half-applied. Old keys expire on their own; no flush.

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below:
    - Backend classification applies to every client. The chips are shared React the Capacitor shells render; no native work.

- Docs updated (exact files):
  - [x] Listed below:
    - `docs/reference/architecture/one-location-place-taxonomy.md` *(new)* — the strict definitions, the four rules, and how to change the taxonomy.

- Top-level / devex / config / generated / ignore files touched:
  - [x] Listed below with the existing workflow they attach to:
    - `consent-protocol/scripts/test-ci.manifest.txt` — registers three suites, read by `scripts/run-test-ci.sh` in `protocol-check`.
    - `scripts/ci/web-targeted-check.sh` — adds the maps service to the One Location pack's glob (precedent: the Feed and Connect packs already list Python paths).
    - `consent-protocol/pyproject.toml` — adds the new pure module to the mypy override list so it is type-checked.

- Trust boundary touched:
  - [x] None of the listed surfaces. This changes how a public Google Places result is *labelled*; it reads no user data, grants nothing, and sends nothing new to the provider.

- Caller / proxy / backend pairing:
  - [x] Listed below with contract proof:
    - The client owns no taxonomy — it filters `place.categories` handed to it. A vitest contract asserts the chip `value`s match the backend Literal, and a second asserts the layout spec's hand-copied label replica matches the component (a stale replica passes rather than fails, so nothing else would notice).

- Rollback or safe-failure behavior:
  - [x] Listed below:
    - Reverting restores the old table; no data migration either way. The client tolerates a response from either side: `placesInCategory` treats a missing or empty `categories` as `other`, so a row cached before this shipped is still reachable rather than dropped.

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below:
    - `CI=1 npx playwright test e2e/one-location-check-in-panel.layout.spec.ts --project=chromium` — 21 passed. `MAX_CATEGORY_SCROLL_EXTENT_PX` **re-measured, not guessed**: eleven chips are 847px (eight were 632px), constant raised 660 → 880 with the same headroom. `MIN_VISIBLE_CHIPS` is unchanged and still passes, because the new chips are appended after the leading ones.

- Verification commands executed:
  - [x] `pytest tests/test_place_taxonomy.py tests/services/test_google_maps_service.py tests/test_places_directory.py tests/test_places_coordinate_privacy.py` — **92 passed**
  - [x] `ruff check .` + `ruff format --check .` (pinned 0.15.11) — clean, 1012 files
  - [x] `mypy` on the service + the new module — no new errors (6 pre-existing on `main`, unchanged)
  - [x] `cd hushh-webapp && npm run typecheck` — 0 errors
  - [x] `npm run verify:one-location` — **36 files, 728 tests passed**
  - [x] `npx eslint` on every touched file — clean
  - [x] `node scripts/verify-doc-{brand,governance,links}.cjs` — all pass
  - [x] `python3 scripts/ci/verify-protected-behavior-tests.py` — 12 behaviours, 20 files intact

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate any.
- [x] This PR changes a current reachable app + backend surface.
- [x] Reachable production attach point: `GoogleMapsService.nearby_places`, reached from the Check-in drawer via `POST /api/one/location/maps/nearby-places`.
- [x] New tests import and exercise production code, not only mock components.
- [x] New helpers are wired: `place_taxonomy` is imported by `google_maps_service` for classification, the subtitle and the Hotels sweep bucket.
- [x] Production surface proved: `test_nearby_places_does_not_file_a_lounge_under_hotels` and `test_nearby_places_reaches_a_temple_and_files_it_under_worship` drive the real `nearby_places` through a mocked provider.
- [x] Required checks are current on this head, commits are signed off, branch is rebased on latest `main`.
- [x] Maintainer edits are enabled.
- [x] Not part of a stack.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js + the consent-protocol service — the whole change.
- [x] **iOS**: not applicable — no native plugin surface; the shell renders the same React and calls the same API.
- [x] **Android**: not applicable — same reason.

## 🧪 Testing

- [x] Tested on Web (unit, contract and browser layout suites above)
- [ ] Tested on iOS Simulator/Device — pending joint UAT testing
- [ ] Tested on Android Emulator/Device — pending joint UAT testing
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed

**`consent-protocol/tests/test_place_taxonomy.py`** *(new, 11 cases)* — the two properties that carry the weight:

| Test | Pins |
| --- | --- |
| `test_every_google_type_lands_in_exactly_one_chip` | **The partition.** Set-equality against the full Table A list minus the geographic family, plus a no-duplicates assertion. This is the "nothing is missed" guarantee |
| `test_no_place_is_ever_left_without_a_chip` | `[]`, `["establishment", "point_of_interest"]` and an unknown type all return `["other"]` |
| `test_a_lounge_is_not_a_hotel` | The reported row |
| `test_a_precise_type_always_beats_a_vague_one` | The general rule behind it |
| `test_a_place_google_knows_only_as_lodging_is_still_somewhere_to_stay` | The deliberate residual — why `lodging` is not simply dropped |
| `test_hotels_means_somewhere_you_can_sleep` | Campsites and mobile-home parks are out |
| `test_a_contractor_is_not_a_hotel` | Table B `general_contractor` read response-side |
| `test_worship_and_civic_are_reachable_at_all` | Every type in both families |
| `test_a_type_claimed_twice_fails_at_import_rather_than_in_the_drawer` | The import-time guard |
| `test_the_subtitle_never_reads_lodging` | And never blank |

**Also added**: three end-to-end cases in `test_google_maps_service.py` (lounge not filed under Hotels; a temple is both *fetched* and *chipped*; "Anil Residency" keeps its chip but loses the word "Lodging"), and three client contracts in the sheet's own suite.

**Registration — without this, none of it runs.** `test_google_maps_service.py` and `test_places_directory.py` were **absent from the manifest**, and no web pack fired on a `google_maps_service.py` change either. So a backend-only taxonomy change ran zero tests on both halves — which is how a category filter shipped listing a lounge. All three suites are registered, and the service is in the One Location pack's glob.

## 📸 Screenshots / Video

The visible change is three chips, one renamed label, and a different subtitle string. Browser proof is the layout-contract run above, which measures the chip row at 320/360/375/390/430px and re-measures the scroll extent from the real markup.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No. It classifies public Google Places results.
- [x] `checkConsentToken()`: not applicable — no new endpoint; the existing vault-owner gate on the maps route is untouched.
- [x] Sensitive surface touched: **none**
- [x] Error path, rollback, or safe-failure behavior proved: a place that matches nothing is `other` rather than dropped; the client treats an absent `categories` as `other`; a partial sweep failure still returns the buckets that succeeded, unchanged.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed
