### PR TITLE
Fix Connect person profile navigation

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -258,6 +258,51 @@ describe("Connect — People", () => {
     expect(screen.getByLabelText("Connected from your contacts")).toBeTruthy();
   });
 
+  it("opens a connection's person profile from My connections", async () => {
+    mocks.listConnections.mockResolvedValue([
+      {
+        connectionId: "c-scoped",
+        userId: "u-scoped",
+        publicPersonRef: "person-ref-scoped",
+        displayName: "Scoped Friend",
+        photoUrl: null,
+        createdAt: null,
+      },
+    ]);
+
+    render(<ConnectPageClient />);
+
+    const myConnections = await screen.findByTestId(
+      "connect-my-connections-group",
+    );
+    const connectionName = await within(myConnections).findByText(
+      "Scoped Friend",
+    );
+    const connectionAction = connectionName.closest("button");
+    expect(connectionAction).toBeTruthy();
+
+    fireEvent.click(connectionAction!);
+
+    expect(mocks.routerPush).toHaveBeenCalledWith(
+      "/people/person-ref-scoped?from=%2Fone%2Fconnect",
+    );
+    expect(mocks.routerPush).not.toHaveBeenCalledWith(
+      expect.stringContaining("/one/profile/access/connection"),
+    );
+    expect(mocks.routerPush).not.toHaveBeenCalledWith(
+      expect.stringContaining("u-scoped"),
+    );
+
+    mocks.routerPush.mockClear();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove connection with Scoped Friend",
+      }),
+    );
+
+    expect(mocks.routerPush).not.toHaveBeenCalled();
+  });
+
   it("loads page 2 in stable server order and keeps its contact badge", async () => {
     mocks.listConnectionsPage.mockImplementation(async (options) => ({
       items:

--- a/hushh-webapp/__tests__/components/onboarding-journey-guard.test.tsx
+++ b/hushh-webapp/__tests__/components/onboarding-journey-guard.test.tsx
@@ -17,6 +17,7 @@ const {
   bootstrapStateMock,
   getCachedBootstrapStateMock,
   isPersistentSetupResolvedMock,
+  isOnboardingAdmissionExemptRouteMock,
 } = vi.hoisted(
   () => ({
     push: vi.fn(),
@@ -24,6 +25,7 @@ const {
     bootstrapStateMock: vi.fn(),
     getCachedBootstrapStateMock: vi.fn(),
     isPersistentSetupResolvedMock: vi.fn(),
+    isOnboardingAdmissionExemptRouteMock: vi.fn(),
   }),
 );
 
@@ -66,7 +68,7 @@ vi.mock("@/lib/navigation/routes", () => ({
   buildOneSetupRoute: ({ returnTo }: { returnTo: string }) =>
     `/one/setup?return_to=${encodeURIComponent(returnTo)}`,
   isCapabilityOnboardingRoute: () => false,
-  isOnboardingAdmissionExemptRoute: () => false,
+  isOnboardingAdmissionExemptRoute: isOnboardingAdmissionExemptRouteMock,
   normalizeStaticExportPathname: (pathname: string) =>
     pathname.replace(/\/index\.html$/i, "").replace(/\/+$/, "") || "/",
 
@@ -121,6 +123,8 @@ describe("OnboardingJourneyGuard", () => {
     getCachedBootstrapStateMock.mockReset();
     isPersistentSetupResolvedMock.mockReset();
     isPersistentSetupResolvedMock.mockReturnValue(false);
+    isOnboardingAdmissionExemptRouteMock.mockReset();
+    isOnboardingAdmissionExemptRouteMock.mockReturnValue(false);
     pathnameValue = "/one/setup";
     window.history.replaceState(null, "", "/one/setup");
     clearSetupIntent();
@@ -272,6 +276,27 @@ describe("OnboardingJourneyGuard", () => {
       );
     });
     expect(screen.queryByText("location workspace")).toBeNull();
+  });
+
+  it("does not replace a Connect-origin person profile with setup or One home", async () => {
+    pathnameValue = "/people/person-ref-scoped";
+    window.history.replaceState(
+      null,
+      "",
+      "/people/person-ref-scoped?from=/one/connect",
+    );
+    isOnboardingAdmissionExemptRouteMock.mockReturnValue(true);
+    getCachedBootstrapStateMock.mockReturnValue(null);
+
+    render(
+      <OnboardingJourneyGuard>
+        <div>person profile</div>
+      </OnboardingJourneyGuard>,
+    );
+
+    expect(screen.getByText("person profile")).toBeTruthy();
+    expect(bootstrapStateMock).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
   });
 
 

--- a/hushh-webapp/__tests__/components/person-profile-page.test.tsx
+++ b/hushh-webapp/__tests__/components/person-profile-page.test.tsx
@@ -1,0 +1,176 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode, TextareaHTMLAttributes } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getPublic: vi.fn(),
+  getViewer: vi.fn(),
+  push: vi.fn(),
+  pathname: "/people/actual-public-ref",
+  native: true,
+  platform: "ios",
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mocks.pathname,
+  useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    getPlatform: () => mocks.platform,
+    isNativePlatform: () => mocks.native,
+  },
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ user: null, loading: false }),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    vaultKey: null,
+    vaultOwnerToken: null,
+    isVaultUnlocked: true,
+  }),
+}));
+
+vi.mock("@/lib/services/person-profile-service", () => ({
+  PersonProfileService: {
+    getPublic: mocks.getPublic,
+    getViewer: mocks.getViewer,
+    createInformationRequest: vi.fn(),
+    connect: vi.fn(),
+    cancelConnectionRequest: vi.fn(),
+    removeConnection: vi.fn(),
+    getInformationRequestExports: vi.fn(),
+    cancelInformationRequest: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/one-kyc-client-zk-service", () => ({
+  OneKycClientZkService: {
+    decryptScopedExport: vi.fn(),
+    ensureConnector: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/app-ui/app-page-shell", () => ({
+  AppPageShell: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+}));
+
+vi.mock("@/components/app-ui/page-sections", () => ({
+  PageHeader: ({
+    title,
+    description,
+  }: {
+    title: string;
+    description?: string;
+  }) => (
+    <header>
+      <h2>{title}</h2>
+      {description ? <p>{description}</p> : null}
+    </header>
+  ),
+}));
+
+vi.mock("@/lib/morphy-ux/button", () => ({
+  Button: ({
+    asChild,
+    children,
+    ...props
+  }: {
+    asChild?: boolean;
+    children: ReactNode;
+  }) => (asChild ? <>{children}</> : <button {...props}>{children}</button>),
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DialogContent: ({ children }: { children: ReactNode }) => <section>{children}</section>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <footer>{children}</footer>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/textarea", () => ({
+  Textarea: (props: TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
+}));
+
+vi.mock("@/lib/morphy-ux/ui/surface-primitives", () => ({
+  AvatarBubble: () => <span data-testid="avatar" />,
+  SectionCard: ({ children }: { children: ReactNode }) => <section>{children}</section>,
+  StatusPill: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/lib/agent/local-onboarding-actions", () => ({
+  useLocalOnboardingActionHandler: vi.fn(),
+}));
+
+vi.mock("@/lib/voice/voice-surface-metadata", () => ({
+  usePublishVoiceSurfaceMetadata: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import { PersonProfilePage } from "@/components/connections/person-profile-page";
+
+describe("PersonProfilePage native profile route", () => {
+  beforeEach(() => {
+    mocks.getPublic.mockResolvedValue({
+      personRef: "actual-public-ref",
+      displayName: "Actual Person",
+      photoUrl: null,
+      verifiedRole: null,
+    });
+    mocks.getViewer.mockResolvedValue(null);
+    mocks.pathname = "/people/actual-public-ref";
+    mocks.native = true;
+    mocks.platform = "ios";
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("uses the real iOS pathname person ref when native serves the static export shell", async () => {
+    render(
+      <PersonProfilePage
+        personRef="00000000-0000-4000-8000-000000000001"
+        initialProfile={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mocks.getPublic).toHaveBeenCalledWith("actual-public-ref");
+    });
+    expect(mocks.getPublic).not.toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-000000000001",
+    );
+    expect(await screen.findByRole("heading", { name: "Actual Person" })).toBeInTheDocument();
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it("keeps the server-provided person ref outside native iOS", async () => {
+    mocks.native = false;
+    mocks.platform = "web";
+
+    render(
+      <PersonProfilePage
+        personRef="server-public-ref"
+        initialProfile={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mocks.getPublic).toHaveBeenCalledWith("server-public-ref");
+    });
+  });
+});

--- a/hushh-webapp/__tests__/lib/onboarding-route-admission.test.ts
+++ b/hushh-webapp/__tests__/lib/onboarding-route-admission.test.ts
@@ -37,6 +37,9 @@ describe("onboarding route admission", () => {
     expect(isOnboardingAdmissionExemptRoute("/login")).toBe(true);
     expect(isOnboardingAdmissionExemptRoute("/one/profile")).toBe(true);
     expect(isOnboardingAdmissionExemptRoute("/one/profile/security")).toBe(true);
+    expect(isOnboardingAdmissionExemptRoute("/people/person-ref-scoped")).toBe(
+      true,
+    );
     expect(isOnboardingAdmissionExemptRoute("/marketplace")).toBe(false);
     expect(isOnboardingAdmissionExemptRoute("/ria")).toBe(false);
   });

--- a/hushh-webapp/__tests__/navigation/routes.test.ts
+++ b/hushh-webapp/__tests__/navigation/routes.test.ts
@@ -8,6 +8,7 @@ import {
   buildKaiMarketRoute,
   buildOneSetupKaiRoute,
   buildOneSetupCapabilityRoute,
+  buildPersonProfileRoute,
   buildWelcomeRoute,
   isAnalyticsExemptRoute,
   isCapabilityHandoffTarget,
@@ -22,6 +23,7 @@ import {
   isRiaRoute,
   resolveCapabilityHandoffTarget,
   resolveCompletedSetupCapabilityEntry,
+  resolvePersonRefFromProfilePathname,
   ROUTES,
 } from "@/lib/navigation/routes";
 import {
@@ -61,6 +63,32 @@ describe("navigation routes", () => {
     );
     expect(buildWelcomeRoute("https://example.com")).toBe(ROUTES.HOME);
     expect(buildWelcomeRoute("//example.com")).toBe(ROUTES.HOME);
+  });
+
+  it("builds person profile routes with a safe origin marker", () => {
+    expect(
+      buildPersonProfileRoute("public person/ref", { from: ROUTES.CONNECT }),
+    ).toBe("/people/public%20person%2Fref?from=%2Fone%2Fconnect");
+    expect(
+      buildPersonProfileRoute("public-person-ref", {
+        from: "https://example.com/one/connect",
+      }),
+    ).toBe("/people/public-person-ref");
+    expect(buildPersonProfileRoute("public-person-ref")).toBe(
+      "/people/public-person-ref",
+    );
+  });
+
+  it("resolves the active person ref from public profile pathnames", () => {
+    expect(resolvePersonRefFromProfilePathname("/people/public-person-ref")).toBe(
+      "public-person-ref",
+    );
+    expect(
+      resolvePersonRefFromProfilePathname(
+        "/people/public%20person%2Fref?from=%2Fone%2Fconnect",
+      ),
+    ).toBe("public person/ref");
+    expect(resolvePersonRefFromProfilePathname("/one/profile/access")).toBeNull();
   });
 
   it("builds canonical nested profile routes while preserving transient query state", () => {
@@ -210,10 +238,14 @@ describe("navigation routes", () => {
   it("defines profile and Connect inside the vault-protected One route family", () => {
     expect(ROUTES.PROFILE).toBe("/one/profile");
     expect(ROUTES.PROFILE_SECURITY).toBe("/one/profile/security");
+    expect(ROUTES.PERSON_PROFILE).toBe("/people/[personRef]");
     expect(ROUTES.CONNECT).toBe("/one/connect");
     expect(ROUTES.CONNECT_SETTINGS).toBe("/one/connect/settings");
     expect(isOnboardingAdmissionExemptRoute(ROUTES.PROFILE)).toBe(true);
     expect(isOnboardingAdmissionExemptRoute(ROUTES.PROFILE_SECURITY)).toBe(
+      true,
+    );
+    expect(isOnboardingAdmissionExemptRoute("/people/person-ref-scoped")).toBe(
       true,
     );
   });

--- a/hushh-webapp/__tests__/navigation/top-shell-back.test.ts
+++ b/hushh-webapp/__tests__/navigation/top-shell-back.test.ts
@@ -49,6 +49,19 @@ describe("top shell back action", () => {
     ).toEqual({ href: "/one", mode: "push", transitionMode: "full" });
   });
 
+  it("returns a Connect-opened person profile directly to Connect", () => {
+    expect(
+      resolveTopShellBackAction({
+        pathname: "/people/person-ref-scoped",
+        searchParams: new URLSearchParams("from=/one/connect"),
+      }),
+    ).toEqual({
+      href: "/one/connect",
+      mode: "push",
+      transitionMode: "full",
+    });
+  });
+
   it("returns the resolved action to the shared transition owner", () => {
     const navigate = vi.fn();
     expect(

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -434,6 +434,50 @@ describe("top shell breadcrumbs", () => {
     });
   });
 
+  it("keeps Connect as the origin for a person profile opened from Connect", () => {
+    const fromConnect = new URLSearchParams();
+    fromConnect.set("from", "/one/connect");
+
+    expect(
+      resolveTopShellBreadcrumb("/people/person-ref-scoped", fromConnect),
+    ).toEqual({
+      backHref: "/one/connect",
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Connect", href: "/one/connect" },
+        { label: "Profile" },
+      ],
+    });
+
+    const unsafeOrigin = new URLSearchParams();
+    unsafeOrigin.set("from", "//evil.example/one/connect");
+    expect(
+      resolveTopShellBreadcrumb("/people/person-ref-scoped", unsafeOrigin),
+    ).toBeNull();
+  });
+
+  it("keeps the Profile access connection detail route scoped to Access & sharing", () => {
+    const connectionParams = new URLSearchParams();
+    connectionParams.set("id", "c-scoped");
+
+    expect(
+      resolveTopShellBreadcrumb(
+        "/one/profile/access/connection",
+        connectionParams,
+      ),
+    ).toEqual({
+      backHref: "/one/profile/access",
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Profile", href: "/one/profile" },
+        { label: "Access & sharing", href: "/one/profile/access" },
+        { label: "Connection detail" },
+      ],
+    });
+  });
+
   it("owns profile nested and legacy panels from the shared top bar", () => {
     const panelParams = new URLSearchParams();
 

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -2519,7 +2519,13 @@ export default function ConnectPageClient() {
                             density="compact"
                             onClick={
                               connection.publicPersonRef
-                                ? () => router.push(buildPersonProfileRoute(connection.publicPersonRef!))
+                                ? () =>
+                                    router.push(
+                                      buildPersonProfileRoute(
+                                        connection.publicPersonRef!,
+                                        { from: ROUTES.CONNECT },
+                                      ),
+                                    )
                                 : undefined
                             }
                             trailing={
@@ -2877,7 +2883,13 @@ export default function ConnectPageClient() {
                                 density="compact"
                                 onClick={
                                   !isSelectionMode && person.publicPersonRef
-                                    ? () => router.push(buildPersonProfileRoute(person.publicPersonRef!))
+                                    ? () =>
+                                        router.push(
+                                          buildPersonProfileRoute(
+                                            person.publicPersonRef!,
+                                            { from: ROUTES.CONNECT },
+                                          ),
+                                        )
                                     : undefined
                                 }
                                 trailing={

--- a/hushh-webapp/components/connections/person-profile-page.tsx
+++ b/hushh-webapp/components/connections/person-profile-page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { Capacitor } from "@capacitor/core";
 import { CheckCircle2, Copy, Eye, EyeOff, LockKeyhole } from "lucide-react";
 import { toast } from "sonner";
 
@@ -31,7 +32,10 @@ import {
   type PublicPersonProfile,
   type ViewerPersonProfile,
 } from "@/lib/services/person-profile-service";
-import { ROUTES } from "@/lib/navigation/routes";
+import {
+  resolvePersonRefFromProfilePathname,
+  ROUTES,
+} from "@/lib/navigation/routes";
 import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 
@@ -49,11 +53,30 @@ function initials(name: string): string {
 
 export function PersonProfilePage({ personRef, initialProfile }: Props) {
   const router = useRouter();
+  const pathname = usePathname();
   const { user, loading: authLoading } = useAuth();
   const { vaultKey, vaultOwnerToken, isVaultUnlocked } = useVault();
-  const [profile, setProfile] = useState<PublicPersonProfile | null>(initialProfile);
+  const resolvedPersonRef = useMemo(() => {
+    const isNativeIOS =
+      Capacitor.isNativePlatform() && Capacitor.getPlatform() === "ios";
+    if (!isNativeIOS) return personRef;
+    return resolvePersonRefFromProfilePathname(pathname) || personRef;
+  }, [pathname, personRef]);
+  const [profileState, setProfileState] = useState<{
+    personRef: string;
+    profile: PublicPersonProfile | null;
+  }>({ personRef: resolvedPersonRef, profile: initialProfile });
+  const profile =
+    profileState.personRef === resolvedPersonRef ? profileState.profile : null;
   const [publicProfileUnavailable, setPublicProfileUnavailable] = useState(false);
-  const [viewerProfile, setViewerProfile] = useState<ViewerPersonProfile | null>(null);
+  const [viewerProfileState, setViewerProfileState] = useState<{
+    personRef: string;
+    profile: ViewerPersonProfile | null;
+  }>({ personRef: resolvedPersonRef, profile: null });
+  const viewerProfile =
+    viewerProfileState.personRef === resolvedPersonRef
+      ? viewerProfileState.profile
+      : null;
   const [selectedScopeRefs, setSelectedScopeRefs] = useState<Set<string>>(new Set());
   const [reviewOpen, setReviewOpen] = useState(false);
   const [purpose, setPurpose] = useState("");
@@ -67,9 +90,12 @@ export function PersonProfilePage({ personRef, initialProfile }: Props) {
   useEffect(() => {
     if (profile) return;
     let active = true;
-    void PersonProfileService.getPublic(personRef)
+    setPublicProfileUnavailable(false);
+    void PersonProfileService.getPublic(resolvedPersonRef)
       .then((value) => {
-        if (active) setProfile(value);
+        if (active) {
+          setProfileState({ personRef: resolvedPersonRef, profile: value });
+        }
       })
       .catch(() => {
         if (active) setPublicProfileUnavailable(true);
@@ -77,20 +103,35 @@ export function PersonProfilePage({ personRef, initialProfile }: Props) {
     return () => {
       active = false;
     };
-  }, [personRef, profile]);
+  }, [resolvedPersonRef, profile]);
 
   useEffect(() => {
     if (authLoading || !user) return;
     let active = true;
     void user
       .getIdToken()
-      .then((token) => PersonProfileService.getViewer(personRef, token))
-      .then((value) => active && setViewerProfile(value))
+      .then((token) => PersonProfileService.getViewer(resolvedPersonRef, token))
+      .then((value) => {
+        if (active) {
+          setViewerProfileState({
+            personRef: resolvedPersonRef,
+            profile: value,
+          });
+        }
+      })
       .catch(() => undefined);
     return () => {
       active = false;
     };
-  }, [authLoading, personRef, user]);
+  }, [authLoading, resolvedPersonRef, user]);
+
+  useEffect(() => {
+    setSelectedScopeRefs(new Set());
+    setReviewOpen(false);
+    setPurpose("");
+    setDecryptedByRequest({});
+    setRevealedRequests(new Set());
+  }, [resolvedPersonRef]);
 
   useEffect(() => {
     if (isVaultUnlocked) return;
@@ -126,7 +167,7 @@ export function PersonProfilePage({ personRef, initialProfile }: Props) {
         vaultOwnerToken,
       });
       await PersonProfileService.createInformationRequest({
-        personRef,
+        personRef: resolvedPersonRef,
         scopeRefs: selectedScopes.map((scope) => scope.scopeRef),
         purpose: purpose.trim(),
         durationSeconds: 7 * 24 * 60 * 60,
@@ -138,7 +179,10 @@ export function PersonProfilePage({ personRef, initialProfile }: Props) {
       setSelectedScopeRefs(new Set());
       setPurpose("");
       const idToken = await user.getIdToken();
-      setViewerProfile(await PersonProfileService.getViewer(personRef, idToken));
+      setViewerProfileState({
+        personRef: resolvedPersonRef,
+        profile: await PersonProfileService.getViewer(resolvedPersonRef, idToken),
+      });
       toast.success("Request sent for review");
     } catch (reason) {
       toast.error(reason instanceof Error ? reason.message : "Request could not be sent.");
@@ -154,11 +198,24 @@ export function PersonProfilePage({ personRef, initialProfile }: Props) {
       const idToken = await user.getIdToken();
       const relationship =
         action === "connect"
-          ? await PersonProfileService.connect(personRef, idToken)
+          ? await PersonProfileService.connect(resolvedPersonRef, idToken)
           : action === "cancel"
-            ? await PersonProfileService.cancelConnectionRequest(personRef, idToken)
-            : await PersonProfileService.removeConnection(personRef, idToken);
-      setViewerProfile((current) => current ? { ...current, relationship } : current);
+            ? await PersonProfileService.cancelConnectionRequest(
+                resolvedPersonRef,
+                idToken,
+              )
+            : await PersonProfileService.removeConnection(
+                resolvedPersonRef,
+                idToken,
+              );
+      setViewerProfileState((current) =>
+        current.personRef === resolvedPersonRef && current.profile
+          ? {
+              personRef: resolvedPersonRef,
+              profile: { ...current.profile, relationship },
+            }
+          : current,
+      );
       toast.success(
         action === "connect"
           ? "Connection request sent"
@@ -229,7 +286,10 @@ export function PersonProfilePage({ personRef, initialProfile }: Props) {
     try {
       await PersonProfileService.cancelInformationRequest({ bundleId, vaultOwnerToken });
       const idToken = await user.getIdToken();
-      setViewerProfile(await PersonProfileService.getViewer(personRef, idToken));
+      setViewerProfileState({
+        personRef: resolvedPersonRef,
+        profile: await PersonProfileService.getViewer(resolvedPersonRef, idToken),
+      });
       toast.success("Information request cancelled");
     } catch (reason) {
       toast.error(reason instanceof Error ? reason.message : "The information request could not be cancelled.");

--- a/hushh-webapp/ios/App/App/MyViewController.swift
+++ b/hushh-webapp/ios/App/App/MyViewController.swift
@@ -2,6 +2,74 @@ import UIKit
 import Capacitor
 import WebKit
 
+struct HushhNativeRouter: Router {
+    private static let nativeStaticPersonProfileRef = "00000000-0000-4000-8000-000000000001"
+    private static let personProfileRoutePrefix = "/people/"
+    private static let personProfileStaticAssetNames: Set<String> = [
+        "__next._full.txt",
+        "__next._head.txt",
+        "__next._index.txt",
+        "__next._tree.txt",
+        "__next.people.$d$personRef.__PAGE__.txt",
+        "__next.people.$d$personRef.txt",
+        "__next.people.txt",
+        "index.html",
+        "index.txt",
+    ]
+
+    var basePath: String = ""
+
+    func route(for path: String) -> String {
+        if let personProfileAssetPath = personProfileAssetPath(for: path) {
+            return basePath + personProfileAssetPath
+        }
+
+        let pathUrl = URL(fileURLWithPath: path)
+
+        if pathUrl.pathExtension.isEmpty {
+            return basePath + "/index.html"
+        }
+
+        return basePath + path
+    }
+
+    func personProfileAssetPath(for path: String) -> String? {
+        guard path.hasPrefix(Self.personProfileRoutePrefix) else {
+            return nil
+        }
+
+        let remainder = path.dropFirst(Self.personProfileRoutePrefix.count)
+        guard !remainder.isEmpty else {
+            return nil
+        }
+        if remainder.hasSuffix(".txt") && !remainder.contains("/") {
+            let personRef = remainder.dropLast(4)
+            guard !personRef.isEmpty else {
+                return nil
+            }
+            return "\(Self.personProfileRoutePrefix)\(Self.nativeStaticPersonProfileRef)/index.txt"
+        }
+
+        let parts = remainder.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+        guard let personRef = parts.first, !personRef.isEmpty else {
+            return nil
+        }
+
+        let assetName: String
+        if parts.count == 1 || parts[1].isEmpty {
+            assetName = "index.html"
+        } else {
+            assetName = String(parts[1])
+        }
+
+        guard Self.personProfileStaticAssetNames.contains(assetName) else {
+            return nil
+        }
+
+        return "\(Self.personProfileRoutePrefix)\(Self.nativeStaticPersonProfileRef)/\(assetName)"
+    }
+}
+
 /**
  * MyViewController - Custom Capacitor Bridge View Controller
  * 
@@ -16,6 +84,10 @@ class MyViewController: CAPBridgeViewController, WKScriptMessageHandler {
     private var nativeTestStatusLabel: NativeTestStatusLabel?
     private var nativeTestPollTimer: Timer?
     private var nativeTestPollInFlight = false
+
+    override open func router() -> Router {
+        HushhNativeRouter()
+    }
 
     deinit {
         nativeTestPollTimer?.invalidate()

--- a/hushh-webapp/ios/App/AppTests/NativeSupportTests.swift
+++ b/hushh-webapp/ios/App/AppTests/NativeSupportTests.swift
@@ -51,6 +51,42 @@ final class NativeSupportTests: XCTestCase {
         XCTAssertTrue(config.statusJavaScript.contains("bridge._uiFlowsRoutingOwned === true"))
     }
 
+    func testNativeRouterServesPersonProfileShellForArbitraryPublicRefs() {
+        var router = HushhNativeRouter()
+        router.basePath = "/app/public"
+
+        XCTAssertEqual(
+            router.route(for: "/people/person-ref-scoped/"),
+            "/app/public/people/00000000-0000-4000-8000-000000000001/index.html"
+        )
+        XCTAssertEqual(
+            router.route(for: "/people/person-ref-scoped/index.txt"),
+            "/app/public/people/00000000-0000-4000-8000-000000000001/index.txt"
+        )
+        XCTAssertEqual(
+            router.route(for: "/people/person-ref-scoped.txt"),
+            "/app/public/people/00000000-0000-4000-8000-000000000001/index.txt"
+        )
+        XCTAssertEqual(
+            router.route(for: "/people/person-ref-scoped/__next.people.$d$personRef.txt"),
+            "/app/public/people/00000000-0000-4000-8000-000000000001/__next.people.$d$personRef.txt"
+        )
+    }
+
+    func testNativeRouterLeavesProfileAccessConnectionRouteUnchanged() {
+        var router = HushhNativeRouter()
+        router.basePath = "/app/public"
+
+        XCTAssertEqual(
+            router.route(for: "/one/profile/access/connection"),
+            "/app/public/index.html"
+        )
+        XCTAssertEqual(
+            router.route(for: "/one/profile/access/connection/index.txt"),
+            "/app/public/one/profile/access/connection/index.txt"
+        )
+    }
+
     func testNormalizeBackendUrlRewritesLocalhost() {
         XCTAssertEqual(
             HushhProxyClient.normalizeBackendUrl("http://localhost:8000/"),

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -55,10 +55,28 @@ export function isKaiMarketPathname(value: string | null | undefined): boolean {
   return financeRoutePathname(value) === KAI_MARKET_PATH;
 }
 
-export function buildPersonProfileRoute(personRef: string): string {
+export function buildPersonProfileRoute(
+  personRef: string,
+  entries?: { from?: string | null },
+): string {
   const normalized = String(personRef || "").trim();
   if (!normalized) throw new Error("A public person reference is required.");
-  return `/people/${encodeURIComponent(normalized)}`;
+  return withQuery(`/people/${encodeURIComponent(normalized)}`, {
+    from: normalizeInternalRouteHref(entries?.from),
+  });
+}
+
+export function resolvePersonRefFromProfilePathname(
+  pathname: string | null | undefined,
+): string | null {
+  const match = String(pathname || "").match(/^\/people\/([^/?#]+)/);
+  const rawRef = match?.[1]?.trim();
+  if (!rawRef) return null;
+  try {
+    return decodeURIComponent(rawRef);
+  } catch {
+    return rawRef;
+  }
 }
 
 export const ROUTES = {
@@ -466,6 +484,7 @@ export function isOnboardingAdmissionExemptRoute(pathname: string): boolean {
     normalizedPathname === ROUTES.LOGOUT ||
     normalizedPathname === ROUTES.PROFILE ||
     normalizedPathname.startsWith(`${ROUTES.PROFILE}/`) ||
+    normalizedPathname.startsWith("/people/") ||
     normalizedPathname.startsWith(`${ROUTES.ONE_LOCATION}/view/`) ||
     normalizedPathname.startsWith(`${ROUTES.ONE_LOCATION}/request/`) ||
     normalizedPathname === ROUTES.CIRCLE_JOIN

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -994,6 +994,22 @@ function resolveTopShellBreadcrumbInner(
     };
   }
 
+  if (pathname.startsWith("/people/")) {
+    const originHref = normalizeInternalRouteHref(searchParams?.get("from"));
+    if (!originHref) {
+      return null;
+    }
+    return {
+      backHref: originHref,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: profileOriginCrumbLabel(originHref), href: originHref },
+        { label: "Profile" },
+      ],
+    };
+  }
+
   if (pathname === ROUTES.MARKETPLACE) {
     return {
       backHref: ROUTES.ONE_HOME,


### PR DESCRIPTION
## Summary

- Route Connect My Connections and directory person taps to the existing /people/[publicPersonRef] profile flow with from=/one/connect.
- Preserve Connect-origin breadcrumbs/back navigation directly to /one/connect.
- Keep the existing Profile → Access & sharing → Connection Detail route unchanged.
- Fix iOS native static routing so arbitrary /people/* profile routes and RSC payloads use the exported placeholder bundle without forcing a full WebView navigation.

## Verification

- Focused Vitest: 7 files, 157 tests passed.
- Frontend typecheck: passed.
- ESLint: passed.
- Native Swift support tests: 9 passed.
- git diff --check: passed.
