### PR TITLE
Bump iOS marketing version to 1.3.8

### DIFF
--- a/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
@@ -612,7 +612,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.7;
+				MARKETING_VERSION = 1.3.8;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.hushh.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -641,7 +641,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.7;
+				MARKETING_VERSION = 1.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hushh.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary

- Bump the iOS App target MARKETING_VERSION from 1.3.7 to 1.3.8 for Debug and Release.
- Leave CURRENT_PROJECT_VERSION unchanged so TestFlight continues to resolve the next build number automatically.
- Keep the TestFlight upload workflow unchanged.

## Verification

Local:

- plutil -lint hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
- No stale MARKETING_VERSION = 1.3.7 values remain in hushh-webapp/ios
- Xcode Debug build settings: MARKETING_VERSION=1.3.8, CURRENT_PROJECT_VERSION=69
- Xcode Release build settings: MARKETING_VERSION=1.3.8, CURRENT_PROJECT_VERSION=69
- git diff --check

GitHub PR checks:

- CI Status Gate: passed
- Web Core (Next.js): passed
- Web Targeted Contracts: passed
- Integration: passed
- DCO, Governance, Secret Scan, Base Freshness, PR Base Policy, Upstream Sync: passed
- Protocol (Python), MCP Package: skipped by path filters

## Scope

Only the iOS marketing version was updated for the next App Store Connect/TestFlight train.