### PR TITLE
fix(location): consistent RIA avatars

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -315,6 +315,7 @@ class CircleMemberPageItem(_CamelModel):
     relationship: str
     can_connect: bool = Field(alias="canConnect")
     connected_from_contacts: bool = Field(alias="connectedFromContacts")
+    is_ria: bool = Field(default=False, alias="isRia")
 
 
 class CircleMembersPageResponse(_CamelModel):

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -35,6 +35,7 @@ from hushh_mcp.operons.location.policy import (
 )
 from hushh_mcp.runtime_settings import get_core_security_settings
 from hushh_mcp.services.people_search_sql import people_query_match_params
+from hushh_mcp.services.ria_status import RIA_VERIFIED_STATUS_SQL
 from hushh_mcp.types import AgentID, UserID
 from mcp_modules.log_redaction import redact_log_field, redact_log_value
 
@@ -1669,6 +1670,7 @@ class OneLocationAgentService:
             "keyRegisteredAt": _iso(row.get("key_created_at") or row.get("created_at")),
             "canReceiveLocation": bool(row.get("key_id")),
             "connectedFromContacts": bool(row.get("connected_from_contacts")),
+            "isRia": bool(row.get("is_ria")),
         }
 
     @staticmethod
@@ -3803,7 +3805,7 @@ class OneLocationAgentService:
         # a Circle qualifies through the Circle branch, and stops qualifying
         # the moment that Circle membership ends.
         rows = self._execute_many(
-            """
+            f"""
             SELECT
               a.user_id, a.display_name, a.email, a.phone_number, a.phone_verified,
               COALESCE(a.custom_photo_url, a.photo_url) AS photo_url,
@@ -3824,7 +3826,13 @@ class OneLocationAgentService:
                     (contact_connection.user_b_id = :owner_user_id
                      AND contact_connection.user_a_id = a.user_id)
                   )
-              ) AS connected_from_contacts
+              ) AS connected_from_contacts,
+              EXISTS (
+                SELECT 1
+                FROM ria_profiles ria_annotation
+                WHERE ria_annotation.user_id = a.user_id
+                  AND {RIA_VERIFIED_STATUS_SQL}
+              ) AS is_ria
             FROM actor_identity_cache a
             LEFT JOIN LATERAL (
               SELECT key_id, public_key_jwk, algorithm, created_at
@@ -3897,7 +3905,7 @@ class OneLocationAgentService:
               )
             ORDER BY COALESCE(a.display_name, a.phone_number, a.user_id), a.user_id
             LIMIT :limit
-            """,
+            """,  # nosec B608 - RIA_VERIFIED_STATUS_SQL is a static module constant.
             {"owner_user_id": owner_user_id, "limit": max(1, min(int(limit), 100))},
         )
 
@@ -3934,12 +3942,18 @@ class OneLocationAgentService:
         normalized_query = str(query or "").strip().lower()
         offset = (normalized_page - 1) * normalized_limit
         rows = self._execute_many(
-            """
+            f"""
             WITH eligible AS (
               SELECT
                 identity.user_id, identity.display_name, identity.email,
                 identity.phone_number, identity.phone_verified,
                 COALESCE(identity.custom_photo_url, identity.photo_url) AS photo_url,
+                EXISTS (
+                  SELECT 1
+                  FROM ria_profiles ria_annotation
+                  WHERE ria_annotation.user_id = identity.user_id
+                    AND {RIA_VERIFIED_STATUS_SQL}
+                ) AS is_ria,
                 LOWER(CASE
                   WHEN BTRIM(COALESCE(identity.display_name, '')) <> ''
                    AND BTRIM(identity.display_name) <> identity.user_id
@@ -4031,7 +4045,7 @@ class OneLocationAgentService:
             )
             SELECT page_rows.user_id, page_rows.display_name, page_rows.email,
                    page_rows.phone_number, page_rows.phone_verified,
-                   page_rows.photo_url,
+                   page_rows.photo_url, page_rows.is_ria,
                    recipient_key.key_id, recipient_key.public_key_jwk,
                    recipient_key.algorithm,
                    recipient_key.created_at AS key_created_at,
@@ -4057,7 +4071,7 @@ class OneLocationAgentService:
             ) recipient_key ON TRUE
             ORDER BY page_rows.match_rank, page_rows.normalized_name,
                      page_rows.user_id
-            """,
+            """,  # nosec B608 - RIA_VERIFIED_STATUS_SQL is a static module constant.
             {
                 "owner_user_id": owner_user_id,
                 "query": normalized_query,

--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -618,6 +618,7 @@ class OneLocationCircleService:
             # can start.
             "canConnect": (relationship == "none" and bool(row.get("phone_verified"))),
             "connectedFromContacts": bool(row.get("connected_from_contacts")),
+            "isRia": bool(row.get("is_ria")),
         }
 
     @staticmethod
@@ -835,7 +836,7 @@ class OneLocationCircleService:
                     status_code=404,
                 )
             members_result = self._db.execute_raw(
-                """
+                f"""
                 SELECT
                   membership.user_id, membership.role, membership.joined_at,
                   identity.display_name, identity.email, identity.photo_url,
@@ -843,6 +844,12 @@ class OneLocationCircleService:
                   recipient_key.key_id, recipient_key.public_key_jwk,
                   recipient_key.algorithm,
                   recipient_key.created_at AS key_created_at,
+                  EXISTS (
+                    SELECT 1
+                    FROM ria_profiles ria_annotation
+                    WHERE ria_annotation.user_id = membership.user_id
+                      AND {RIA_VERIFIED_STATUS_SQL}
+                  ) AS is_ria,
                   EXISTS (
                     SELECT 1
                     FROM connections contact_connection
@@ -903,7 +910,7 @@ class OneLocationCircleService:
                 ORDER BY
                   CASE membership.role WHEN 'owner' THEN 0 ELSE 1 END,
                   COALESCE(identity.display_name, membership.user_id)
-                """,
+                """,  # nosec B608 - RIA_VERIFIED_STATUS_SQL is a static module constant.
                 {"circle_id": cleaned_circle_id, "viewer_user_id": user_id},
             )
             circle = self._circle_summary(dict(summary_row))
@@ -1038,7 +1045,7 @@ class OneLocationCircleService:
         offset = (normalized_page - 1) * normalized_limit
         try:
             result = self._db.execute_raw(
-                """
+                f"""
                 WITH authorized_circle AS (
                   SELECT circle.id, circle.owner_user_id
                   FROM one_location_circles circle
@@ -1054,6 +1061,12 @@ class OneLocationCircleService:
                   SELECT membership.user_id, membership.role, membership.joined_at,
                          identity.display_name, identity.email, identity.photo_url,
                          identity.custom_photo_url, identity.phone_verified,
+                         EXISTS (
+                           SELECT 1
+                           FROM ria_profiles ria_annotation
+                           WHERE ria_annotation.user_id = membership.user_id
+                             AND {RIA_VERIFIED_STATUS_SQL}
+                         ) AS is_ria,
                          LOWER(CASE
                            WHEN BTRIM(COALESCE(identity.display_name, '')) <> ''
                             AND BTRIM(identity.display_name) <> membership.user_id
@@ -1166,7 +1179,7 @@ class OneLocationCircleService:
                 ) recipient_key ON TRUE
                 ORDER BY page_rows.match_rank, page_rows.normalized_name,
                          page_rows.user_id
-                """,
+                """,  # nosec B608 - RIA_VERIFIED_STATUS_SQL is a static module constant.
                 {
                     "circle_id": cleaned_circle_id,
                     "viewer_user_id": user_id,

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -880,6 +880,16 @@ def test_verified_recipient_directory_sources_from_connections_and_circles() -> 
     assert service.params["owner_user_id"] == "owner"
 
 
+def test_paged_verified_recipient_directory_uses_the_shared_verified_ria_gate() -> None:
+    service = RecipientDirectoryProbe()
+
+    assert service.list_verified_recipients_page(owner_user_id="owner")["items"] == []
+    assert "ria_profiles ria_annotation" in service.sql
+    assert "'finra_verified'" in service.sql
+    assert "page_rows.is_ria" in service.sql
+    assert service.params["owner_user_id"] == "owner"
+
+
 def test_list_verified_recipients_sources_from_connections(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -899,6 +909,7 @@ def test_list_verified_recipients_sources_from_connections(
                 "public_key_jwk": "{}",
                 "algorithm": "ECDH-P256-AES256-GCM",
                 "key_created_at": None,
+                "is_ria": True,
             }
         ]
 
@@ -906,8 +917,11 @@ def test_list_verified_recipients_sources_from_connections(
     monkeypatch.setattr(svc, "_apply_kai_circle_recommendations", lambda **kw: kw["recipients"])
     out = svc.list_verified_recipients(owner_user_id="owner")
     assert "FROM connections c" in captured["sql"]
+    assert "ria_profiles ria_annotation" in captured["sql"]
+    assert "'finra_verified'" in captured["sql"]
     assert "a.phone_verified = TRUE" not in captured["sql"]
     assert out and out[0]["userId"] == "friend"
+    assert out[0]["isRia"] is True
 
 
 def test_list_active_owner_grants_is_scoped_to_this_owner_and_active_status(
@@ -3199,6 +3213,29 @@ def test_recipient_payload_masks_email_for_directory_disambiguation() -> None:
     assert payload is not None
     assert payload["maskedEmail"] == "a***y@example.com"
     assert "abdul.secondary@example.com" not in json.dumps(payload)
+
+
+def test_recipient_payload_marks_verified_ria_status() -> None:
+    payload = OneLocationAgentService._recipient_payload(
+        {
+            "user_id": "advisor-user",
+            "display_name": "Ada Advisor",
+            "phone_verified": True,
+            "is_ria": True,
+        }
+    )
+    assert payload is not None
+    assert payload["isRia"] is True
+
+    payload = OneLocationAgentService._recipient_payload(
+        {
+            "user_id": "person-user",
+            "display_name": "Pat Person",
+            "phone_verified": True,
+        }
+    )
+    assert payload is not None
+    assert payload["isRia"] is False
 
 
 def test_directory_candidate_search_filters_before_pagination(

--- a/consent-protocol/tests/services/test_one_location_circle_service.py
+++ b/consent-protocol/tests/services/test_one_location_circle_service.py
@@ -139,6 +139,30 @@ def test_eligible_connection_payload_marks_verified_ria_status() -> None:
     )
 
 
+def test_circle_member_payload_marks_verified_ria_status() -> None:
+    assert (
+        OneLocationCircleService._member_payload(
+            {
+                "user_id": "advisor-user",
+                "display_name": "Ada Advisor",
+                "phone_verified": True,
+                "is_ria": True,
+            }
+        )["isRia"]
+        is True
+    )
+    assert (
+        OneLocationCircleService._member_payload(
+            {
+                "user_id": "person-user",
+                "display_name": "Pat Person",
+                "phone_verified": True,
+            }
+        )["isRia"]
+        is False
+    )
+
+
 def test_the_roster_and_picker_queries_read_the_email_the_ladder_needs() -> None:
     """A ladder with no rung to stand on resolves nothing.
 
@@ -156,6 +180,24 @@ def test_the_roster_and_picker_queries_read_the_email_the_ladder_needs() -> None
 
     source = inspect.getsource(OneLocationCircleService.list_eligible_direct_connections)
     assert "identity.email" in source
+
+
+def test_circle_member_queries_use_the_shared_verified_ria_gate() -> None:
+    import inspect
+
+    from hushh_mcp.services.ria_iam_service import RIAIAMService
+    from hushh_mcp.services.ria_status import RIA_VERIFIED_STATUS_SQL
+
+    for status in RIAIAMService._RIA_VERIFIED_STATUSES:
+        assert f"'{status}'" in RIA_VERIFIED_STATUS_SQL
+
+    source = inspect.getsource(OneLocationCircleService.get_circle)
+    assert "RIA_VERIFIED_STATUS_SQL" in source
+    assert "ria_profiles ria_annotation" in source
+
+    source = inspect.getsource(OneLocationCircleService.list_circle_members_page)
+    assert "RIA_VERIFIED_STATUS_SQL" in source
+    assert "ria_profiles ria_annotation" in source
 
 
 def test_eligible_connection_queries_use_the_shared_verified_ria_gate() -> None:

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -3773,8 +3773,7 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "People" }));
     expect(await screen.findByText("Trusted B")).toBeTruthy();
     expect(screen.queryByText(/Request location/)).toBeNull();
-    expect(screen.getByText("TB").className).toContain("bg-[#E5E5EA]");
-    expect(screen.getByText("TB").className).toContain("text-[#6E6E73]");
+    expect(screen.getByText("TB")).toBeTruthy();
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Now" }));
@@ -5148,8 +5147,18 @@ describe("OneLocationAgentPage", () => {
     // The roster carries `role="list"`, and every entry in it is wrapped as a
     // `listitem`. The new compact treatment removes section headers entirely,
     // so a screen reader never reads "Recent" as a person between two names.
+    const state = locationState();
     mockGetState.mockResolvedValue({
-      ...locationState(),
+      ...state,
+      recipients: state.recipients.map((recipient) =>
+        recipient.userId === "user_b"
+          ? {
+              ...recipient,
+              photoUrl: "https://cdn.example.test/trusted-b-avatar.jpg",
+              isRia: true,
+            }
+          : recipient,
+      ),
       // The page derives `requestedByMe` from `requests`, filtered to the ones
       // this viewer sent, so the fixture has to seed the field the API returns.
       requests: [
@@ -5181,6 +5190,12 @@ describe("OneLocationAgentPage", () => {
     expect(
       within(list).getByRole("button", { name: /Select Advisor C/i }),
     ).toBeTruthy();
+    expect(
+      list.querySelector(
+        '[data-photo-url="https://cdn.example.test/trusted-b-avatar.jpg"]',
+      ),
+    ).toBeTruthy();
+    expect(within(list).getByLabelText("Verified advisor")).toBeTruthy();
   });
 
   it("offers a way to Connect when the person being looked for is not on the list", async () => {

--- a/hushh-webapp/__tests__/lib/one-location/paged-reads-contract.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/paged-reads-contract.test.ts
@@ -35,6 +35,7 @@ const RECIPIENT = {
   userId: "u-1",
   displayName: "Aman",
   email: "a***@example.com",
+  isRia: false,
 };
 
 describe("one-location paged reads", () => {

--- a/hushh-webapp/__tests__/services/location-agent-service.test.ts
+++ b/hushh-webapp/__tests__/services/location-agent-service.test.ts
@@ -79,7 +79,7 @@ describe("OneLocationService", () => {
     });
 
     await expect(OneLocationService.listRecipients("vault-token")).resolves.toEqual([
-      { userId: "user_b", displayName: "Person B" },
+      { userId: "user_b", displayName: "Person B", isRia: false },
     ]);
     expect(mockApiJson).toHaveBeenCalledWith("/api/one/location/recipients", {
       headers: { Authorization: "Bearer vault-token" },
@@ -88,7 +88,14 @@ describe("OneLocationService", () => {
 
   it("reads recipient pages without changing the legacy complete-list contract", async () => {
     mockApiJson.mockResolvedValueOnce({
-      items: [{ userId: "user_51", displayName: "Same", connectedFromContacts: true }],
+      items: [
+        {
+          userId: "user_51",
+          displayName: "Same",
+          connectedFromContacts: true,
+          isRia: true,
+        },
+      ],
       page: 2,
       hasMore: true,
       totalCount: 5000,
@@ -106,13 +113,41 @@ describe("OneLocationService", () => {
       { headers: { Authorization: "Bearer vault-token" } },
     );
     expect(page).toMatchObject({ page: 2, hasMore: true, totalCount: 5000 });
-    expect(page.items[0]).toMatchObject({ connectedFromContacts: true });
+    expect(page.items[0]).toMatchObject({
+      connectedFromContacts: true,
+      isRia: true,
+    });
+  });
+
+  it("normalizes RIA status on Circle detail member rows", async () => {
+    mockApiJson.mockResolvedValueOnce({
+      circle: {
+        id: "circle-1",
+        name: "Family",
+        members: [
+          { userId: "member-1", displayName: "Ada Advisor", isRia: true },
+          { userId: "member-2", displayName: "Pat Person" },
+        ],
+      },
+    });
+
+    const circle = await OneLocationService.getCircle({
+      vaultOwnerToken: "vault-token",
+      circleId: "circle-1",
+    });
+
+    expect(circle.members.map((member) => member.isRia)).toEqual([true, false]);
   });
 
   it("uses overview, member pages, eligible pages, and summary-only Trusted reads", async () => {
     mockApiJson
       .mockResolvedValueOnce({ circle: { id: "circle-1", name: "Family" } })
-      .mockResolvedValueOnce({ items: [], page: 2, hasMore: true, totalCount: 5000 })
+      .mockResolvedValueOnce({
+        items: [{ userId: "member-1", displayName: "Member One", isRia: true }],
+        page: 2,
+        hasMore: true,
+        totalCount: 5000,
+      })
       .mockResolvedValueOnce({
         eligibleConnections: [],
         pendingInvites: [],
@@ -127,7 +162,7 @@ describe("OneLocationService", () => {
       vaultOwnerToken: "vault-token",
       circleId: "circle-1",
     });
-    await OneLocationService.listCircleMembersPage({
+    const membersPage = await OneLocationService.listCircleMembersPage({
       vaultOwnerToken: "vault-token",
       circleId: "circle-1",
       page: 2,
@@ -152,6 +187,7 @@ describe("OneLocationService", () => {
       "/api/one/location/circles/circle-1/eligible-connections?page=2&limit=50&query=same",
       "/api/one/location/circles/trusted?summaryOnly=true",
     ]);
+    expect(membersPage.items[0]).toMatchObject({ isRia: true });
   });
 
   it("stores encrypted envelopes without plaintext coordinates", async () => {

--- a/hushh-webapp/components/one-location/redesign/__tests__/people-hub.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/people-hub.test.tsx
@@ -97,6 +97,43 @@ function vm(overrides: Partial<LocationHubViewModel> = {}): LocationHubViewModel
 }
 
 describe("PeopleHub requests sent manage surface", () => {
+  it("uses the Connect avatar renderer for Location people rows", () => {
+    render(
+      <PeopleHub
+        vm={vm({
+          requestedByMe: [],
+          receivedGrants: [],
+          editingGrantId: null,
+          visibleRecipients: [
+            {
+              ...recipient,
+              photoUrl: "https://cdn.example.test/roopmann-location.jpg",
+              isRia: true,
+            },
+          ],
+        })}
+        onAddConnections={vi.fn()}
+        onInvite={vi.fn()}
+        onCreateCircle={vi.fn()}
+        onJoinCircle={vi.fn()}
+        onOpenCircle={vi.fn()}
+        focusedInviteId={null}
+        onDismissFocusedInvite={vi.fn()}
+        onStartShare={vi.fn()}
+      />,
+    );
+
+    const peopleList = screen.getByTestId("one-location-people-list");
+    expect(
+      peopleList.querySelector(
+        '[data-photo-url="https://cdn.example.test/roopmann-location.jpg"]',
+      ),
+    ).toBeTruthy();
+    expect(
+      within(peopleList).getByLabelText("Verified advisor"),
+    ).toBeInTheDocument();
+  });
+
   it("uses quick extension actions instead of the old duration editor", () => {
     render(
       <PeopleHub

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -137,6 +137,7 @@ function ContactRow({
   completed,
   label,
   photoUrl,
+  verified,
   fromContacts,
   isLast,
   onToggle,
@@ -147,6 +148,7 @@ function ContactRow({
   completed: boolean;
   label: string;
   photoUrl?: string | null;
+  verified?: boolean;
   fromContacts?: boolean;
   isLast: boolean;
   onToggle: () => void;
@@ -167,6 +169,7 @@ function ContactRow({
       <ContactAvatar
         label={label}
         photoUrl={photoUrl}
+        verified={verified}
         className="h-[42px] w-[42px]"
       />
       <span className="min-w-0 flex-1">
@@ -749,6 +752,7 @@ export function CheckInFlow({
                 completed={completedRecipientIds.includes(recipient.userId)}
                 label={vm.recipientLabel(recipient)}
                 photoUrl={recipient.photoUrl}
+                verified={Boolean(recipient.isRia)}
                 fromContacts={recipient.connectedFromContacts}
                 isLast={index === filtered.length - 1}
                 onToggle={() => toggle(recipient.userId)}

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/circle-member-actions-menu.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/circle-member-actions-menu.test.tsx
@@ -88,7 +88,10 @@ describe("CircleMemberActionsMenu on a phone", () => {
   });
 
   it("opens a bottom sheet that names the member instead of an anchored menu over the next row", async () => {
-    renderMenu();
+    renderMenu({
+      photoUrl: "https://cdn.example.test/ankit-avatar.jpg",
+      verified: true,
+    });
 
     fireEvent.click(screen.getByRole("button", { name: triggerName }));
 
@@ -104,6 +107,12 @@ describe("CircleMemberActionsMenu on a phone", () => {
     // Whose actions these are, said on the surface rather than by proximity.
     expect(within(sheet).getByText(MEMBER_NAME)).toBeInTheDocument();
     expect(within(sheet).getByText("Connected")).toBeInTheDocument();
+    expect(
+      sheet.querySelector(
+        '[data-photo-url="https://cdn.example.test/ankit-avatar.jpg"]',
+      ),
+    ).toBeTruthy();
+    expect(within(sheet).getByLabelText("Verified advisor")).toBeInTheDocument();
 
     expect(
       within(sheet).getByRole("menuitem", { name: /Share location/i }),

--- a/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx
@@ -107,6 +107,8 @@ describe("named Circle flows", () => {
           secureLocationReady: true,
           relationship: "connected" as const,
           connectedFromContacts: true,
+          photoUrl: "https://cdn.example.test/asha-contact.jpg",
+          isRia: true,
         },
       ],
     }));
@@ -114,7 +116,16 @@ describe("named Circle flows", () => {
     render(<CircleDetailFlow circleId="circle-1" {...detailProps(onLoad)} />);
 
     expect(await screen.findByText("Asha Contact")).toBeTruthy();
-    expect(screen.getByLabelText("Connected from your contacts")).toBeTruthy();
+    const roster = screen.getByTestId("one-location-circle-members");
+    expect(
+      roster.querySelector(
+        '[data-photo-url="https://cdn.example.test/asha-contact.jpg"]',
+      ),
+    ).toBeTruthy();
+    expect(within(roster).getByLabelText("Verified advisor")).toBeTruthy();
+    expect(
+      within(roster).getByLabelText("Connected from your contacts"),
+    ).toBeTruthy();
   });
 
   it("uses bounded member pages and keeps duplicate names addressable by user id", async () => {

--- a/hushh-webapp/components/one-location/redesign/circles/circle-member-actions-menu.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/circle-member-actions-menu.tsx
@@ -67,8 +67,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { ConnectionPersonAvatar } from "@/components/connections/connection-person-avatar";
 import {
   Drawer,
   DrawerContent,
@@ -182,10 +182,11 @@ function useSheetPresentation(): boolean {
 
 export type CircleMemberActionsMenuProps = {
   displayName: string;
-  /** Initials for the sheet header's avatar, computed by the row so the two
-   *  avatars of the same person can never disagree. */
+  /** Retained for existing callers; the shared avatar component now owns
+   *  fallback initials so roster rows and sheets cannot disagree. */
   initials: string;
   photoUrl?: string | null;
+  verified?: boolean;
   /** The row's own second line ("Connected", "Owner", "Location setup
    *  needed"). Repeated in the sheet header so the sheet identifies the
    *  person exactly the way the row it came from did. */
@@ -209,8 +210,8 @@ export type CircleMemberActionsMenuProps = {
  */
 export function CircleMemberActionsMenu({
   displayName,
-  initials,
   photoUrl,
+  verified = false,
   secondaryLine,
   canShare,
   canRemove,
@@ -316,10 +317,12 @@ export function CircleMemberActionsMenu({
                     left this to proximity, and proximity is the one thing a
                     roster of near-identical rows cannot carry. */}
                 <div className="flex items-center gap-3 pb-3">
-                  <Avatar className="h-11 w-11 shrink-0">
-                    {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
-                    <AvatarFallback>{initials}</AvatarFallback>
-                  </Avatar>
+                  <ConnectionPersonAvatar
+                    label={displayName}
+                    photoUrl={photoUrl}
+                    verified={verified}
+                    className="h-11 w-11"
+                  />
                   <div className="min-w-0 flex-1 text-left">
                     <DrawerTitle className="truncate text-[17px] leading-[22px]">
                       {displayName}

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -30,7 +30,6 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   SheetClose,
   Sheet,
@@ -940,10 +939,12 @@ function CircleMemberRow({
 
   return (
     <div className={CIRCLE_MEMBER_ROW_CLASSNAME}>
-      <Avatar className={CIRCLE_MEMBER_AVATAR_CLASSNAME}>
-        {member.photoUrl ? <AvatarImage src={member.photoUrl} alt="" /> : null}
-        <AvatarFallback>{circleInitials(member.displayName)}</AvatarFallback>
-      </Avatar>
+      <ConnectionPersonAvatar
+        label={member.displayName}
+        photoUrl={member.photoUrl}
+        verified={Boolean(member.isRia)}
+        className={CIRCLE_MEMBER_AVATAR_CLASSNAME}
+      />
       <div className="min-w-0 flex-1">
         {/* `truncate`, not `break-words`. A long name used to wrap to three
             lines and push its own row to twice the height of its neighbours,
@@ -1057,6 +1058,7 @@ function CircleMemberRow({
           displayName={member.displayName}
           initials={circleInitials(member.displayName)}
           photoUrl={member.photoUrl}
+          verified={Boolean(member.isRia)}
           secondaryLine={secondaryLine}
           canShare={canShare}
           canRemove={canRemove}
@@ -2227,20 +2229,14 @@ export function CircleDetailFlow({
                             <SettingsRow
                               key={invite.id}
                               leading={
-                                <Avatar className="h-10 w-10">
-                                  {invite.inviteePhotoUrl ? (
-                                    <AvatarImage
-                                      src={invite.inviteePhotoUrl}
-                                      alt=""
-                                    />
-                                  ) : null}
-                                  <AvatarFallback>
-                                    {circleInitials(
-                                      invite.inviteeDisplayName ||
-                                        "One connection",
-                                    )}
-                                  </AvatarFallback>
-                                </Avatar>
+                                <ConnectionPersonAvatar
+                                  label={
+                                    invite.inviteeDisplayName ||
+                                    "One connection"
+                                  }
+                                  photoUrl={invite.inviteePhotoUrl}
+                                  className="h-10 w-10"
+                                />
                               }
                               title={
                                 invite.inviteeDisplayName || "One connection"

--- a/hushh-webapp/components/one-location/redesign/contact-picker/atoms.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/atoms.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
-import Image from "next/image";
+import type { ReactNode } from "react";
 import { Loader2 } from "lucide-react";
 
 import { ContactSourceBadge } from "@/components/connections/contact-source-badge";
+import { ConnectionPersonAvatar } from "@/components/connections/connection-person-avatar";
 import { cn } from "@/lib/utils";
 import { roleClasses } from "@/lib/morphy-ux/tokens/semantic-roles";
 
@@ -40,38 +40,20 @@ export function ContactAvatar({
   label,
   photoUrl,
   className,
+  verified = false,
 }: {
   label: string;
   photoUrl?: string | null;
   className?: string;
+  verified?: boolean;
 }) {
-  const [imageFailed, setImageFailed] = useState(false);
-  const showImage = Boolean(photoUrl) && !imageFailed;
-
   return (
-    <span
-      className={cn(
-        "relative flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full text-[15px] font-semibold",
-        CONTACT_AVATAR_TONE,
-        className,
-      )}
-      aria-hidden
-    >
-      {showImage && photoUrl ? (
-        <Image
-          src={photoUrl}
-          alt=""
-          fill
-          sizes="52px"
-          unoptimized
-          referrerPolicy="no-referrer"
-          className="object-cover"
-          onError={() => setImageFailed(true)}
-        />
-      ) : (
-        initials(label)
-      )}
-    </span>
+    <ConnectionPersonAvatar
+      label={label}
+      photoUrl={photoUrl}
+      verified={verified}
+      className={cn("h-9 w-9 text-[15px]", className)}
+    />
   );
 }
 
@@ -154,6 +136,7 @@ export function ContactRowAction({
 export function ContactRow({
   label,
   photoUrl,
+  verified = false,
   subtitle,
   fromContacts,
   selected,
@@ -164,6 +147,7 @@ export function ContactRow({
 }: {
   label: string;
   photoUrl?: string | null;
+  verified?: boolean;
   subtitle?: string | null;
   fromContacts?: boolean;
   selected: boolean;
@@ -177,7 +161,7 @@ export function ContactRow({
       className="flex min-h-[58px] items-center gap-3 px-3.5 py-2"
       data-testid="contact-picker-row"
     >
-      <ContactAvatar label={label} photoUrl={photoUrl} />
+      <ContactAvatar label={label} photoUrl={photoUrl} verified={verified} />
       <span className="min-w-0 flex-1">
         <span className="flex min-w-0 items-start gap-1.5">
           <span className="min-w-0 flex-1 truncate text-[17px] font-normal leading-[22px] text-[color:var(--app-label)]">

--- a/hushh-webapp/components/one-location/redesign/contact-picker/circle-member-picker.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/circle-member-picker.tsx
@@ -22,6 +22,7 @@ type MemberRow = {
   userId: string;
   label: string;
   photoUrl?: string | null;
+  isRia: boolean;
   fromContacts: boolean;
   /** Set when the member cannot receive SMS yet; explains why, inline. */
   blockedReason: string | null;
@@ -108,6 +109,7 @@ export function CircleMemberPicker({
       userId: target.recipient.userId,
       label: recipientLabel(target.recipient),
       photoUrl: target.recipient.photoUrl,
+      isRia: Boolean(target.recipient.isRia),
       fromContacts: Boolean(target.recipient.connectedFromContacts),
       blockedReason: null,
     }));
@@ -124,6 +126,7 @@ export function CircleMemberPicker({
           userId: item.member.userId,
           label: recipientLabel(item.member),
           photoUrl: item.member.photoUrl,
+          isRia: Boolean(item.member.isRia),
           fromContacts: Boolean(item.member.connectedFromContacts),
           blockedReason: item.label,
         }))
@@ -306,7 +309,11 @@ export function CircleMemberPicker({
                         (added || blocked) && "opacity-60",
                       )}
                     >
-                      <ContactAvatar label={row.label} photoUrl={row.photoUrl} />
+                      <ContactAvatar
+                        label={row.label}
+                        photoUrl={row.photoUrl}
+                        verified={row.isRia}
+                      />
                       <span className="min-w-0 flex-1">
                         <span className="flex min-w-0 items-start gap-1.5">
                           <span className="min-w-0 flex-1 truncate text-[17px] font-normal leading-[22px] text-foreground">

--- a/hushh-webapp/components/one-location/redesign/contact-picker/selected-review-sheet.tsx
+++ b/hushh-webapp/components/one-location/redesign/contact-picker/selected-review-sheet.tsx
@@ -145,7 +145,11 @@ export function SelectedContactsSheet({
                 const busy = busyUserId === recipient.userId;
                 return (
                   <div className="flex min-h-[58px] items-center gap-3 px-3.5 py-2">
-                    <ContactAvatar label={label} photoUrl={recipient.photoUrl} />
+                    <ContactAvatar
+                      label={label}
+                      photoUrl={recipient.photoUrl}
+                      verified={Boolean(recipient.isRia)}
+                    />
                     <span className="min-w-0 flex-1">
                       <span className="flex min-w-0 items-start gap-1.5">
                         <span className="min-w-0 flex-1 truncate text-[17px] font-normal leading-[22px] text-foreground">

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -27,7 +27,6 @@ import {
   type ReactNode,
 } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
@@ -134,8 +133,8 @@ import {
 } from "./primitives";
 import { MUTED_TEXT, SUBCARD_SURFACE } from "./tokens";
 import { ContactSourceBadge } from "@/components/connections/contact-source-badge";
+import { ConnectionPersonAvatar } from "@/components/connections/connection-person-avatar";
 import {
-  initialsFrom,
   RequestCard,
   SharedWithMeCard,
   type GrantViewStatus,
@@ -3152,6 +3151,7 @@ function StopGrantTextButton({
 function PersonRow({
   name,
   photoUrl,
+  verified,
   fromContacts,
   subtitle,
   active,
@@ -3161,6 +3161,7 @@ function PersonRow({
 }: {
   name: string;
   photoUrl?: string | null;
+  verified?: boolean;
   fromContacts?: boolean;
   subtitle: string;
   /** True when there's a live connection (you're sharing or they're sharing). */
@@ -3175,9 +3176,6 @@ function PersonRow({
    */
   expansion?: ReactNode;
 }) {
-  const [imageFailed, setImageFailed] = useState(false);
-  const showImage = Boolean(photoUrl) && !imageFailed;
-
   return (
     // The separator and the hover wash belong to the whole row INCLUDING its
     // breakdown: a person's two shares are one row, and a hairline cutting
@@ -3191,27 +3189,19 @@ function PersonRow({
     >
       <div className="flex min-h-[60px] items-center gap-3 px-4 py-2.5 sm:min-h-16">
         <div className="relative shrink-0">
-          <span
-            className="relative flex h-9 w-9 items-center justify-center overflow-hidden rounded-full bg-[#E5E5EA] text-[13px] font-semibold text-[#6E6E73] dark:bg-[rgba(142,142,147,0.28)] dark:text-[#D1D1D6]"
-            aria-hidden
-          >
-            {showImage && photoUrl ? (
-              <Image
-                src={photoUrl}
-                alt=""
-                fill
-                sizes="36px"
-                unoptimized
-                referrerPolicy="no-referrer"
-                className="object-cover"
-                onError={() => setImageFailed(true)}
-              />
-            ) : (
-              personInitials(name)
-            )}
-          </span>
+          <ConnectionPersonAvatar
+            label={name}
+            photoUrl={photoUrl}
+            verified={verified}
+            className="h-9 w-9 text-[13px]"
+          />
           {active ? (
-            <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full border-2 border-[color:var(--app-primary-surface)] bg-[color:var(--app-success)]" />
+            <span
+              className={cn(
+                "absolute h-3 w-3 rounded-full border-2 border-[color:var(--app-primary-surface)] bg-[color:var(--app-success)]",
+                verified ? "-right-0.5 -top-0.5" : "bottom-0 right-0",
+              )}
+            />
           ) : null}
         </div>
         <div className="min-w-0 flex-1 space-y-0.5">
@@ -3535,6 +3525,7 @@ export function PeopleHub({
                         key={r.userId}
                         name={name}
                         photoUrl={r.photoUrl}
+                        verified={Boolean(r.isRia)}
                         fromContacts={r.connectedFromContacts}
                         expansion={
                           shareGroup && !singleGrant ? (
@@ -4291,7 +4282,13 @@ function ShareFlow({
             ? `${selected ? "Deselect" : "Select"} ${label} for private sharing`
             : undefined
         }
-        leading={<Avatar initials={initialsFrom(label)} imageUrl={r.photoUrl} />}
+        leading={
+          <ConnectionPersonAvatar
+            label={label}
+            photoUrl={r.photoUrl}
+            verified={Boolean(r.isRia)}
+          />
+        }
         title={
           <span className="flex min-w-0 items-start gap-1.5">
             <span className="min-w-0 flex-1 truncate">{label}</span>
@@ -4902,6 +4899,7 @@ function SelectionDot({ selected }: { selected: boolean }) {
 function RequestRecipientListRow({
   name,
   photoUrl,
+  verified,
   fromContacts,
   subtitle,
   tone,
@@ -4919,6 +4917,7 @@ function RequestRecipientListRow({
 }: {
   name: string;
   photoUrl?: string | null;
+  verified?: boolean;
   fromContacts?: boolean;
   subtitle?: string;
   tone: "ready" | "pending" | "neutral";
@@ -4949,7 +4948,7 @@ function RequestRecipientListRow({
       )}
     >
       <div className="flex min-h-[58px] items-center gap-3 px-3.5 py-2">
-        <ContactAvatar label={name} photoUrl={photoUrl} />
+        <ContactAvatar label={name} photoUrl={photoUrl} verified={verified} />
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-start gap-1.5">
             <span className="min-w-0 flex-1 truncate text-[17px] font-normal leading-[22px] text-foreground">
@@ -5434,6 +5433,7 @@ function AskFlow({
                   key={r.userId}
                   name={recipientLabel}
                   photoUrl={r.photoUrl}
+                  verified={Boolean(r.isRia)}
                   fromContacts={r.connectedFromContacts}
                   subtitle={
                     status.selectable && status.tone === "ready"
@@ -5592,6 +5592,7 @@ function SelectedRecipientsRail({
                   key={recipient.userId}
                   label={label}
                   photoUrl={recipient.photoUrl}
+                  verified={Boolean(recipient.isRia)}
                   className="h-9 w-9 border-2 border-[color:var(--app-card-surface-default-solid)] text-[13px]"
                 />
               );
@@ -5627,6 +5628,7 @@ function SelectedRecipientsRail({
                 <ContactAvatar
                   label={label}
                   photoUrl={recipient.photoUrl}
+                  verified={Boolean(recipient.isRia)}
                   className="h-8 w-8 text-[13px]"
                 />
                 <span className="flex min-w-0 flex-1 items-start gap-1.5 text-[17px] font-normal leading-[22px] text-[color:var(--app-label)]">

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -329,6 +329,7 @@ export function SmsContactsFlow({
                       <ContactRow
                         label={label}
                         photoUrl={recipient.photoUrl}
+                        verified={Boolean(recipient.isRia)}
                         subtitle={recipientSubtitle(recipient)}
                         fromContacts={recipient.connectedFromContacts}
                         selected={selectedIds.has(recipient.userId)}
@@ -390,6 +391,7 @@ export function SmsContactsFlow({
             <ContactAvatar
               label={pendingRemoval ? recipientLabel(pendingRemoval) : "?"}
               photoUrl={pendingRemoval?.photoUrl}
+              verified={Boolean(pendingRemoval?.isRia)}
               className="h-[52px] w-[52px] rounded-[16px] text-xl"
             />
             <AlertDialogTitle className="mt-1 !text-center !text-[20px] !font-semibold !leading-[25px] !tracking-normal">

--- a/hushh-webapp/lib/one-location/__tests__/circle-recipient-selection-avatar.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/circle-recipient-selection-avatar.test.ts
@@ -4,7 +4,10 @@ import {
   mergeRecipientsByUserId,
   resolveCircleRecipientSelection,
 } from "@/lib/one-location/circle-recipient-selection";
-import type { OneLocationCircleDetail, OneLocationRecipient } from "@/lib/one-location/types";
+import type {
+  OneLocationCircleDetail,
+  OneLocationRecipient,
+} from "@/lib/one-location/types";
 
 const publicKeyJwk: JsonWebKey = { kty: "EC" };
 
@@ -28,6 +31,7 @@ describe("circle recipient avatar identity", () => {
           canReceiveLocation: true,
           keyId: "key-person-1",
           publicKeyJwk,
+          isRia: true,
         },
       ],
     };
@@ -37,6 +41,7 @@ describe("circle recipient avatar identity", () => {
     expect(selection.ready[0]?.recipient.photoUrl).toBe(
       "https://lh3.googleusercontent.com/avatar",
     );
+    expect(selection.ready[0]?.recipient.isRia).toBe(true);
   });
 
   it("does not overwrite an existing recipient photo with a null Circle value", () => {
@@ -47,16 +52,24 @@ describe("circle recipient avatar identity", () => {
       phoneVerified: true,
       keyAlgorithm: "test",
       canReceiveLocation: true,
+      isRia: true,
     };
     const circleRecipient: OneLocationRecipient = {
       ...directoryRecipient,
       photoUrl: null,
+      isRia: false,
       keyId: "key-person-1",
       publicKeyJwk,
     };
 
-    expect(
-      mergeRecipientsByUserId([directoryRecipient], [circleRecipient])[0]?.photoUrl,
-    ).toBe("https://lh3.googleusercontent.com/directory-avatar");
+    const merged = mergeRecipientsByUserId(
+      [directoryRecipient],
+      [circleRecipient],
+    )[0];
+
+    expect(merged?.photoUrl).toBe(
+      "https://lh3.googleusercontent.com/directory-avatar",
+    );
+    expect(merged?.isRia).toBe(true);
   });
 });

--- a/hushh-webapp/lib/one-location/circle-recipient-selection.ts
+++ b/hushh-webapp/lib/one-location/circle-recipient-selection.ts
@@ -92,6 +92,7 @@ export function resolveCircleRecipientSelection(params: {
         keyRegisteredAt: member.keyRegisteredAt,
         canReceiveLocation: true,
         connectedFromContacts: member.connectedFromContacts,
+        isRia: Boolean(member.isRia),
       },
     });
   }
@@ -147,6 +148,7 @@ export function mergeRecipientsByUserId(
         recommendationSummary:
           recipient.recommendationSummary ?? existing?.recommendationSummary,
         photoUrl: recipient.photoUrl ?? existing?.photoUrl ?? null,
+        isRia: Boolean(recipient.isRia || existing?.isRia),
       });
     }
   }

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -25,6 +25,7 @@ import type {
   OneLocationCircleInviteCode,
   OneLocationCircleInvitePreview,
   OneLocationCircleKind,
+  OneLocationCircleMember,
   OneLocationCircleMemberInvite,
   OneLocationCircleMemberPage,
   OneLocationCircleOverview,
@@ -68,6 +69,39 @@ type OneLocationCircleEligibleConnectionsApiResponse = {
   remainingCapacity?: number;
 };
 
+type OneLocationRecipientApiRow = Omit<OneLocationRecipient, "isRia"> & {
+  isRia?: boolean | null;
+};
+
+type OneLocationCircleMemberApiRow = Omit<OneLocationCircleMember, "isRia"> & {
+  isRia?: boolean | null;
+};
+
+type OneLocationStateApiResponse = Omit<OneLocationState, "recipients"> & {
+  recipients?: OneLocationRecipientApiRow[];
+};
+
+type OneLocationRecipientPageApiResponse = Omit<
+  OneLocationRecipientPage,
+  "items"
+> & {
+  items?: OneLocationRecipientApiRow[];
+};
+
+type OneLocationCircleDetailApiResponse = Omit<
+  OneLocationCircleDetail,
+  "members"
+> & {
+  members?: OneLocationCircleMemberApiRow[];
+};
+
+type OneLocationCircleMemberPageApiResponse = Omit<
+  OneLocationCircleMemberPage,
+  "items"
+> & {
+  items?: OneLocationCircleMemberApiRow[];
+};
+
 function normalizeEligibleConnection(
   connection: OneLocationCircleEligibleConnectionApiRow,
 ): OneLocationCircleEligibleConnection {
@@ -75,6 +109,39 @@ function normalizeEligibleConnection(
     ...connection,
     isRia: Boolean(connection.isRia),
   };
+}
+
+function normalizeRecipient(
+  recipient: OneLocationRecipientApiRow,
+): OneLocationRecipient {
+  return {
+    ...recipient,
+    isRia: Boolean(recipient.isRia),
+  };
+}
+
+function normalizeCircleMember(
+  member: OneLocationCircleMemberApiRow,
+): OneLocationCircleMember {
+  return {
+    ...member,
+    isRia: Boolean(member.isRia),
+  };
+}
+
+function normalizeCircleDetail(
+  circle: OneLocationCircleDetailApiResponse,
+): OneLocationCircleDetail {
+  return {
+    ...circle,
+    members: (circle.members ?? []).map(normalizeCircleMember),
+  };
+}
+
+function normalizeCircleMaybeDetail(
+  circle: OneLocationCircleDetailApiResponse | OneLocationCircleOverview,
+): OneLocationCircleDetail | OneLocationCircleOverview {
+  return "members" in circle ? normalizeCircleDetail(circle) : circle;
 }
 
 function authHeaders(vaultOwnerToken: string): Record<string, string> {
@@ -447,7 +514,7 @@ export class OneLocationService {
     algorithm: string;
     encryptedPrivateKeyJwk?: OneLocationEncryptedPrivateKey | null;
   }): Promise<OneLocationRecipient> {
-    const response = await apiJson<{ recipientKey: OneLocationRecipient }>(
+    const response = await apiJson<{ recipientKey: OneLocationRecipientApiRow }>(
       "/api/one/location/recipient-keys",
       {
         method: "POST",
@@ -462,13 +529,20 @@ export class OneLocationService {
         }),
       },
     );
-    return response.recipientKey;
+    return normalizeRecipient(response.recipientKey);
   }
 
   static async getState(vaultOwnerToken: string): Promise<OneLocationState> {
-    return apiJsonWithRetry<OneLocationState>("/api/one/location/state", {
-      headers: jsonAuthHeaders(vaultOwnerToken),
-    });
+    const state = await apiJsonWithRetry<OneLocationStateApiResponse>(
+      "/api/one/location/state",
+      {
+        headers: jsonAuthHeaders(vaultOwnerToken),
+      },
+    );
+    return {
+      ...state,
+      recipients: (state.recipients ?? []).map(normalizeRecipient),
+    };
   }
 
   static async updateAutoApprovePreference(params: {
@@ -560,11 +634,11 @@ export class OneLocationService {
   static async listRecipients(
     vaultOwnerToken: string,
   ): Promise<OneLocationRecipient[]> {
-    const response = await apiJson<{ recipients: OneLocationRecipient[] }>(
+    const response = await apiJson<{ recipients?: OneLocationRecipientApiRow[] }>(
       "/api/one/location/recipients",
       { headers: authHeaders(vaultOwnerToken) },
     );
-    return response.recipients ?? [];
+    return (response.recipients ?? []).map(normalizeRecipient);
   }
 
   static async listRecipientsPage(params: {
@@ -579,10 +653,16 @@ export class OneLocationService {
     });
     if (params.query?.trim()) search.set("query", params.query.trim());
     const endpoint = `/api/one/location/recipients?${search.toString()}`;
-    const payload = await apiJson<Partial<OneLocationRecipientPage>>(endpoint, {
-      headers: authHeaders(params.vaultOwnerToken),
-    });
-    const items = pagedItems(payload, "/api/one/location/recipients");
+    const payload = await apiJson<Partial<OneLocationRecipientPageApiResponse>>(
+      endpoint,
+      {
+        headers: authHeaders(params.vaultOwnerToken),
+      },
+    );
+    const items = pagedItems(
+      payload,
+      "/api/one/location/recipients",
+    ).map(normalizeRecipient);
     return {
       items,
       page: Math.max(1, Number(payload.page ?? params.page ?? 1)),
@@ -605,11 +685,11 @@ export class OneLocationService {
     vaultOwnerToken: string;
     circleId: string;
   }): Promise<OneLocationCircleDetail> {
-    const response = await apiJson<{ circle: OneLocationCircleDetail }>(
+    const response = await apiJson<{ circle: OneLocationCircleDetailApiResponse }>(
       `/api/one/location/circles/${encodeURIComponent(params.circleId)}`,
       { headers: authHeaders(params.vaultOwnerToken) },
     );
-    return response.circle;
+    return normalizeCircleDetail(response.circle);
   }
 
   static async getCircleOverview(params: {
@@ -636,11 +716,11 @@ export class OneLocationService {
     });
     if (params.query?.trim()) search.set("query", params.query.trim());
     const route = `/api/one/location/circles/${encodeURIComponent(params.circleId)}/members`;
-    const payload = await apiJson<Partial<OneLocationCircleMemberPage>>(
+    const payload = await apiJson<Partial<OneLocationCircleMemberPageApiResponse>>(
       `${route}?${search.toString()}`,
       { headers: authHeaders(params.vaultOwnerToken) },
     );
-    const items = pagedItems(payload, route);
+    const items = pagedItems(payload, route).map(normalizeCircleMember);
     return {
       items,
       page: Math.max(1, Number(payload.page ?? params.page ?? 1)),
@@ -658,11 +738,11 @@ export class OneLocationService {
   static async ensureSmsSystemCircle(params: {
     vaultOwnerToken: string;
   }): Promise<OneLocationCircleDetail> {
-    const response = await apiJson<{ circle: OneLocationCircleDetail }>(
+    const response = await apiJson<{ circle: OneLocationCircleDetailApiResponse }>(
       "/api/one/location/circles/sms-system",
       { method: "POST", headers: authHeaders(params.vaultOwnerToken) },
     );
-    return response.circle;
+    return normalizeCircleDetail(response.circle);
   }
 
   /**
@@ -684,12 +764,12 @@ export class OneLocationService {
     summaryOnly?: boolean;
   }): Promise<OneLocationCircleDetail | OneLocationCircleOverview> {
     const response = await apiJson<{
-      circle: OneLocationCircleDetail | OneLocationCircleOverview;
+      circle: OneLocationCircleDetailApiResponse | OneLocationCircleOverview;
     }>(
       `/api/one/location/circles/trusted${params.summaryOnly ? "?summaryOnly=true" : ""}`,
       { method: "POST", headers: authHeaders(params.vaultOwnerToken) },
     );
-    return response.circle;
+    return normalizeCircleMaybeDetail(response.circle);
   }
 
   static async createNamedCircle(params: {
@@ -697,7 +777,7 @@ export class OneLocationService {
     name: string;
     kind: OneLocationCircleKind;
   }): Promise<OneLocationCircleDetail> {
-    const response = await apiJson<{ circle: OneLocationCircleDetail }>(
+    const response = await apiJson<{ circle: OneLocationCircleDetailApiResponse }>(
       "/api/one/location/circles",
       {
         method: "POST",
@@ -705,7 +785,7 @@ export class OneLocationService {
         body: JSON.stringify({ name: params.name, kind: params.kind }),
       },
     );
-    return response.circle;
+    return normalizeCircleDetail(response.circle);
   }
 
   /**
@@ -759,7 +839,7 @@ export class OneLocationService {
     name?: string;
     kind?: OneLocationCircleKind;
   }): Promise<OneLocationCircleDetail> {
-    const response = await apiJson<{ circle: OneLocationCircleDetail }>(
+    const response = await apiJson<{ circle: OneLocationCircleDetailApiResponse }>(
       `/api/one/location/circles/${encodeURIComponent(params.circleId)}`,
       {
         method: "PATCH",
@@ -770,7 +850,7 @@ export class OneLocationService {
         }),
       },
     );
-    return response.circle;
+    return normalizeCircleDetail(response.circle);
   }
 
   static async deleteNamedCircle(params: {
@@ -835,11 +915,18 @@ export class OneLocationService {
     vaultOwnerToken: string;
     code: string;
   }): Promise<{ circle: OneLocationCircleDetail; joined: boolean }> {
-    return apiJson("/api/one/location/circle-codes/join", {
+    const response = await apiJson<{
+      circle: OneLocationCircleDetailApiResponse;
+      joined: boolean;
+    }>("/api/one/location/circle-codes/join", {
       method: "POST",
       headers: jsonAuthHeaders(params.vaultOwnerToken),
       body: JSON.stringify({ code: params.code }),
     });
+    return {
+      circle: normalizeCircleDetail(response.circle),
+      joined: response.joined,
+    };
   }
 
   static async leaveNamedCircle(params: {
@@ -1000,14 +1087,14 @@ export class OneLocationService {
     vaultOwnerToken: string;
     inviteId: string;
   }): Promise<OneLocationCircleDetail> {
-    const response = await apiJson<{ circle: OneLocationCircleDetail }>(
+    const response = await apiJson<{ circle: OneLocationCircleDetailApiResponse }>(
       `/api/one/location/circle-member-invites/${encodeURIComponent(params.inviteId)}/accept`,
       {
         method: "POST",
         headers: authHeaders(params.vaultOwnerToken),
       },
     );
-    return response.circle;
+    return normalizeCircleDetail(response.circle);
   }
 
   static async declineNamedCircleMemberInvite(params: {

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -85,6 +85,7 @@ export type OneLocationRecipient = {
   verificationBadge?: string | null;
   lastInteractionAt?: string | null;
   connectedFromContacts?: boolean;
+  isRia?: boolean;
 };
 
 export type OneLocationRecipientPage = {
@@ -402,6 +403,7 @@ export type OneLocationCircleMember = {
   /** False when there is nothing to request: self, connected, or already pending. */
   canConnect?: boolean;
   connectedFromContacts?: boolean;
+  isRia?: boolean;
 };
 
 export type OneLocationCircleMemberRelationship =


### PR DESCRIPTION
## Summary

- Follows merged PR #6268 and extends the same verified-RIA avatar behavior from Connect to all relevant Location avatar surfaces.
- Propagates backend `isRia` for Location recipients and Circle members using the shared verified-RIA status gate.
- Normalizes missing `isRia` values to `false` on the Location frontend service boundary.
- Reuses the existing `ConnectionPersonAvatar` rendering path for Location people lists, request-location, check-in/SMS, selected people, circles, and member/action-sheet surfaces.

## Verification

- `cd consent-protocol && uv run pytest tests/services/test_one_location_agent_service.py::test_paged_verified_recipient_directory_uses_the_shared_verified_ria_gate tests/services/test_one_location_agent_service.py::test_list_verified_recipients_sources_from_connections tests/services/test_one_location_agent_service.py::test_recipient_payload_marks_verified_ria_status tests/services/test_one_location_circle_service.py::test_circle_member_payload_marks_verified_ria_status tests/services/test_one_location_circle_service.py::test_circle_member_queries_use_the_shared_verified_ria_gate tests/services/test_one_location_circle_service.py::test_eligible_connection_queries_use_the_shared_verified_ria_gate tests/services/test_one_location_circle_service.py::test_invitable_connections_are_not_narrowed_to_directly_requested_ones` — 7 passed
- `cd hushh-webapp && npm run test -- __tests__/components/one-location-agent-page.test.tsx components/one-location/redesign/__tests__/people-hub.test.tsx` — 130 passed
- `cd hushh-webapp && npm run test -- __tests__/services/location-agent-service.test.ts components/one-location/redesign/circles/__tests__/named-circle-flows.test.tsx components/one-location/redesign/circles/__tests__/circle-member-actions-menu.test.tsx lib/one-location/__tests__/circle-recipient-selection-avatar.test.ts __tests__/lib/one-location/paged-reads-contract.test.ts` — 95 passed
- `cd hushh-webapp && npm run verify:one-location` — 731 passed
- `cd hushh-webapp && npm run typecheck` — passed
- `cd hushh-webapp && npx eslint ... --max-warnings=0` — passed
- `cd consent-protocol && uv run ruff check ...` — passed
- `git diff --check origin/main..HEAD` — passed
- `bash scripts/ci/check-dco-signoff.sh origin/main HEAD` — passed
