### PR TITLE
fix(wallet): give the wallet card a way back out

### DIFF
--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -936,4 +936,30 @@ describe("top shell breadcrumbs", () => {
       resolveTopShellBreadcrumb("/ria/picks", new URLSearchParams("view=Debate")),
     ).toEqual(barePicks);
   });
+
+  it("gives the wallet card a way back to the row that opened it", () => {
+    // It had no entry at all, so the resolver returned null and the top shell
+    // rendered no breadcrumb -- leaving the screen with no way out. The Back
+    // control inside the workspace is a stage control between steps of the
+    // pass flow, present in only one stage, so it never served as the exit.
+    expect(resolveTopShellBreadcrumb("/one/wallet-card")).toEqual({
+      backHref: "/one/profile/account",
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Profile", href: "/one/profile" },
+        { label: "Account", href: "/one/profile/account" },
+        { label: "Apple Wallet" },
+      ],
+    });
+  });
+
+  it("sends the wallet card back to Account, the panel it is reached from", () => {
+    // profile-workspace-page.tsx pushes this route from the Apple Wallet row
+    // inside the Account panel. Backing out to bare /one/profile would land
+    // somebody a level above the row they tapped.
+    const config = resolveTopShellBreadcrumb("/one/wallet-card");
+    expect(config?.backHref).toBe("/one/profile/account");
+    expect(config?.backHref).not.toBe("/one/profile");
+  });
 });

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -837,6 +837,29 @@ function resolveTopShellBreadcrumbInner(
     };
   }
 
+  // Reached only from Profile > Account (profile-workspace-page.tsx pushes
+  // ROUTES.ONE_WALLET_CARD from the "Apple Wallet" row), and it had no entry
+  // here at all -- so the resolver returned null, the top shell rendered no
+  // breadcrumb, and the screen had no way back out. The Back control inside
+  // the workspace is a stage control (setStage("manage")); it moves between
+  // steps of the pass flow and exists in only one of them, so it was never
+  // the way out of the surface.
+  if (pathname === ROUTES.ONE_WALLET_CARD) {
+    return {
+      backHref: ROUTES.PROFILE_ACCOUNT,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Profile", href: ROUTES.PROFILE },
+        { label: "Account", href: ROUTES.PROFILE_ACCOUNT },
+        // Matches WALLET_CARD_COPY.profileEntry.title, the row that leads
+        // here. Kept as a literal rather than an import so a navigation
+        // module does not reach into a component folder for a string.
+        { label: "Apple Wallet" },
+      ],
+    };
+  }
+
   if (pathname === ROUTES.ONE_MARKETPLACE) {
     const originHref = normalizeInternalRouteHref(searchParams?.get("from"));
     const fromProfile = originHref === ROUTES.PROFILE;


### PR DESCRIPTION
## Cause

`/one/wallet-card` had **no entry** in the top-shell breadcrumb resolver. `resolveTopShellBreadcrumb` returned `null`, the shell rendered no breadcrumb, and the screen had no back control at all.

The `Back` button inside the workspace looks like the exit but is not one — it is a stage control (`setStage("manage")`) that moves between steps of the pass flow, and it renders in only one of those stages. Everywhere else there was nothing.

## The fix

An entry for the route, with back going to **Profile → Account** rather than bare Profile. That is the panel the route is actually pushed from (`profile-workspace-page.tsx:3117` opens it from the "Apple Wallet" row inside Account), and returning a level above the row somebody tapped is its own small wrongness.

The crumb label matches `WALLET_CARD_COPY.profileEntry.title` so it agrees with the row that led there. Kept as a literal rather than an import, so a navigation module doesn't reach into a component folder for a string — the same practice the "Choose your AI" crumb already uses in this file.

## Test plan

- [x] Two new tests: the full breadcrumb config, and a targeted assertion that back is `/one/profile/account` and **not** `/one/profile` — the interesting half, and the one a future edit is most likely to get subtly wrong.
- [x] `npx vitest run __tests__/utils/top-shell-breadcrumbs.test.ts` — 35/35.
- [x] Wider sweep (`__tests__/utils/`, `__tests__/navigation/`, `components/wallet-card/__tests__/`) — 330 passed, 3 failed.
- [x] **Those 3 are pre-existing** — stashed the change and reproduced the identical set on clean `main` (`connect-circle-breadcrumbs` ×2, `home-shell-contract` ×1). Untouched by this PR.
- [x] `npx tsc --noEmit`, `eslint --max-warnings=0` — clean.

Addresses #6287.
