### PR TITLE
fix(connect): resolve person profile 

### DIFF
--- a/hushh-webapp/__tests__/app/people/public-person-profile-page.test.tsx
+++ b/hushh-webapp/__tests__/app/people/public-person-profile-page.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connection: vi.fn(),
+  fetchPythonApi: vi.fn(),
+  notFound: vi.fn(),
+}));
+
+vi.mock("next/server", () => ({
+  connection: mocks.connection,
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: mocks.notFound,
+}));
+
+vi.mock("@/app/api/_utils/backend", () => ({
+  fetchPythonApi: mocks.fetchPythonApi,
+}));
+
+vi.mock("@/components/connections/person-profile-page", () => ({
+  PersonProfilePage: () => null,
+}));
+
+import PublicPersonProfileRoute, {
+  generateStaticParams,
+} from "@/app/people/[personRef]/page";
+
+describe("public person profile route", () => {
+  const originalCapacitorBuild = process.env.CAPACITOR_BUILD;
+
+  beforeEach(() => {
+    process.env.CAPACITOR_BUILD = "";
+    mocks.connection.mockResolvedValue(undefined);
+    mocks.fetchPythonApi.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          personRef: "public-person-ref",
+          displayName: "Public Person",
+          photoUrl: null,
+          verifiedRole: null,
+        }),
+        { status: 200 },
+      ),
+    );
+  });
+
+  afterEach(() => {
+    process.env.CAPACITOR_BUILD = originalCapacitorBuild;
+    vi.clearAllMocks();
+  });
+
+  it("binds web requests to the live request before the no-store profile fetch", async () => {
+    const element = await PublicPersonProfileRoute({
+      params: Promise.resolve({ personRef: "public-person-ref" }),
+    });
+
+    expect(mocks.connection).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchPythonApi).toHaveBeenCalledWith(
+      "/api/public/people/public-person-ref",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+    expect(mocks.connection.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.fetchPythonApi.mock.invocationCallOrder[0],
+    );
+    expect(element.props).toMatchObject({
+      personRef: "public-person-ref",
+      initialProfile: {
+        personRef: "public-person-ref",
+        displayName: "Public Person",
+      },
+    });
+  });
+
+  it("keeps the Capacitor static shell free of web-only server fetches", async () => {
+    process.env.CAPACITOR_BUILD = "true";
+
+    const element = await PublicPersonProfileRoute({
+      params: Promise.resolve({ personRef: "native-placeholder-ref" }),
+    });
+
+    expect(mocks.connection).not.toHaveBeenCalled();
+    expect(mocks.fetchPythonApi).not.toHaveBeenCalled();
+    expect(element.props).toMatchObject({
+      personRef: "native-placeholder-ref",
+      initialProfile: null,
+    });
+    expect(generateStaticParams()).toEqual([
+      { personRef: "00000000-0000-4000-8000-000000000001" },
+    ]);
+  });
+});

--- a/hushh-webapp/app/people/[personRef]/page.tsx
+++ b/hushh-webapp/app/people/[personRef]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { connection } from "next/server";
 
 import { PersonProfilePage } from "@/components/connections/person-profile-page";
 import { fetchPythonApi } from "@/app/api/_utils/backend";
@@ -23,6 +24,7 @@ export default async function PublicPersonProfileRoute({
   if (process.env.CAPACITOR_BUILD === "true") {
     return <PersonProfilePage personRef={personRef} initialProfile={null} />;
   }
+  await connection();
   const response = await fetchPythonApi(
     `/api/public/people/${encodeURIComponent(personRef)}`,
     { cache: "no-store", signal: AbortSignal.timeout(15_000) },


### PR DESCRIPTION
## Summary

- Fix the UAT web /people/[personRef] route by binding the server render to a live request before the no-store public profile fetch.
- Preserve the existing Connect route contract: /people/<publicPersonRef>?from=/one/connect.
- Preserve Capacitor/iOS behavior by leaving the native static shell branch free of web-only server fetches.

## Verification

- Focused Vitest: 5 files passed, 133 tests passed
- npm run typecheck: passed
- Targeted ESLint: passed
- git diff --check: passed
- DCO signoff check: passed

## Scope

Follow-up to PR #6276. 