### PR TITLE
fix(one-pkm): share a memory in place instead of opening the Consent Center

### DIFF
--- a/hushh-webapp/__tests__/components/pkm-natural-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/pkm-natural-panel.test.tsx
@@ -103,6 +103,31 @@ function baseMetadata() {
   };
 }
 
+// A domain manifest whose `profile` scope is a materialized, consumer-visible
+// share bundle — the shape buildPkmShareBundles() keeps. `posture` sets whether
+// the scope is currently "ask before sharing" (consent_required) or private.
+function financialManifest(posture: "consent_required" | "private") {
+  return {
+    domain: "financial",
+    manifest_version: 7,
+    scope_registry: [
+      {
+        scope_handle: "financial.profile",
+        scope_label: "Profile",
+        visibility_posture: posture,
+        exposure_enabled: posture !== "private",
+        summary_projection: {
+          top_level_scope_path: "profile",
+          materialization_state: "materialized",
+          materialized_leaf_count: 2,
+          consumer_visible: true,
+          internal_only: false,
+        },
+      },
+    ],
+  };
+}
+
 const FULL_BLOB = {
   financial: {
     profile: { risk_profile: "balanced" },
@@ -432,5 +457,152 @@ describe("PkmNaturalPanel — Memory redesign", () => {
     expect(screen.getByTestId("memory-category-financial")).toBeTruthy();
     expect(screen.queryByText(/no active access/i)).toBeNull();
     expect(screen.queryByText(/shared/i)).toBeNull();
+  });
+
+  // ── Issue #6307: item sharing acts in place, never opens the Consent Center ──
+  describe("memory item sharing — in place, no Consent Center redirect", () => {
+    async function openRiskProfileSharing() {
+      await openMainScreen();
+      fireEvent.click(screen.getByRole("button", { name: "Open memory: Risk Profile" }));
+      await screen.findByRole("heading", { name: "Risk Profile" });
+      fireEvent.click(screen.getByRole("button", { name: "Open sharing settings" }));
+      return screen.findByRole("switch", { name: "Make this memory private" });
+    }
+
+    it("opens sharing on the same memory screen and never routes to /consents", async () => {
+      vi.spyOn(PersonalKnowledgeModelService, "getDomainManifest").mockResolvedValue(
+        financialManifest("consent_required") as never,
+      );
+
+      const toggle = await openRiskProfileSharing();
+
+      // The control is right here, and the memory screen is still mounted.
+      expect(toggle).toBeTruthy();
+      expect(screen.getByRole("heading", { name: "Risk Profile" })).toBeTruthy();
+      // No navigation at all — specifically not to the Consent Center.
+      expect(push).not.toHaveBeenCalled();
+      expect(push).not.toHaveBeenCalledWith(expect.stringContaining("/consent"));
+    });
+
+    it("changes this memory's own scope through the PKM scope-exposure contract", async () => {
+      vi.spyOn(PersonalKnowledgeModelService, "getDomainManifest").mockResolvedValue(
+        financialManifest("consent_required") as never,
+      );
+      const updateScopeExposure = vi
+        .spyOn(PersonalKnowledgeModelService, "updateScopeExposure")
+        .mockResolvedValue({
+          success: true,
+          manifest: financialManifest("private") as never,
+          revokedGrantCount: 1,
+          revokedGrantIds: ["grant_1"],
+        } as never);
+
+      const toggle = await openRiskProfileSharing();
+      fireEvent.click(toggle);
+
+      await waitFor(() => expect(updateScopeExposure).toHaveBeenCalledTimes(1));
+      expect(updateScopeExposure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "reviewer",
+          domain: "financial",
+          expectedManifestVersion: 7,
+          changes: [{ scopeHandle: "financial.profile", visibilityPosture: "private" }],
+        }),
+      );
+      // Grant revocation is left to the backend default — never opted out of here.
+      expect(updateScopeExposure.mock.calls[0][0]).not.toHaveProperty(
+        "revokeMatchingActiveGrants",
+      );
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a redacted error and stays on the memory when the change fails", async () => {
+      vi.spyOn(PersonalKnowledgeModelService, "getDomainManifest").mockResolvedValue(
+        financialManifest("consent_required") as never,
+      );
+      vi.spyOn(PersonalKnowledgeModelService, "updateScopeExposure").mockRejectedValue(
+        new Error("scope_exposure server stack trace"),
+      );
+
+      const toggle = await openRiskProfileSharing();
+      fireEvent.click(toggle);
+
+      expect(
+        await screen.findByText("Sharing choices couldn’t be updated. Refresh and try again."),
+      ).toBeTruthy();
+      // No server detail leaked, no crash, no redirect.
+      expect(screen.queryByText(/server stack trace/)).toBeNull();
+      expect(screen.getByRole("heading", { name: "Risk Profile" })).toBeTruthy();
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    it("re-verifies recipients after revoking sharing so the row drops 'Shared'", async () => {
+      let financialProfileShared = true;
+      vi.spyOn(PersonalKnowledgeModelService, "getMutationSharingImpact").mockImplementation(
+        async ({ domain, scopePath }) => {
+          const shared =
+            domain === "financial" && scopePath === "profile" && financialProfileShared;
+          return {
+            activeRecipientCount: shared ? 1 : 0,
+            recipientLabels: shared ? ["Planner Pro"] : [],
+            entersNextExportRevision: false,
+            summary: "ok",
+            affectedGrantIds: [],
+            affectedExportIds: [],
+          };
+        },
+      );
+      vi.spyOn(PersonalKnowledgeModelService, "getDomainManifest").mockResolvedValue(
+        financialManifest("consent_required") as never,
+      );
+      vi.spyOn(PersonalKnowledgeModelService, "updateScopeExposure").mockImplementation(
+        async () => {
+          // Backend revokes the matching grant; the next impact check must see it.
+          financialProfileShared = false;
+          return {
+            success: true,
+            manifest: financialManifest("private") as never,
+            revokedGrantCount: 1,
+            revokedGrantIds: ["grant_1"],
+          } as never;
+        },
+      );
+
+      await openMainScreen();
+      fireEvent.click(screen.getByRole("button", { name: "Open memory: Risk Profile" }));
+      await screen.findByRole("heading", { name: "Risk Profile" });
+      const meta = screen.getByTestId("memory-detail-meta");
+      await waitFor(() => expect(meta).toHaveTextContent("Shared"));
+
+      fireEvent.click(screen.getByRole("button", { name: "Open sharing settings" }));
+      fireEvent.click(await screen.findByRole("switch", { name: "Make this memory private" }));
+
+      await waitFor(() =>
+        expect(PersonalKnowledgeModelService.updateScopeExposure).toHaveBeenCalled(),
+      );
+      await waitFor(() => expect(meta).toHaveTextContent("Private"));
+      expect(meta).not.toHaveTextContent("Shared");
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    it("fails closed when the scope has no materialized share bundle", async () => {
+      vi.spyOn(PersonalKnowledgeModelService, "getDomainManifest").mockResolvedValue(null);
+      const updateScopeExposure = vi.spyOn(
+        PersonalKnowledgeModelService,
+        "updateScopeExposure",
+      );
+
+      await openMainScreen();
+      fireEvent.click(screen.getByRole("button", { name: "Open memory: Risk Profile" }));
+      await screen.findByRole("heading", { name: "Risk Profile" });
+      fireEvent.click(screen.getByRole("button", { name: "Open sharing settings" }));
+
+      expect(
+        await screen.findByText(/Sharing controls for this memory aren’t available right now/),
+      ).toBeTruthy();
+      expect(screen.queryByRole("switch")).toBeNull();
+      expect(updateScopeExposure).not.toHaveBeenCalled();
+      expect(push).not.toHaveBeenCalled();
+    });
   });
 });

--- a/hushh-webapp/components/profile/pkm-memory-detail.tsx
+++ b/hushh-webapp/components/profile/pkm-memory-detail.tsx
@@ -21,11 +21,20 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { Button } from "@/lib/morphy-ux/morphy";
 import { pkmMemoryRowLabels, type PkmMemoryCard } from "@/lib/pkm/pkm-memory-cards";
 
 export type MemorySharingState = "loading" | "private" | "shared" | "unavailable";
+
+/**
+ * The two real encrypted-PKM sharing postures for a memory's scope. `null` means
+ * the scope's posture could not be resolved (no materialized share bundle, or the
+ * manifest failed to load) — the in-place control then fails closed rather than
+ * guessing.
+ */
+export type MemorySharingPosture = "private" | "consent_required" | null;
 
 function sharingRowValue(state: MemorySharingState): string {
   switch (state) {
@@ -49,29 +58,38 @@ function sharingRowValue(state: MemorySharingState): string {
 export function PkmMemoryDetail({
   card,
   sharingState,
+  sharingPosture,
+  sharingBusy,
+  sharingError,
   canMutate,
   saving,
   deleting,
   actionError,
   onBack,
-  onOpenSharing,
+  onSharingChange,
+  onSharingOpenChange,
   onSave,
   onForget,
 }: {
   card: PkmMemoryCard;
   sharingState: MemorySharingState;
+  sharingPosture: MemorySharingPosture;
+  sharingBusy: boolean;
+  sharingError: string | null;
   canMutate: boolean;
   saving: boolean;
   deleting: boolean;
   actionError: string | null;
   onBack: () => void;
-  onOpenSharing: () => void;
+  onSharingChange: (nextPosture: "private" | "consent_required") => void;
+  onSharingOpenChange?: (open: boolean) => void;
   onSave: (nextValue: string) => void;
   onForget: () => void;
 }) {
   const { primary, secondary } = pkmMemoryRowLabels(card);
   const [editOpen, setEditOpen] = useState(false);
   const [forgetOpen, setForgetOpen] = useState(false);
+  const [sharingOpen, setSharingOpen] = useState(false);
   const [editValue, setEditValue] = useState(card.value);
   const busy = saving || deleting;
 
@@ -82,6 +100,17 @@ export function PkmMemoryDetail({
   useEffect(() => {
     setEditValue(card.value);
   }, [card.id, card.value]);
+
+  // A new memory starts with its own sharing sheet closed.
+  useEffect(() => {
+    setSharingOpen(false);
+  }, [card.id]);
+
+  function changeSharingOpen(open: boolean) {
+    if (sharingBusy) return;
+    setSharingOpen(open);
+    onSharingOpenChange?.(open);
+  }
 
   return (
     <div className="space-y-7" data-pkm-detail-panel="true" data-pkm-memory-detail="true">
@@ -106,7 +135,7 @@ export function PkmMemoryDetail({
       <SettingsGroup separatorInset testId="memory-detail-meta">
         <SettingsRow
           title="Sharing"
-          onClick={onOpenSharing}
+          onClick={() => changeSharingOpen(true)}
           ariaLabel="Open sharing settings"
           trailing={
             <span className="flex items-center gap-1 text-[15px] text-muted-foreground">
@@ -187,6 +216,67 @@ export function PkmMemoryDetail({
             >
               {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden /> : null}
               Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={sharingOpen} onOpenChange={changeSharingOpen}>
+        <DialogContent
+          showCloseButton={false}
+          className="gap-4 sm:max-w-[380px]"
+          data-pkm-memory-sharing-sheet="true"
+        >
+          <DialogHeader>
+            <DialogTitle>Sharing</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm font-medium text-foreground">{primary}</p>
+
+          {sharingPosture === null ? (
+            <p className="text-sm text-muted-foreground">
+              Sharing controls for this memory aren’t available right now. Refresh and try again.
+            </p>
+          ) : (
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-foreground">Ask before sharing</p>
+                <p className="text-sm text-muted-foreground">
+                  {sharingPosture === "consent_required"
+                    ? "One asks for your approval before sharing this with anyone."
+                    : "This stays private. One never offers it, even when someone asks."}
+                </p>
+              </div>
+              <Switch
+                checked={sharingPosture === "consent_required"}
+                disabled={sharingBusy}
+                onCheckedChange={(enabled) =>
+                  onSharingChange(enabled ? "consent_required" : "private")
+                }
+                aria-label={
+                  sharingPosture === "consent_required"
+                    ? "Make this memory private"
+                    : "Ask before sharing this memory"
+                }
+              />
+            </div>
+          )}
+
+          {sharingBusy ? (
+            <p className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Updating sharing choices…
+            </p>
+          ) : null}
+          {sharingError ? <p className="text-sm text-destructive">{sharingError}</p> : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              effect="fade"
+              disabled={sharingBusy}
+              onClick={() => changeSharingOpen(false)}
+            >
+              Done
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/hushh-webapp/components/profile/pkm-natural-panel.tsx
+++ b/hushh-webapp/components/profile/pkm-natural-panel.tsx
@@ -2,12 +2,12 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Loader2, Lock, ShieldAlert } from "lucide-react";
-import { useRouter } from "next/navigation";
 
 import { PkmMemoryRow } from "@/components/profile/pkm-memory-row";
 import { PkmMemoryLevel } from "@/components/profile/pkm-memory-level";
 import {
   PkmMemoryDetail,
+  type MemorySharingPosture,
   type MemorySharingState,
 } from "@/components/profile/pkm-memory-detail";
 import { SettingsGroup, SettingsRow, SettingsSegmentedTabs } from "@/components/app-ui/settings-ui";
@@ -24,7 +24,6 @@ import {
   buildPkmDomainPresentation,
   isConsumerBrowsablePkmDomain,
 } from "@/lib/profile/pkm-profile-presentation";
-import { ROUTES } from "@/lib/navigation/routes";
 import {
   addToPKM,
   clearAgentPkmContext,
@@ -101,7 +100,6 @@ export function PkmNaturalPanel({
   refreshToken?: number;
   onOpenExplorer?: () => void;
 } = {}) {
-  const router = useRouter();
   const { user, loading: authLoading } = useAuth();
   const { isVaultUnlocked, vaultKey, vaultOwnerToken } = useVault();
   const pkmChangeRevision = usePkmDomainChangeRevision(user?.uid);
@@ -140,6 +138,9 @@ export function PkmNaturalPanel({
   const [sharingManifests, setSharingManifests] = useState<Record<string, DomainManifest | null>>({});
   const [sharingManifestsLoading, setSharingManifestsLoading] = useState(false);
   const [sharingActionKey, setSharingActionKey] = useState<string | null>(null);
+  const [selectedCardManifest, setSelectedCardManifest] = useState<DomainManifest | null>(null);
+  const [memorySharingActionId, setMemorySharingActionId] = useState<string | null>(null);
+  const [memorySharingError, setMemorySharingError] = useState<string | null>(null);
   const [homeSearchQuery, setHomeSearchQuery] = useState("");
   const [memoryCards, setMemoryCards] = useState<PkmMemoryCard[]>([]);
   const [memoryCardsLoading, setMemoryCardsLoading] = useState(false);
@@ -560,6 +561,31 @@ export function PkmNaturalPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedCard?.id]);
 
+  // A memory opened straight from search or "Recently learned" has no selected
+  // category, so its domain manifest — the source of the per-scope share bundle
+  // and the manifest version the backend checks — is loaded here on demand.
+  useEffect(() => {
+    let cancelled = false;
+    if (!selectedCard || !user || !vaultOwnerToken) {
+      setSelectedCardManifest(null);
+      return undefined;
+    }
+    void PersonalKnowledgeModelService.getDomainManifest(
+      user.uid,
+      selectedCard.domain,
+      vaultOwnerToken,
+    )
+      .then((manifest) => {
+        if (!cancelled) setSelectedCardManifest(manifest);
+      })
+      .catch(() => {
+        if (!cancelled) setSelectedCardManifest(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pkmChangeRevision, refreshNonce, selectedCard, user, vaultOwnerToken]);
+
   async function persistMemoryCardChange(params: {
     card: PkmMemoryCard;
     action: "edited" | "deleted";
@@ -797,6 +823,89 @@ export function PkmNaturalPanel({
     return "loading";
   }
 
+  // The share bundle for this memory's own top-level scope, resolved from the
+  // domain manifest. Reuses the same PKM sharing contract the Sharing tab uses.
+  function memoryScopeShareBundle(card: PkmMemoryCard) {
+    const scopePath = cardScopePath(card);
+    return (
+      buildPkmShareBundles(selectedCardManifest).find(
+        (bundle) => bundle.topLevelScopePath === scopePath,
+      ) || null
+    );
+  }
+
+  function memorySharingPosture(card: PkmMemoryCard): MemorySharingPosture {
+    const bundle = memoryScopeShareBundle(card);
+    if (!bundle || !bundle.scopeHandle) return null;
+    return bundle.enabled ? "consent_required" : "private";
+  }
+
+  // In-place per-memory sharing. Stays on the memory screen — no redirect to the
+  // Consent Center — and drives the same scope-exposure endpoint as the Sharing
+  // tab, so grant revocation on turning a scope private is handled server-side.
+  async function updateMemoryScopeSharing(
+    card: PkmMemoryCard,
+    nextPosture: "private" | "consent_required",
+  ) {
+    if (!user || !vaultOwnerToken) return;
+    const manifest = selectedCardManifest;
+    const bundle = memoryScopeShareBundle(card);
+    if (!manifest || !bundle?.scopeHandle) {
+      setMemorySharingError(
+        "Sharing controls for this memory aren’t available right now. Refresh and try again.",
+      );
+      return;
+    }
+    setMemorySharingActionId(cardImpactKey(card));
+    setMemorySharingError(null);
+    try {
+      const operation = PersonalKnowledgeModelService.updateScopeExposure({
+        userId: user.uid,
+        domain: card.domain,
+        expectedManifestVersion: manifest.manifest_version,
+        vaultOwnerToken,
+        changes: [{ scopeHandle: bundle.scopeHandle, visibilityPosture: nextPosture }],
+      });
+      void morphyToast.promise(operation, {
+        loading: "Updating sharing choices…",
+        success:
+          nextPosture === "consent_required"
+            ? "One will ask before sharing this."
+            : "This is private again.",
+        error: "Sharing choices changed elsewhere. Refresh and try again.",
+      });
+      const result = await operation;
+      if (result.manifest) setSelectedCardManifest(result.manifest);
+      // Turning a scope private revokes matching active grants server-side, so
+      // re-verify this memory's recipients instead of trusting a stale "Shared".
+      try {
+        const impact = await PersonalKnowledgeModelService.getMutationSharingImpact({
+          userId: user.uid,
+          domain: card.domain,
+          scopePath: cardScopePath(card),
+          vaultOwnerToken,
+        });
+        setSharingImpacts((current) => ({ ...current, [cardImpactKey(card)]: impact }));
+      } catch {
+        setSharingImpacts((current) => {
+          const next = { ...current };
+          delete next[cardImpactKey(card)];
+          return next;
+        });
+        setSharingImpactError(
+          "Current sharing couldn’t be verified. Refresh before changing details.",
+        );
+      }
+      setRefreshNonce((value) => value + 1);
+    } catch {
+      setMemorySharingError(
+        "Sharing choices couldn’t be updated. Refresh and try again.",
+      );
+    } finally {
+      setMemorySharingActionId(null);
+    }
+  }
+
   const trimmedQuery = homeSearchQuery.trim();
   const searchResults = trimmedQuery
     ? selectRelevantPkmMemoryCards(browsableCards, homeSearchQuery, 24)
@@ -880,6 +989,9 @@ export function PkmNaturalPanel({
         <PkmMemoryDetail
           card={selectedCard}
           sharingState={memorySharingState(selectedCard)}
+          sharingPosture={memorySharingPosture(selectedCard)}
+          sharingBusy={memorySharingActionId === cardImpactKey(selectedCard)}
+          sharingError={memorySharingError}
           canMutate={Boolean(sharingImpacts[cardImpactKey(selectedCard)])}
           saving={memoryActionId === `${selectedCard.id}:edited`}
           deleting={memoryActionId === `${selectedCard.id}:deleted`}
@@ -887,8 +999,14 @@ export function PkmNaturalPanel({
           onBack={() => {
             setSelectedCard(null);
             setMemoryActionError(null);
+            setMemorySharingError(null);
           }}
-          onOpenSharing={() => router.push(ROUTES.CONSENTS)}
+          onSharingChange={(nextPosture) =>
+            void updateMemoryScopeSharing(selectedCard, nextPosture)
+          }
+          onSharingOpenChange={(open) => {
+            if (!open) setMemorySharingError(null);
+          }}
           onSave={(nextValue) =>
             void persistMemoryCardChange({ card: selectedCard, action: "edited", nextValue })
           }


### PR DESCRIPTION
## Problem

In Memory, opening a specific memory and tapping **Sharing** redirected to the Consent Center (`/one/consent`), pulling the user off the memory they were looking at. (#6307)

## Fix

The **Sharing** row now opens an in-place dialog on the same memory screen.

- Reuses the existing PKM sharing contract: `PersonalKnowledgeModelService.updateScopeExposure` against this memory's own top-level scope, resolved from the domain manifest with the same `buildPkmShareBundles()` bundles the Sharing tab already uses. No new backend behavior, no duplicated consent logic.
- Offers only the two real postures — **private** and **ask before sharing** (`consent_required`).
- Turning a scope private still revokes matching active grants server-side — the `revoke_matching_active_grants` default on the endpoint is left untouched — and the detail row re-verifies recipients via `getMutationSharingImpact` afterwards rather than showing a stale "Shared".
- Fails closed: no materialized share bundle / manifest load failure → the dialog shows an unavailable message and never calls the backend.
- Update failures are redacted and keep the user on the memory screen.

## Tests

New regression block in `hushh-webapp/__tests__/components/pkm-natural-panel.test.tsx`:

- sharing opens in place and never routes to `/consents` (`router.push` not called)
- toggling calls `updateScopeExposure` with the correct `domain` + `scopeHandle` + `visibilityPosture`, and never opts out of grant revocation
- a failed update surfaces a redacted error, no crash, no redirect
- after revoking, the row re-verifies and drops "Shared"
- fails closed when the scope has no materialized share bundle

`vitest` (17/17 in that file), `tsc --noEmit`, and `eslint` on the changed files all pass.

Closes #6307