### PR TITLE
fix(gmail): remove duplicate connected text, standardize currency display, fix floating bar overlap and shopping summary spacing

### DIFF
--- a/hushh-webapp/components/gmail/gmail-receipts-page.tsx
+++ b/hushh-webapp/components/gmail/gmail-receipts-page.tsx
@@ -110,15 +110,16 @@ function formatAmount(
   amount?: number | null,
 ): string {
   if (typeof amount !== "number" || Number.isNaN(amount)) return "—";
-  const normalized = (currency || "USD").toUpperCase();
+  const normalized = (currency || "USD").trim().toUpperCase();
   try {
-    return new Intl.NumberFormat(undefined, {
+    return new Intl.NumberFormat("en-US", {
       style: "currency",
       currency: normalized,
+      minimumFractionDigits: 2,
       maximumFractionDigits: 2,
     }).format(amount);
   } catch {
-    return `${normalized} ${amount.toFixed(2)}`;
+    return `${amount.toFixed(2)} ${normalized}`;
   }
 }
 
@@ -1433,7 +1434,7 @@ export default function GmailReceiptsPage({
     <AppPageShell
       as="div"
       width="reading"
-      className="pb-[calc(var(--app-bottom-fixed-ui,96px)+1.25rem)] sm:pb-10 md:pb-8"
+      className="pb-[calc(var(--app-bottom-fixed-ui,96px)+1.5rem)]"
       nativeTest={
         journeyVariant === "workspace"
           ? {
@@ -1536,9 +1537,13 @@ export default function GmailReceiptsPage({
                   <h2 className="text-lg font-semibold tracking-tight text-foreground">
                     {statusSummary.title}
                   </h2>
-                  <p className="break-words text-sm text-muted-foreground">
-                    {statusSummary.detail}
-                  </p>
+                  {statusSummary.detail &&
+                  (!isConnected ||
+                    !statusSummary.detail.startsWith("Connected to")) ? (
+                    <p className="break-words text-sm text-muted-foreground">
+                      {statusSummary.detail}
+                    </p>
+                  ) : null}
                   {statusSummary.helper ? (
                     <p className="break-words text-xs text-muted-foreground">
                       {statusSummary.helper}
@@ -1676,8 +1681,8 @@ export default function GmailReceiptsPage({
           ) : null}
 
           {isConnected ? (
-            <SurfaceInset className="space-y-3 px-4 py-4 text-sm sm:px-5 sm:py-5">
-              <div className="space-y-1">
+            <SurfaceInset className="space-y-4 px-4 py-4.5 text-sm sm:px-5 sm:py-5.5">
+              <div className="space-y-1.5">
                 <p className="font-medium text-foreground">Shopping summary</p>
                 <p className="text-muted-foreground">
                   Generated from your synced receipts. You choose when to save
@@ -1686,15 +1691,15 @@ export default function GmailReceiptsPage({
               </div>
 
               {receiptMemoryLoading && !receiptMemoryArtifact ? (
-                <div className="flex items-center gap-2 rounded-xl border border-border/60 bg-background/60 px-3 py-3 text-muted-foreground">
+                <div className="flex items-center gap-2.5 rounded-xl border border-border/60 bg-background/60 px-3.5 py-3.5 text-muted-foreground">
                   <Loader2 className="h-4 w-4 animate-spin" />
                   Creating your shopping summary…
                 </div>
               ) : null}
 
               {receiptMemoryArtifact ? (
-                <div className="space-y-3 rounded-xl border border-border/60 bg-background/60 p-3">
-                  <div className="flex flex-wrap items-center gap-2">
+                <div className="space-y-4 rounded-xl border border-border/60 bg-background/60 p-4 sm:p-4.5">
+                  <div className="flex flex-wrap items-center gap-2.5">
                     <Badge variant="secondary">
                       {receiptMemoryArtifact.freshness.is_stale
                         ? "Needs refresh"
@@ -1719,7 +1724,7 @@ export default function GmailReceiptsPage({
                     <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
                       Shopping summary
                     </p>
-                    <p className="min-h-[96px] whitespace-pre-wrap rounded-xl border border-border/70 bg-background px-3 py-3 text-sm leading-6 text-foreground">
+                    <p className="min-h-[96px] whitespace-pre-wrap rounded-xl border border-border/70 bg-background px-3.5 py-3.5 text-sm leading-6 text-foreground">
                       {
                         receiptMemoryArtifact.candidate_pkm_payload
                           .receipts_memory.readable_summary.text
@@ -1729,7 +1734,7 @@ export default function GmailReceiptsPage({
 
                   {receiptMemoryArtifact.candidate_pkm_payload.receipts_memory
                     .readable_summary.highlights.length > 0 ? (
-                    <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                    <div className="flex flex-wrap gap-2.5 pt-0.5 text-xs text-muted-foreground">
                       {receiptMemoryArtifact.candidate_pkm_payload.receipts_memory.readable_summary.highlights.map(
                         (item) => (
                           <Badge key={item} variant="outline">


### PR DESCRIPTION
## Summary

Applies 4 isolated, non-structural UI polish fixes to the Gmail agent page (`/one/gmail`):

1. **Remove Duplicate Connected Text**: Suppressed the redundant `"Connected to [email]"` line inside the Status card while keeping it in the page header description.
2. **Standardize Currency Display**: Updated `formatAmount` to format amounts with explicit `"en-US"` locale (`$1.00`, `₹588.82`, `€42.50`, `£15.99`) so every row shows a standard currency symbol without duplicate currency code suffixes. Preserved `"—"` for rows missing amount data.
3. **Fix Floating Bar Overlap Clearance**: Set `AppPageShell` bottom clearance to `pb-[calc(var(--app-bottom-fixed-ui,96px)+1.5rem)]` (matching the design system token `--app-page-content-bottom-gap` of 24px) so 100% of card content is visible above the fixed bottom bar across all breakpoints.
4. **Shopping Summary Card Spacing**: Added breathing room between status badges, summary text paragraph, fact-chips, and action buttons (`space-y-4`, `p-4 sm:p-4.5`, `gap-2.5`).

## Files Changed

- `hushh-webapp/components/gmail/gmail-receipts-page.tsx` (1 file only)

## Verification & Testing

- `npx tsc --noEmit` passed with 0 errors.
- Verified runtime currency formatting output: `USD` → `$1.00`, `INR` → `₹588.82`, `EUR` → `€42.50`, `GBP` → `£15.99`, `null` → `—`.
- Verified desktop bottom scroll clearance: last card sits 24px above fixed bottom bar with zero overlap.