### PR TITLE
fix(ria): narrow the RIA shell from standard to agent width

### DIFF
--- a/hushh-webapp/__tests__/app/ria/header-regression.contract.test.ts
+++ b/hushh-webapp/__tests__/app/ria/header-regression.contract.test.ts
@@ -45,6 +45,19 @@ describe("RIA shared header regression contract", () => {
     expect(globals).toContain("--ria-selected-tint: var(--app-accent-surface)");
   });
 
+  it("gives RiaPageShell an \"agent\"-width default, not the wider \"standard\"", () => {
+    // The one place this now needs to be right: every caller that does not
+    // pass its own `width` -- Profile, the client account/request detail
+    // pages, RiaClientWorkspace, and the Marketplace RIA public profile --
+    // inherits this. A future edit widening the default silently widens all
+    // of them at once, which is exactly how this shipped too wide the first
+    // time.
+    const riaShell = read("components/ria/ria-page-shell.tsx");
+
+    expect(riaShell).toContain('width = "agent"');
+    expect(riaShell).not.toContain('width = "standard"');
+  });
+
   it("keeps ria picks on shared surfaces with responsive table sizing", () => {
     const riaPicks = read("app/ria/picks/page.tsx");
 
@@ -60,9 +73,14 @@ describe("RIA shared header regression contract", () => {
     const riaClients = read("app/ria/clients/page.tsx");
     const riaPicks = read("app/ria/picks/page.tsx");
 
+    // "agent" (880px), not "standard" (1440px) -- Connect and Marketplace are
+    // directory-browsing surfaces at that wider measure; RIA is a workspace,
+    // closer in shape to Location's primary surface. See ria-page-shell.tsx.
     expect(riaProfile).toContain("RiaPageShell");
-    expect(riaClients).toContain('width="standard"');
-    expect(riaPicks).toContain('width="standard"');
+    expect(riaClients).toContain('width="agent"');
+    expect(riaPicks).toContain('width="agent"');
+    expect(riaClients).not.toContain('width="standard"');
+    expect(riaPicks).not.toContain('width="standard"');
     expect(riaClients).not.toContain('width="expanded"');
     expect(riaPicks).not.toContain('width="expanded"');
     expect(riaClients).toContain('<AppPageHeaderRegion className="pt-2 sm:pt-3">');

--- a/hushh-webapp/__tests__/app/ria/header-regression.contract.test.ts
+++ b/hushh-webapp/__tests__/app/ria/header-regression.contract.test.ts
@@ -54,8 +54,8 @@ describe("RIA shared header regression contract", () => {
     // time.
     const riaShell = read("components/ria/ria-page-shell.tsx");
 
-    expect(riaShell).toContain('width = "agent"');
-    expect(riaShell).not.toContain('width = "standard"');
+    expect(riaShell).toMatch(/\bwidth\s*=\s*["']agent["']/);
+    expect(riaShell).not.toMatch(/\bwidth\s*=\s*["']standard["']/);
   });
 
   it("keeps ria picks on shared surfaces with responsive table sizing", () => {

--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -168,7 +168,7 @@ export default function RiaClientsPage() {
       <>
         <AppPageShell
           as="main"
-          width="standard"
+          width="agent"
           nativeTest={{
             routeId: "/ria/clients",
             marker: "native-route-ria-clients",
@@ -187,7 +187,7 @@ export default function RiaClientsPage() {
   return (
     <AppPageShell
       as="main"
-      width="standard"
+      width="agent"
       nativeTest={{
         routeId: "/ria/clients",
         marker: "native-route-ria-clients",

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -2712,7 +2712,11 @@ export default function RiaPicksPage() {
   return (
     <AppPageShell
       as="main"
-      width="standard"
+      // Matches RiaPageShell's own default -- see its comment. The wide
+      // tables inside this screen already gate themselves behind
+      // `hidden md:block` and their own horizontal scroll, so narrowing the
+      // shell does not affect them.
+      width="agent"
       nativeTest={{
         routeId: "/ria/picks",
         marker: "native-route-ria-picks",

--- a/hushh-webapp/app/ria/workspace/page.tsx
+++ b/hushh-webapp/app/ria/workspace/page.tsx
@@ -38,7 +38,7 @@ function RiaWorkspaceCompatibilityRedirect() {
   return (
     <AppPageShell
       as="main"
-      width="standard"
+      width="agent"
       nativeTest={{
         routeId: "/ria/workspace",
         marker: "native-route-ria-workspace",

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -42,7 +42,14 @@ export function RiaPageShell({
   icon = BriefcaseBusiness,
   statusPanel,
   children,
-  width = "standard",
+  // "standard" (90rem / 1440px) matched Connect and Marketplace, but those
+  // are directory-browsing surfaces; RIA's own screens are read-and-act
+  // workspaces, closer in shape to Location's primary surface, which uses
+  // "agent" (880px). At phone width the two are visually identical --
+  // both exceed the viewport, so `width: 100%` governs either way -- the
+  // difference shows up on an iPad or any Capacitor window wider than a
+  // phone, which is where "very wide, wrong container" was reported from.
+  width = "agent",
   className,
   headerClassName,
   contentClassName,


### PR DESCRIPTION
## What changed

RIA screens moved from `width="standard"` (90rem / 1440px) to `width="agent"` (880px) — the same shell measure `/one/location`'s primary surface uses.

`standard` is the same width Connect and Marketplace use, and those are directory-browsing surfaces at that width on purpose. RIA is a workspace — read-and-act, not browse-and-pick — closer in shape to Location.

## Why this matters more on the Capacitor iOS build than in a browser tab

On a phone-portrait viewport, `standard` and `agent` render **visually identical** — both max-widths exceed the actual viewport, so `width: 100%` governs either way, and nothing here changes what an iPhone in portrait shows. The difference is real on anything wider: an iPad, split-view multitasking, or any resizable Capacitor window — which is exactly where "very wide, wrong container" was reported from.

## Where it's fixed

Changed the **shared default** in `ria-page-shell.tsx` rather than touching every call site by hand, so every `RiaPageShell` consumer moves together: Profile, the client account/request detail pages, `RiaClientWorkspace`, and the Marketplace RIA public profile all inherit it with no per-file change. The three surfaces that call `AppPageShell` directly instead of going through `RiaPageShell` (`picks`, `clients`, `workspace`) were updated by hand to match.

`picks`' wide tables (`min-w-[640px]` / `[700px]`) are untouched — they already gate behind `hidden md:block` with their own horizontal scroll, so the shell width has no effect on them.

## Test plan

- [x] The existing `header-regression.contract.test.ts` pinned `width="standard"` as the expected value for `clients` and `picks` — updated to `"agent"`.
- [x] Added a dedicated guard on the shared default itself in `ria-page-shell.tsx`, since a future one-line edit there would otherwise silently widen every RIA screen at once — which is how this shipped too wide the first time.
- [x] `npx vitest run __tests__/app/ria/ components/ria/__tests__/ app/marketplace/ria/__tests__/` — 54/54.
- [x] `npx tsc --noEmit`, `eslint --max-warnings=0` — clean.

Addresses #6288.
