### PR TITLE
[Bug]: Deduplicate and clarify SEC evidence links in RIA Marketplace

### DIFF
--- a/hushh-webapp/__tests__/app/marketplace/page-card-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/app/marketplace/page-card-layout.contract.test.ts
@@ -60,4 +60,15 @@ describe("marketplace client card layout contract", () => {
     expect(source).toContain("aria-busy={contactMatchLoading}");
     expect(source).not.toContain('aria-label={directoryKind === "investors" ? "Refresh deck" : "Restart deck"}');
   });
+
+  it("renders marketplace SEC evidence links with normalized labels", () => {
+    const source = readMarketplacePage();
+
+    expect(source).toContain("marketplaceInvestorEvidenceLinks(selectedInvestorEvidence)");
+    expect(source).toContain("key={source.id}");
+    expect(source).toContain("href={source.url}");
+    expect(source).toContain("{source.label}");
+    expect(source).toContain("aria-label={`${source.label} opens in a new tab`}");
+    expect(source).not.toContain("SEC source");
+  });
 });

--- a/hushh-webapp/__tests__/lib/marketplace/investor-evidence-links.test.ts
+++ b/hushh-webapp/__tests__/lib/marketplace/investor-evidence-links.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import { marketplaceInvestorEvidenceLinks } from "@/lib/marketplace/investor-discovery";
+import type { MarketplaceInvestor } from "@/lib/services/ria-service";
+
+function evidence(
+  overrides: NonNullable<MarketplaceInvestor["evidence"]>
+): NonNullable<MarketplaceInvestor["evidence"]> {
+  return overrides;
+}
+
+describe("marketplaceInvestorEvidenceLinks", () => {
+  it("labels distinct SEC evidence surfaces without generic duplicate-looking text", () => {
+    const links = marketplaceInvestorEvidenceLinks(
+      evidence({
+        source_urls: [
+          "https://data.sec.gov/submissions/CIK0000123456.json",
+          "https://www.sec.gov/edgar/browse/?CIK=0000123456",
+          "https://www.sec.gov/Archives/edgar/data/123456/000012345626000001/xslForm13F_X02/primary_doc.xml",
+        ],
+        forms: [{ form: "13F", last_filed_at: "2026-03-31" }],
+      })
+    );
+
+    expect(links).toEqual([
+      {
+        id: "url:https://data.sec.gov/submissions/CIK0000123456.json",
+        label: "SEC submissions - CIK 0000123456",
+        url: "https://data.sec.gov/submissions/CIK0000123456.json",
+      },
+      {
+        id: "url:https://www.sec.gov/edgar/browse/?CIK=0000123456",
+        label: "SEC company page - CIK 0000123456",
+        url: "https://www.sec.gov/edgar/browse/?CIK=0000123456",
+      },
+      {
+        id: "sec-accession:0000123456-26-000001",
+        label: "SEC Form 13F - 0000123456-26-000001",
+        url: "https://www.sec.gov/Archives/edgar/data/123456/000012345626000001/xslForm13F_X02/primary_doc.xml",
+      },
+    ]);
+  });
+
+  it("deduplicates exact repeated source URLs by stable URL identity", () => {
+    const links = marketplaceInvestorEvidenceLinks(
+      evidence({
+        source_urls: [
+          "https://data.sec.gov/submissions/CIK0000123456.json",
+          "https://data.sec.gov/submissions/CIK0000123456.json",
+        ],
+      })
+    );
+
+    expect(links).toHaveLength(1);
+    expect(links[0]?.label).toBe("SEC submissions - CIK 0000123456");
+  });
+
+  it("deduplicates SEC filing URLs that point to the same accession", () => {
+    const links = marketplaceInvestorEvidenceLinks(
+      evidence({
+        source_urls: [
+          "https://www.sec.gov/Archives/edgar/data/123456/000012345626000001/primary_doc.xml",
+          "https://www.sec.gov/Archives/edgar/data/123456/0000123456-26-000001-index.html",
+        ],
+        forms: [{ form: "13F", last_filed_at: "2026-03-31" }],
+      })
+    );
+
+    expect(links).toHaveLength(1);
+    expect(links[0]?.id).toBe("sec-accession:0000123456-26-000001");
+    expect(links[0]?.label).toBe("SEC Form 13F - 0000123456-26-000001");
+  });
+
+  it("keeps multiple distinct SEC filings visible with unique accession labels", () => {
+    const links = marketplaceInvestorEvidenceLinks(
+      evidence({
+        source_urls: [
+          "https://www.sec.gov/Archives/edgar/data/123456/000012345626000001/primary_doc.xml",
+          "https://www.sec.gov/Archives/edgar/data/123456/000012345626000002/primary_doc.xml",
+        ],
+        forms: [{ form: "13F", last_filed_at: "2026-03-31" }],
+      })
+    );
+
+    expect(links.map((link) => link.label)).toEqual([
+      "SEC Form 13F - 0000123456-26-000001",
+      "SEC Form 13F - 0000123456-26-000002",
+    ]);
+  });
+
+  it("falls back to numbered filing labels only when no SEC metadata can identify the URL", () => {
+    const links = marketplaceInvestorEvidenceLinks(
+      evidence({
+        source_urls: [
+          "https://example.com/a",
+          "https://example.com/b",
+        ],
+      })
+    );
+
+    expect(links.map((link) => link.label)).toEqual([
+      "SEC filing 1",
+      "SEC filing 2",
+    ]);
+  });
+});

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -35,6 +35,7 @@ import {
   isMarketplaceInvestorConnectable,
   isMarketplaceInvestorShortlistable,
   isPublicSecMarketplaceInvestor,
+  marketplaceInvestorEvidenceLinks,
   marketplaceInvestorActionTarget,
   marketplaceInvestorCardId,
   marketplaceInvestorCurationLabel,
@@ -797,11 +798,8 @@ export default function MarketplacePage() {
   const selectedInvestorAddress = formatEvidenceAddress(
     selectedInvestorEvidence?.business_address
   );
-  const selectedInvestorEvidenceLinks = Array.isArray(selectedInvestorEvidence?.source_urls)
-    ? selectedInvestorEvidence.source_urls
-        .filter((url): url is string => Boolean(url))
-        .slice(0, 3)
-    : [];
+  const selectedInvestorEvidenceLinks =
+    marketplaceInvestorEvidenceLinks(selectedInvestorEvidence);
   const selectedInvestorFormsLabel = formatEvidenceForms(selectedInvestorEvidence?.forms);
   const selectedInvestorCurationLabel = selectedInvestor
     ? marketplaceInvestorCurationLabel(selectedInvestor)
@@ -1706,10 +1704,15 @@ export default function MarketplacePage() {
                 ) : null}
                 {selectedInvestorEvidenceLinks.length > 0 ? (
                   <div className="flex flex-wrap gap-2">
-                    {selectedInvestorEvidenceLinks.map((url) => (
-                      <Button key={url} asChild variant="none" effect="fade" size="sm">
-                        <a href={url} target="_blank" rel="noopener noreferrer">
-                          SEC source
+                    {selectedInvestorEvidenceLinks.map((source) => (
+                      <Button key={source.id} asChild variant="none" effect="fade" size="sm">
+                        <a
+                          href={source.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label={`${source.label} opens in a new tab`}
+                        >
+                          {source.label}
                           <ArrowUpRight className="ml-2 h-4 w-4" />
                         </a>
                       </Button>

--- a/hushh-webapp/lib/marketplace/investor-discovery.ts
+++ b/hushh-webapp/lib/marketplace/investor-discovery.ts
@@ -1,5 +1,11 @@
 import type { MarketplaceInvestor } from "@/lib/services/ria-service";
 
+export type MarketplaceEvidenceLink = {
+  id: string;
+  label: string;
+  url: string;
+};
+
 export function marketplaceInvestorCardId(investor: MarketplaceInvestor): string {
   const explicitId = String(investor.id || "").trim();
   if (explicitId) return explicitId;
@@ -81,4 +87,135 @@ export function marketplaceInvestorCurationLabel(investor: MarketplaceInvestor):
   if (tier === "showcase") return "Showcase";
   if (tier === "qualified") return "Qualified";
   return null;
+}
+
+const SEC_ACCESSION_PATTERN = /\b\d{10}-\d{2}-\d{6}\b/;
+const SEC_ACCESSION_COMPACT_PATTERN = /\b\d{18}\b/;
+
+function compactAccessionToDashed(value: string): string {
+  return `${value.slice(0, 10)}-${value.slice(10, 12)}-${value.slice(12)}`;
+}
+
+function normalizeSecAccession(value: unknown): string | null {
+  const text = String(value || "").trim();
+  if (!text) return null;
+
+  const dashed = text.match(SEC_ACCESSION_PATTERN)?.[0];
+  if (dashed) return dashed;
+
+  const compact = text.match(SEC_ACCESSION_COMPACT_PATTERN)?.[0];
+  return compact ? compactAccessionToDashed(compact) : null;
+}
+
+function normalizeEvidenceUrl(value: unknown): string | null {
+  const rawUrl = String(value || "").trim();
+  if (!rawUrl) return null;
+
+  try {
+    const parsed = new URL(rawUrl);
+    parsed.hash = "";
+    parsed.hostname = parsed.hostname.toLowerCase();
+    parsed.searchParams.sort();
+    return parsed.toString();
+  } catch {
+    return rawUrl;
+  }
+}
+
+function evidenceUrlParts(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+function evidenceCikFromUrl(parsed: URL | null): string | null {
+  if (!parsed) return null;
+
+  const queryCik = parsed.searchParams.get("CIK");
+  if (queryCik) return queryCik.trim() || null;
+
+  const pathCik = parsed.pathname.match(/CIK(\d+)\.json$/i)?.[1];
+  return pathCik || null;
+}
+
+function primaryEvidenceForm(
+  forms?: Array<{ form?: string | null; last_filed_at?: string | null }>
+): { form: string | null; lastFiledAt: string | null } {
+  const first = Array.isArray(forms) ? forms[0] : null;
+  return {
+    form: String(first?.form || "").trim() || null,
+    lastFiledAt: String(first?.last_filed_at || "").trim() || null,
+  };
+}
+
+function evidenceLabel(params: {
+  parsed: URL | null;
+  url: string;
+  forms?: Array<{ form?: string | null; last_filed_at?: string | null }>;
+  fallbackIndex: number;
+}): string {
+  const { form, lastFiledAt } = primaryEvidenceForm(params.forms);
+  const accession = normalizeSecAccession(params.url);
+  if (accession) return form ? `SEC Form ${form} - ${accession}` : `SEC filing - ${accession}`;
+
+  const host = params.parsed?.hostname.toLowerCase() || "";
+  const path = params.parsed?.pathname || "";
+  const cik = evidenceCikFromUrl(params.parsed);
+
+  if (host === "data.sec.gov" && /\/submissions\/CIK\d+\.json$/i.test(path)) {
+    return cik ? `SEC submissions - CIK ${cik}` : "SEC submissions";
+  }
+
+  if (host.endsWith("sec.gov") && path.toLowerCase().includes("/edgar/browse/")) {
+    return cik ? `SEC company page - CIK ${cik}` : "SEC company page";
+  }
+
+  if (host.endsWith("sec.gov") && form) {
+    return lastFiledAt ? `SEC Form ${form} - ${lastFiledAt}` : `SEC Form ${form}`;
+  }
+
+  return `SEC filing ${params.fallbackIndex}`;
+}
+
+function evidenceIdentity(url: string): string {
+  const accession = normalizeSecAccession(url);
+  if (accession) return `sec-accession:${accession}`;
+
+  const normalizedUrl = normalizeEvidenceUrl(url);
+  return `url:${normalizedUrl || url}`;
+}
+
+export function marketplaceInvestorEvidenceLinks(
+  evidence: MarketplaceInvestor["evidence"],
+  limit = 3
+): MarketplaceEvidenceLink[] {
+  const sourceUrls = Array.isArray(evidence?.source_urls) ? evidence.source_urls : [];
+  const links: MarketplaceEvidenceLink[] = [];
+  const seen = new Set<string>();
+
+  for (const sourceUrl of sourceUrls) {
+    const url = normalizeEvidenceUrl(sourceUrl);
+    if (!url) continue;
+
+    const id = evidenceIdentity(url);
+    if (seen.has(id)) continue;
+
+    seen.add(id);
+    links.push({
+      id,
+      label: evidenceLabel({
+        parsed: evidenceUrlParts(url),
+        url,
+        forms: evidence?.forms,
+        fallbackIndex: links.length + 1,
+      }),
+      url,
+    });
+
+    if (links.length >= limit) break;
+  }
+
+  return links;
 }


### PR DESCRIPTION
## Summary
- deduplicate marketplace investor SEC evidence links by stable URL/accession identity
- replace repeated generic `SEC source` buttons with source-specific labels from existing SEC URL/form metadata
- keep backend/API/service contracts unchanged

## Tests
- npm.cmd test -- __tests__/lib/marketplace/investor-evidence-links.test.ts __tests__/app/marketplace/page-card-layout.contract.test.ts
- npx.cmd eslint app/marketplace/page.tsx lib/marketplace/investor-discovery.ts __tests__/app/marketplace/page-card-layout.contract.test.ts __tests__/lib/marketplace/investor-evidence-links.test.ts --max-warnings=0
- npm.cmd run typecheck
- npm.cmd run verify:design-system
- npm.cmd run verify:docs
- npm.cmd run verify:cache
- git diff --check

Closes #6331