### PR TITLE
Fix RIA shortlisted prospect discoverability

### DIFF
--- a/hushh-webapp/__tests__/components/ria-nearby-around-you-shortlist-sync.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-nearby-around-you-shortlist-sync.test.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockDiscover, mockListShortlist, mockShortlist } = vi.hoisted(() => ({
+  mockDiscover: vi.fn(),
+  mockListShortlist: vi.fn(),
+  mockShortlist: vi.fn(),
+}));
+
+vi.mock("@/lib/services/nws-nearby-service", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/services/nws-nearby-service")
+  >("@/lib/services/nws-nearby-service");
+  return {
+    ...actual,
+    NwsNearbyService: {
+      discover: mockDiscover,
+      listShortlist: mockListShortlist,
+      shortlist: mockShortlist,
+    },
+  };
+});
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ user: { uid: "ria_1", getIdToken: async () => "token" } }),
+}));
+
+vi.mock("@/lib/one-location/use-current-location", () => ({
+  useCurrentLocation: () => ({
+    status: "idle",
+    permission: null,
+    snapshot: null,
+    error: null,
+    request: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/ria/nearby/nearby-record-sheet", () => ({
+  NearbyRecordSheet: ({
+    record,
+    open,
+    onShortlist,
+    shortlisted,
+  }: {
+    record: { displayName: string | null; personId: string } | null;
+    open: boolean;
+    onShortlist: (record: { displayName: string | null; personId: string }) => void;
+    shortlisted: boolean;
+  }) =>
+    record && open ? (
+      <button type="button" onClick={() => onShortlist(record)}>
+        {shortlisted ? "Shortlisted" : "Shortlist"}
+      </button>
+    ) : null,
+}));
+
+import { NearbyAroundYou } from "@/components/ria/nearby/nearby-around-you";
+
+function record() {
+  return {
+    rank: 1,
+    personId: "b1",
+    displayName: "Builder One",
+    headline: "CEO",
+    organization: "Monolithic Power Systems",
+    lane: "BUILDER",
+    globalNws: 83.4,
+    nearbyRankScore: 83.4,
+    scoreStatus: "PROVISIONAL",
+    scoreKind: null,
+    rankingBasis: null,
+    confidence: { score: 0.78, grade: "B" },
+    publicLocation: {
+      label: "MPS public Kirkland office",
+      associationKind: "CURRENT_ORGANIZATION_OFFICE",
+      granularity: "EXACT_PUBLIC_VENUE",
+      distanceBand: "within 2 km",
+      note: "n",
+    },
+    scoreBreakdown: null,
+    evidence: null,
+    associationContext: null,
+    reasons: ["High-authority roles"],
+    warnings: [],
+    tags: ["semiconductors"],
+    revalidationRequired: false,
+    sources: [],
+    modelVersion: "m",
+  };
+}
+
+const COVERED = {
+  coverage: {
+    status: "COVERED",
+    reasonCode: "APPROVED_BOOTSTRAP_MARKET",
+    marketId: "us-wa-kirkland-bootstrap",
+    marketLabel: "Kirkland",
+    countryCode: "US",
+    message: null,
+    complete: false,
+  },
+  snapshot: {
+    scoreStatus: "PROVISIONAL",
+    complete: false,
+    modelVersion: "m",
+    dataMode: "d",
+    verifiedAt: "2026-08-12",
+  },
+  summary: {
+    returnedCount: 1,
+    candidateCount: 1,
+    searchPerformed: true,
+    effectiveRadiusKm: 20,
+  },
+  release: null,
+  reviewScope: { organizationAnchorCount: 1, marketCensusComplete: false },
+  financialContext: null,
+  scoreDefinition: "s",
+  results: [record()],
+};
+
+async function openAPlace() {
+  fireEvent.click(screen.getByRole("button", { name: /enter a place/i }));
+  const field = await screen.findByLabelText(/postcode/i);
+  fireEvent.change(field, { target: { value: "98033" } });
+  fireEvent.click(screen.getByRole("button", { name: /^search$/i }));
+}
+
+function shortlistedProspectsSection() {
+  return screen.getByRole("heading", { name: /shortlisted prospects/i }).closest("section");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockListShortlist.mockResolvedValue([]);
+  mockDiscover.mockResolvedValue(COVERED);
+});
+
+describe("Around You shortlist sync", () => {
+  it("adds a newly shortlisted record to the discoverable prospects list after persistence succeeds", async () => {
+    mockShortlist.mockResolvedValue({
+      id: "shortlist-b1",
+      target_key: "nws:b1",
+      status: "shortlisted",
+      profile: {
+        displayName: "Builder One",
+        headline: "CEO",
+        organization: "Monolithic Power Systems",
+      },
+      updated_at: "2026-08-27T00:00:00.000Z",
+    });
+
+    render(<NearbyAroundYou />);
+    await openAPlace();
+    await waitFor(() => expect(screen.getByText("Builder One")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Builder One"));
+    fireEvent.click(await screen.findByRole("button", { name: /^shortlist$/i }));
+
+    await waitFor(() =>
+      expect(
+        within(shortlistedProspectsSection()!).getAllByText("Builder One"),
+      ).toHaveLength(1),
+    );
+  });
+});

--- a/hushh-webapp/__tests__/components/ria-nearby-around-you.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-nearby-around-you.test.tsx
@@ -191,7 +191,98 @@ function chooseCountry(code: string, name: string) {
   fireEvent.click(screen.getByRole("option", { name: `${code} - ${name}` }));
 }
 
+function shortlistedProspectsSection() {
+  return screen.getByRole("heading", { name: /shortlisted prospects/i }).closest("section");
+}
+
 describe("Around you", () => {
+  it("shows saved shortlisted prospects before another place search", async () => {
+    mockListShortlist.mockResolvedValue([
+      {
+        id: "shortlist-1",
+        target_key: "nws:persisted_1",
+        status: "shortlisted",
+        profile: {
+          displayName: "Saved Prospect",
+          headline: "Founder",
+          organization: "Saved Office",
+          locationLabel: "Kirkland public association",
+        },
+        updated_at: "2026-08-27T00:00:00.000Z",
+      },
+    ]);
+
+    render(<NearbyAroundYou />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Saved Prospect")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText("Founder - Saved Office - Kirkland public association"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/look around a place/i)).toBeInTheDocument();
+    expect(mockDiscover).not.toHaveBeenCalled();
+  });
+
+  it("removes saved shortlisted prospects through the existing pass action", async () => {
+    mockListShortlist.mockResolvedValue([
+      {
+        id: "shortlist-1",
+        target_key: "nws:persisted_1",
+        status: "shortlisted",
+        profile: {
+          displayName: "Saved Prospect",
+          headline: "Founder",
+          organization: "Saved Office",
+          nearbyRankScore: 77.4,
+          globalNws: 70.1,
+          locationLabel: "Kirkland public association",
+        },
+        updated_at: "2026-08-27T00:00:00.000Z",
+      },
+    ]);
+    mockShortlist.mockResolvedValue({
+      id: "shortlist-1",
+      target_key: "nws:persisted_1",
+      status: "passed",
+      profile: {},
+      updated_at: "2026-08-27T00:00:00.000Z",
+    });
+
+    render(<NearbyAroundYou />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Saved Prospect")).toBeInTheDocument(),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove saved prospect from shortlisted prospects/i }),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText("Saved Prospect")).not.toBeInTheDocument(),
+    );
+    expect(mockShortlist).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idToken: "token",
+        action: "pass",
+        record: expect.objectContaining({
+          personId: "persisted_1",
+          displayName: "Saved Prospect",
+        }),
+      }),
+    );
+  });
+
+  it("keeps empty shortlist state clear before search", async () => {
+    render(<NearbyAroundYou />);
+
+    await waitFor(() =>
+      expect(screen.getByText("No shortlisted prospects yet.")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Star a public record to save it here.")).toBeInTheDocument();
+    expect(screen.getByText(/look around a place/i)).toBeInTheDocument();
+  });
+
   it("does not show the location form until it is asked for", async () => {
     render(<NearbyAroundYou />);
 
@@ -269,6 +360,121 @@ describe("Around you", () => {
 
 
 describe("what the list actually shows", () => {
+  it("marks an already-shortlisted search result without duplicating the saved prospect row", async () => {
+    mockListShortlist.mockResolvedValue([
+      {
+        id: "shortlist-b1",
+        target_key: "nws:b1",
+        status: "shortlisted",
+        profile: {
+          displayName: "Builder One",
+          headline: "CEO",
+          organization: "Monolithic Power Systems",
+        },
+        updated_at: "2026-08-27T00:00:00.000Z",
+      },
+    ]);
+
+    render(<NearbyAroundYou />);
+    await openAPlace();
+    await waitFor(() => expect(screen.getByText("Builder One")).toBeInTheDocument());
+
+    expect(screen.getByLabelText("Shortlisted")).toBeInTheDocument();
+    expect(
+      within(shortlistedProspectsSection()!).getAllByText("Builder One"),
+    ).toHaveLength(1);
+  });
+
+  it("keeps the shortlist row absent when a new shortlist request fails", async () => {
+    mockShortlist.mockRejectedValue(new Error("offline"));
+
+    render(<NearbyAroundYou />);
+    await openAPlace();
+    await waitFor(() => expect(screen.getByText("Builder One")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Builder One"));
+    fireEvent.click(await screen.findByRole("button", { name: /^shortlist$/i }));
+
+    await waitFor(() => expect(mockShortlist).toHaveBeenCalledTimes(1));
+    const close = screen.queryByRole("button", { name: /close detail panel/i });
+    if (close) fireEvent.click(close);
+    expect(screen.queryAllByLabelText("Shortlisted")).toHaveLength(0);
+    expect(
+      within(shortlistedProspectsSection()!).queryByText("Builder One"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("removing a saved prospect clears the star on its visible search result", async () => {
+    mockListShortlist.mockResolvedValue([
+      {
+        id: "shortlist-b1",
+        target_key: "nws:b1",
+        status: "shortlisted",
+        profile: {
+          displayName: "Builder One",
+          headline: "CEO",
+          organization: "Monolithic Power Systems",
+        },
+        updated_at: "2026-08-27T00:00:00.000Z",
+      },
+    ]);
+    mockShortlist.mockResolvedValue({
+      id: "shortlist-b1",
+      target_key: "nws:b1",
+      status: "passed",
+      profile: {},
+      updated_at: "2026-08-27T00:00:00.000Z",
+    });
+
+    render(<NearbyAroundYou />);
+    await openAPlace();
+    await waitFor(() => expect(screen.getByLabelText("Shortlisted")).toBeInTheDocument());
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove builder one from shortlisted prospects/i }),
+    );
+
+    await waitFor(() => expect(screen.queryAllByLabelText("Shortlisted")).toHaveLength(0));
+    expect(mockShortlist).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "pass",
+        record: expect.objectContaining({ personId: "b1" }),
+      }),
+    );
+  });
+
+  it("restores a saved prospect when removal fails", async () => {
+    mockListShortlist.mockResolvedValue([
+      {
+        id: "shortlist-b1",
+        target_key: "nws:b1",
+        status: "shortlisted",
+        profile: {
+          displayName: "Builder One",
+          headline: "CEO",
+          organization: "Monolithic Power Systems",
+        },
+        updated_at: "2026-08-27T00:00:00.000Z",
+      },
+    ]);
+    mockShortlist.mockRejectedValue(new Error("offline"));
+
+    render(<NearbyAroundYou />);
+    await openAPlace();
+    await waitFor(() => expect(screen.getByLabelText("Shortlisted")).toBeInTheDocument());
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove builder one from shortlisted prospects/i }),
+    );
+
+    await waitFor(() =>
+      expect(
+        within(shortlistedProspectsSection()!).getByText("Builder One"),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByLabelText("Shortlisted")).toBeInTheDocument();
+  });
+
   it("shows a ranked few rather than everything the service returned", async () => {
     render(<NearbyAroundYou />);
     await openAPlace();

--- a/hushh-webapp/__tests__/services/nws-nearby-service.test.ts
+++ b/hushh-webapp/__tests__/services/nws-nearby-service.test.ts
@@ -250,6 +250,34 @@ describe("NwsNearbyService.shortlist", () => {
   });
 });
 
+describe("NwsNearbyService.listShortlist", () => {
+  it("reads the advisor's persisted NWS shortlist", async () => {
+    mockApiFetch.mockResolvedValue(
+      jsonResponse({
+        items: [
+          {
+            id: "shortlist-1",
+            target_key: "nws:bootstrap_michael_hsing",
+            status: "shortlisted",
+            profile: { displayName: "Michael R. Hsing" },
+            updated_at: "2026-08-27T00:00:00.000Z",
+          },
+        ],
+      }),
+    );
+
+    const entries = await NwsNearbyService.listShortlist({ idToken: "t" });
+
+    expect(requestedUrl()).toBe("/api/ria/nearby/shortlist");
+    expect((mockApiFetch.mock.calls[0][1] as RequestInit).method).toBe("GET");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      target_key: "nws:bootstrap_michael_hsing",
+      status: "shortlisted",
+    });
+  });
+});
+
 describe("filter helpers", () => {
   it("counts every lane, including the ones with nothing in them", () => {
     const counts = laneCounts([

--- a/hushh-webapp/components/ria/nearby/nearby-around-you.tsx
+++ b/hushh-webapp/components/ria/nearby/nearby-around-you.tsx
@@ -15,7 +15,8 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { MapPin, Star, UserRound } from "lucide-react";
+import type { ReactNode } from "react";
+import { MapPin, Star, Trash2, UserRound } from "lucide-react";
 
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { NearbyFilterBar } from "@/components/ria/nearby/nearby-filters";
@@ -37,6 +38,7 @@ import {
   type NearbyDiscoverResult,
   type NearbyFilters,
   type NearbyRecord,
+  type NearbyShortlistEntry,
 } from "@/lib/services/nws-nearby-service";
 import { cn } from "@/lib/utils";
 
@@ -63,6 +65,64 @@ const COVERAGE_COPY: Record<string, string> = {
  */
 const NATIONAL_MARKET_ID = "us-national-public-association";
 
+function personIdFromShortlist(entry: NearbyShortlistEntry): string {
+  return entry.target_key.replace(/^nws:/, "");
+}
+
+function profileText(
+  profile: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = profile[key];
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function profileNumber(
+  profile: Record<string, unknown>,
+  key: string,
+): number | null {
+  const value = profile[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function recordFromShortlistEntry(entry: NearbyShortlistEntry): NearbyRecord {
+  const profile = entry.profile ?? {};
+  const personId = personIdFromShortlist(entry);
+  return {
+    rank: null,
+    personId,
+    displayName: profileText(profile, "displayName"),
+    headline: profileText(profile, "headline"),
+    organization: profileText(profile, "organization"),
+    lane: null,
+    globalNws: profileNumber(profile, "globalNws"),
+    nearbyRankScore: profileNumber(profile, "nearbyRankScore"),
+    scoreStatus: null,
+    scoreKind: null,
+    rankingBasis: null,
+    confidence: {
+      score: null,
+      grade: null,
+    },
+    publicLocation: {
+      label: profileText(profile, "locationLabel"),
+      associationKind: null,
+      granularity: null,
+      distanceBand: null,
+      note: null,
+    },
+    scoreBreakdown: null,
+    reasons: [],
+    warnings: [],
+    tags: [],
+    revalidationRequired: false,
+    evidence: null,
+    associationContext: null,
+    sources: [],
+    modelVersion: profileText(profile, "modelVersion"),
+  };
+}
+
 export function NearbyAroundYou() {
   const { user } = useAuth();
   const location = useCurrentLocation();
@@ -74,6 +134,8 @@ export function NearbyAroundYou() {
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<NearbyRecord | null>(null);
   const [shortlisted, setShortlisted] = useState<Set<string>>(new Set());
+  const [shortlistEntries, setShortlistEntries] = useState<NearbyShortlistEntry[]>([]);
+  const [shortlistLoading, setShortlistLoading] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
@@ -148,18 +210,17 @@ export function NearbyAroundYou() {
     void (async () => {
       const idToken = await user?.getIdToken();
       if (!idToken) return;
+      setShortlistLoading(true);
       try {
         const entries = await NwsNearbyService.listShortlist({ idToken });
         if (cancelled) return;
-        setShortlisted(
-          new Set(
-            entries
-              .filter((e) => e.status === "shortlisted")
-              .map((e) => e.target_key.replace(/^nws:/, "")),
-          ),
-        );
+        const activeEntries = entries.filter((e) => e.status === "shortlisted");
+        setShortlistEntries(activeEntries);
+        setShortlisted(new Set(activeEntries.map(personIdFromShortlist)));
       } catch {
         // A shortlist that will not load must not block discovery.
+      } finally {
+        if (!cancelled) setShortlistLoading(false);
       }
     })();
     return () => {
@@ -203,10 +264,15 @@ export function NearbyAroundYou() {
         return next;
       });
       try {
-        await NwsNearbyService.shortlist({
+        const entry = await NwsNearbyService.shortlist({
           idToken,
           record,
           action: already ? "pass" : "shortlist",
+        });
+        setShortlistEntries((current) => {
+          const personId = record.personId;
+          const withoutRecord = current.filter((item) => personIdFromShortlist(item) !== personId);
+          return already || entry.status !== "shortlisted" ? withoutRecord : [entry, ...withoutRecord];
         });
       } catch {
         setShortlisted((current) => {
@@ -218,6 +284,35 @@ export function NearbyAroundYou() {
       }
     },
     [shortlisted, user],
+  );
+
+  const handleRemoveShortlistEntry = useCallback(
+    async (entry: NearbyShortlistEntry) => {
+      const idToken = await user?.getIdToken();
+      if (!idToken) return;
+      const record = recordFromShortlistEntry(entry);
+      const personId = record.personId;
+      const previousEntries = shortlistEntries;
+      setShortlistEntries((current) =>
+        current.filter((item) => personIdFromShortlist(item) !== personId),
+      );
+      setShortlisted((current) => {
+        const next = new Set(current);
+        next.delete(personId);
+        return next;
+      });
+      try {
+        await NwsNearbyService.shortlist({ idToken, record, action: "pass" });
+      } catch {
+        setShortlistEntries(previousEntries);
+        setShortlisted((current) => {
+          const next = new Set(current);
+          next.add(personId);
+          return next;
+        });
+      }
+    },
+    [shortlistEntries, user],
   );
 
   const picker = (
@@ -234,30 +329,37 @@ export function NearbyAroundYou() {
   // Nothing chosen yet: one action, one quiet alternative.
   if (!anchor) {
     return (
-      <SettingsGroup>
-        <div className="flex flex-col items-center gap-3 p-8 text-center">
-          <MapPin className="h-5 w-5 text-muted-foreground" aria-hidden />
-          <p className="type-headline">Look around a place</p>
-          <Button
-            type="button"
-            variant="blue-gradient"
-            effect="fill"
-            size="lg"
-            disabled={location.status === "locating"}
-            onClick={() => void location.request()}
-          >
-            Use my location
-          </Button>
-          <button
-            type="button"
-            onClick={() => setPickerOpen(true)}
-            className={cn(MUTED_TEXT, "underline-offset-4 hover:underline")}
-          >
-            Enter a place
-          </button>
-        </div>
+      <SettingsGroupStack>
+        <ShortlistedProspects
+          entries={shortlistEntries}
+          loading={shortlistLoading}
+          onRemove={handleRemoveShortlistEntry}
+        />
+        <SettingsGroup>
+          <div className="flex flex-col items-center gap-3 p-8 text-center">
+            <MapPin className="h-5 w-5 text-muted-foreground" aria-hidden />
+            <p className="type-headline">Look around a place</p>
+            <Button
+              type="button"
+              variant="blue-gradient"
+              effect="fill"
+              size="lg"
+              disabled={location.status === "locating"}
+              onClick={() => void location.request()}
+            >
+              Use my location
+            </Button>
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              className={cn(MUTED_TEXT, "underline-offset-4 hover:underline")}
+            >
+              Enter a place
+            </button>
+          </div>
+        </SettingsGroup>
         {picker}
-      </SettingsGroup>
+      </SettingsGroupStack>
     );
   }
 
@@ -275,6 +377,12 @@ export function NearbyAroundYou() {
 
   return (
     <div className="flex flex-col gap-4">
+      <ShortlistedProspects
+        entries={shortlistEntries}
+        loading={shortlistLoading}
+        onRemove={handleRemoveShortlistEntry}
+      />
+
       <SettingsGroup>
         <div className="flex items-center justify-between gap-3 px-4 py-3">
           <div className="min-w-0">
@@ -408,6 +516,81 @@ export function NearbyAroundYou() {
       />
       {picker}
     </div>
+  );
+}
+
+function SettingsGroupStack({ children }: { children: ReactNode }) {
+  return <div className="flex flex-col gap-4">{children}</div>;
+}
+
+function ShortlistedProspects({
+  entries,
+  loading,
+  onRemove,
+}: {
+  entries: NearbyShortlistEntry[];
+  loading: boolean;
+  onRemove: (entry: NearbyShortlistEntry) => void;
+}) {
+  return (
+    <SettingsGroup
+      separatorInset
+      title="Shortlisted prospects"
+      description={
+        entries.length > 0
+          ? "Prospects saved from public Around You records."
+          : "Star a public record to save it here."
+      }
+    >
+      {loading ? (
+        <div className="flex flex-col gap-2 p-4" aria-busy role="status">
+          {[0, 1].map((row) => (
+            <Skeleton key={row} className="h-14 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : entries.length === 0 ? (
+        <div className="px-4 py-5">
+          <p className={MUTED_TEXT}>No shortlisted prospects yet.</p>
+        </div>
+      ) : (
+        entries.map((entry) => {
+          const profile = entry.profile ?? {};
+          const name = profileText(profile, "displayName") ?? "Public record";
+          const detail = [
+            profileText(profile, "headline"),
+            profileText(profile, "organization"),
+            profileText(profile, "locationLabel"),
+          ]
+            .filter(Boolean)
+            .join(" - ");
+          return (
+            <SettingsRow
+              key={entry.id || entry.target_key}
+              icon={Star}
+              iconTone="orange"
+              density="compact"
+              title={name}
+              description={detail || "Public Around You record"}
+              trailingInteractive
+              stackTrailingOnMobile
+              trailing={
+                <Button
+                  type="button"
+                  variant="none"
+                  effect="fade"
+                  size="sm"
+                  onClick={() => onRemove(entry)}
+                  aria-label={`Remove ${name} from shortlisted prospects`}
+                >
+                  <Trash2 className="mr-2 h-3.5 w-3.5" aria-hidden />
+                  Remove
+                </Button>
+              }
+            />
+          );
+        })
+      )}
+    </SettingsGroup>
   );
 }
 


### PR DESCRIPTION
Closes #6328

Summary:
- show persisted NWS shortlisted prospects in Around You before another location search
- keep search-result star state synchronized with shortlist removal/failure paths
- add focused frontend/service regression coverage

Validation:
- npm.cmd run typecheck
- npm.cmd run verify:design-system
- npm.cmd run verify:docs
- npm.cmd run verify:cache
- targeted ESLint
- targeted RIA clients/Around You tests
- git diff --check