### PR TITLE
fix(ria): surface saved investor leads

### DIFF
--- a/hushh-webapp/__tests__/app/marketplace/page-card-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/app/marketplace/page-card-layout.contract.test.ts
@@ -71,4 +71,18 @@ describe("marketplace client card layout contract", () => {
     expect(source).toContain("aria-label={`${source.label} opens in a new tab`}");
     expect(source).not.toContain("SEC source");
   });
+
+  it("surfaces database-backed saved investor leads in the RIA deck", () => {
+    const source = readMarketplacePage();
+
+    expect(source).toContain('data-testid="marketplace-saved-leads"');
+    expect(source).toContain("Saved investor leads");
+    expect(source).toContain('item.status === "shortlisted"');
+    expect(source).toContain("marketplaceSavedInvestorLeadsFromActions(actions)");
+    expect(source).toContain("setSavedInvestorLeads(savedLeads)");
+    expect(source).toContain("removeSavedInvestorLead");
+    expect(source).toContain('"pass", { gesture: "remove_saved_lead" }');
+    expect(source).toContain('toast.success("Saved lead removed from the RIA deck.")');
+    expect(source).not.toContain("localStorage.setItem(key, JSON.stringify([...savedInvestorLeads");
+  });
 });

--- a/hushh-webapp/__tests__/lib/marketplace/primary-card-label.test.ts
+++ b/hushh-webapp/__tests__/lib/marketplace/primary-card-label.test.ts
@@ -49,4 +49,15 @@ describe("resolveMarketplacePrimaryCardLabel", () => {
       }),
     ).toBe("Save lead");
   });
+
+  it("shows saved lead state for already-shortlisted investors", () => {
+    expect(
+      resolveMarketplacePrimaryCardLabel({
+        kind: "investor",
+        currentPersona: "ria",
+        isInvestorShortlistable: true,
+        isInvestorShortlisted: true,
+      }),
+    ).toBe("Saved lead");
+  });
 });

--- a/hushh-webapp/__tests__/lib/marketplace/saved-investor-leads.test.ts
+++ b/hushh-webapp/__tests__/lib/marketplace/saved-investor-leads.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  marketplaceInvestorActionIdentity,
+  marketplaceSavedInvestorLeadFromAction,
+  marketplaceSavedInvestorLeadsFromActions,
+} from "@/lib/marketplace/investor-discovery";
+import type { MarketplaceInvestorActionRecord } from "@/lib/services/ria-service";
+
+function action(
+  overrides: Partial<MarketplaceInvestorActionRecord> = {},
+): MarketplaceInvestorActionRecord {
+  return {
+    id: "action-1",
+    actor_user_id: "ria-1",
+    ria_profile_id: "ria-profile-1",
+    source_type: "public_sec",
+    target_key: "public_sec:42",
+    public_profile_id: "42",
+    target_user_id: null,
+    action: "shortlist",
+    status: "shortlisted",
+    profile: {
+      id: "public_sec:42",
+      source_type: "public_sec",
+      public_profile_id: "42",
+      display_name: "Ipsen Advisor Group LLC",
+      headline: "Public institutional filer",
+      strategy_summary: "SEC-backed investor discovery profile.",
+    },
+    metadata: { surface: "marketplace" },
+    ...overrides,
+  };
+}
+
+describe("marketplace saved investor leads", () => {
+  it("uses target_key as the stable saved-lead identity", () => {
+    expect(marketplaceInvestorActionIdentity(action())).toBe("public_sec:42");
+  });
+
+  it("projects a shortlisted marketplace action into a saved lead", () => {
+    const lead = marketplaceSavedInvestorLeadFromAction(action());
+
+    expect(lead?.id).toBe("public_sec:42");
+    expect(lead?.investor.display_name).toBe("Ipsen Advisor Group LLC");
+    expect(lead?.investor.public_profile_id).toBe("42");
+  });
+
+  it("does not treat passed actions as saved leads", () => {
+    expect(
+      marketplaceSavedInvestorLeadFromAction(
+        action({ action: "pass", status: "passed" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("deduplicates saved leads by stable identity rather than display name", () => {
+    const leads = marketplaceSavedInvestorLeadsFromActions([
+      action({ id: "action-1", target_key: "public_sec:42" }),
+      action({ id: "action-2", target_key: "public_sec:42" }),
+      action({
+        id: "action-3",
+        target_key: "public_sec:43",
+        public_profile_id: "43",
+        profile: {
+          id: "public_sec:43",
+          source_type: "public_sec",
+          public_profile_id: "43",
+          display_name: "Ipsen Advisor Group LLC",
+        },
+      }),
+    ]);
+
+    expect(leads.map((lead) => lead.id)).toEqual(["public_sec:42", "public_sec:43"]);
+  });
+
+  it("falls back to canonical source identities when target_key is absent", () => {
+    expect(
+      marketplaceInvestorActionIdentity(
+        action({ target_key: null, source_type: "public_sec", public_profile_id: "44" }),
+      ),
+    ).toBe("public_sec:44");
+
+    expect(
+      marketplaceInvestorActionIdentity(
+        action({
+          target_key: null,
+          source_type: "hushh_user",
+          public_profile_id: null,
+          target_user_id: "investor-1",
+        }),
+      ),
+    ).toBe("investor-1");
+  });
+});

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -35,12 +35,15 @@ import {
   isMarketplaceInvestorConnectable,
   isMarketplaceInvestorShortlistable,
   isPublicSecMarketplaceInvestor,
-  marketplaceInvestorEvidenceLinks,
   marketplaceInvestorActionTarget,
   marketplaceInvestorCardId,
   marketplaceInvestorCurationLabel,
+  marketplaceInvestorEvidenceLinks,
   marketplaceInvestorSourceLabel,
   marketplaceInvestorUserId,
+  marketplaceSavedInvestorLeadFromAction,
+  marketplaceSavedInvestorLeadsFromActions,
+  type MarketplaceSavedInvestorLead,
 } from "@/lib/marketplace/investor-discovery";
 import { formatMarketplaceDisplayName } from "@/lib/marketplace/display-name";
 import { resolveMarketplacePrimaryCardLabel } from "@/lib/marketplace/primary-card-label";
@@ -225,6 +228,7 @@ export default function MarketplacePage() {
   const [passedRiaIds, setPassedRiaIds] = useState<string[]>([]);
   const [passedInvestorIds, setPassedInvestorIds] = useState<string[]>([]);
   const [shortlistedInvestorIds, setShortlistedInvestorIds] = useState<string[]>([]);
+  const [savedInvestorLeads, setSavedInvestorLeads] = useState<MarketplaceSavedInvestorLead[]>([]);
   const [contactMatches, setContactMatches] = useState<MarketplaceContactMatch[]>([]);
   const [contactMatchLoading, setContactMatchLoading] = useState(false);
   const [contactMatchError, setContactMatchError] = useState<string | null>(null);
@@ -393,11 +397,13 @@ export default function MarketplacePage() {
           .filter((item) => item.status === "shortlisted")
           .map((item) => String(item.target_key || "").trim())
           .filter(Boolean);
+        const savedLeads = marketplaceSavedInvestorLeadsFromActions(actions);
 
         setPassedInvestorIds((current) => Array.from(new Set([...current, ...passed])));
         setShortlistedInvestorIds((current) =>
           Array.from(new Set([...current, ...shortlisted])),
         );
+        setSavedInvestorLeads(savedLeads);
       } catch (error) {
         console.warn("[Marketplace] Could not load persisted investor deck actions", error);
       }
@@ -430,6 +436,30 @@ export default function MarketplacePage() {
       }
     },
     [user]
+  );
+
+  const forgetInvestorDeckDecision = useCallback(
+    (kind: "shortlisted", investorId: string) => {
+      if (!user || typeof window === "undefined") return;
+      const normalizedId = investorId.trim();
+      if (!normalizedId) return;
+      const key = `marketplace:ria:${user.uid}:${
+        kind === "shortlisted" ? "shortlisted-investors" : "passed-investors"
+      }`;
+      try {
+        const current = JSON.parse(window.localStorage.getItem(key) || "[]");
+        const ids = Array.isArray(current)
+          ? current.map((item) => String(item || "").trim()).filter(Boolean)
+          : [];
+        window.localStorage.setItem(
+          key,
+          JSON.stringify(ids.filter((item) => item !== normalizedId)),
+        );
+      } catch {
+        window.localStorage.setItem(key, "[]");
+      }
+    },
+    [user],
   );
 
   useEffect(() => {
@@ -668,9 +698,13 @@ export default function MarketplacePage() {
       .filter((item) => item.kind === "investor")
       .map((item) => item.profile as MarketplaceInvestor);
     return new Map(
-      [...investors, ...contactInvestors].map((item) => [marketplaceInvestorCardId(item), item])
+      [
+        ...investors,
+        ...contactInvestors,
+        ...savedInvestorLeads.map((lead) => lead.investor),
+      ].map((item) => [marketplaceInvestorCardId(item), item])
     );
-  }, [contactMatches, investors]);
+  }, [contactMatches, investors, savedInvestorLeads]);
 
   const advisorCards = useMemo<DiscoveryCard[]>(() => {
     return rias.map((ria) => {
@@ -925,13 +959,24 @@ export default function MarketplacePage() {
   const shortlistInvestor = useCallback(async (investor: MarketplaceInvestor) => {
     const investorId = marketplaceInvestorCardId(investor);
     try {
-      await persistInvestorAction(investor, "shortlist", { gesture: "right_swipe_or_save" });
+      const actionRecord = await persistInvestorAction(investor, "shortlist", {
+        gesture: "right_swipe_or_save",
+      });
+      const savedLead = actionRecord
+        ? marketplaceSavedInvestorLeadFromAction(actionRecord)
+        : null;
       setShortlistedInvestorIds((current) =>
         current.includes(investorId) ? current : [...current, investorId]
       );
       setPassedInvestorIds((current) =>
         current.includes(investorId) ? current : [...current, investorId]
       );
+      if (savedLead) {
+        setSavedInvestorLeads((current) => [
+          savedLead,
+          ...current.filter((lead) => lead.id !== savedLead.id),
+        ]);
+      }
       rememberInvestorDeckDecision("shortlisted", investorId);
       rememberInvestorDeckDecision("passed", investorId);
       toast.success("Investor lead saved. Saved to the database-backed RIA deck shortlist.");
@@ -939,6 +984,22 @@ export default function MarketplacePage() {
       toast.error(error instanceof Error ? error.message : "Could not save investor lead");
     }
   }, [persistInvestorAction, rememberInvestorDeckDecision]);
+
+  const removeSavedInvestorLead = useCallback(async (lead: MarketplaceSavedInvestorLead) => {
+    try {
+      await persistInvestorAction(lead.investor, "pass", { gesture: "remove_saved_lead" });
+      setSavedInvestorLeads((current) => current.filter((item) => item.id !== lead.id));
+      setShortlistedInvestorIds((current) => current.filter((item) => item !== lead.id));
+      setPassedInvestorIds((current) =>
+        current.includes(lead.id) ? current : [...current, lead.id]
+      );
+      forgetInvestorDeckDecision("shortlisted", lead.id);
+      rememberInvestorDeckDecision("passed", lead.id);
+      toast.success("Saved lead removed from the RIA deck.");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not remove saved lead");
+    }
+  }, [forgetInvestorDeckDecision, persistInvestorAction, rememberInvestorDeckDecision]);
 
   const openDiscoveryProfile = useCallback((card: DiscoveryCard) => {
     if (card.kind === "investor") {
@@ -1249,6 +1310,89 @@ export default function MarketplacePage() {
           </RiaSurface>
         ) : null}
 
+      {!iamUnavailable && isRiaConnectSurface && directoryKind === "investors" && view === "list" ? (
+        <RiaSurface data-testid="marketplace-saved-leads" className="space-y-4 p-4 sm:p-5">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                RIA Deck
+              </p>
+              <h2 className="mt-1 text-[17px] font-semibold leading-snug tracking-normal text-foreground">
+                Saved investor leads
+              </h2>
+            </div>
+            <span className="rounded-full bg-background/70 px-3 py-1 text-xs font-semibold text-muted-foreground dark:bg-white/5">
+              {savedInvestorLeads.length}
+            </span>
+          </div>
+
+          {savedInvestorLeads.length === 0 ? (
+            <p className="text-sm leading-6 text-muted-foreground">
+              Save investor leads from Marketplace to keep them here for follow-up.
+            </p>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-2">
+              {savedInvestorLeads.map((lead) => {
+                const sourceLabel = marketplaceInvestorSourceLabel(lead.investor);
+                const curationLabel = marketplaceInvestorCurationLabel(lead.investor);
+                return (
+                  <div
+                    key={lead.id}
+                    className="rounded-[var(--radius-md)] bg-background/55 p-4 dark:bg-white/5"
+                  >
+                    <div className="flex min-w-0 items-start gap-3">
+                      <ProfileAvatar
+                        kind="investor"
+                        label={lead.investor.display_name}
+                        className="h-10 w-10 shrink-0"
+                        riaSurface={isRiaConnectSurface}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <h3 className="break-words text-sm font-semibold leading-5 text-foreground">
+                          {formatMarketplaceDisplayName(lead.investor.display_name)}
+                        </h3>
+                        <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">
+                          {lead.investor.headline ||
+                            lead.investor.strategy_summary ||
+                            "Saved investor lead"}
+                        </p>
+                        <p className="mt-2 line-clamp-1 text-xs text-muted-foreground">
+                          {[curationLabel, sourceLabel, lead.investor.location_hint]
+                            .filter(Boolean)
+                            .join(" - ") || "RIA Deck lead"}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="mt-4 grid grid-cols-2 gap-2">
+                      <Button
+                        variant="none"
+                        effect="fade"
+                        size="sm"
+                        className="min-w-0 justify-center"
+                        onClick={() => setSelectedProfile({ kind: "investor", id: lead.id })}
+                      >
+                        View details
+                        <ArrowUpRight className="ml-2 h-4 w-4 shrink-0" />
+                      </Button>
+                      <Button
+                        variant="none"
+                        effect="fade"
+                        size="sm"
+                        className="min-w-0 justify-center"
+                        onClick={() => void removeSavedInvestorLead(lead)}
+                      >
+                        <X className="mr-2 h-4 w-4 shrink-0" />
+                        Remove
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </RiaSurface>
+      ) : null}
+
       {iamUnavailable ? (
         <RiaSurface className="border-dashed border-amber-500/40 bg-amber-500/5 p-4">
           <p className="text-sm text-muted-foreground">
@@ -1375,6 +1519,9 @@ export default function MarketplacePage() {
                             isMarketplaceInvestorShortlistable(
                               swipeCard.profile as MarketplaceInvestor
                             ),
+                          isInvestorShortlisted:
+                            swipeCard.kind === "investor" &&
+                            shortlistedInvestorIds.includes(swipeCard.id),
                         })}
                       </span>
                     </Button>
@@ -1508,6 +1655,9 @@ export default function MarketplacePage() {
                           currentPersona,
                           canConnect: item.canConnect,
                           isInvestorShortlistable,
+                          isInvestorShortlisted:
+                            item.kind === "investor" &&
+                            shortlistedInvestorIds.includes(item.id),
                         })}
                       </span>
                     </Button>

--- a/hushh-webapp/lib/marketplace/investor-discovery.ts
+++ b/hushh-webapp/lib/marketplace/investor-discovery.ts
@@ -1,9 +1,18 @@
-import type { MarketplaceInvestor } from "@/lib/services/ria-service";
+import type {
+  MarketplaceInvestor,
+  MarketplaceInvestorActionRecord,
+} from "@/lib/services/ria-service";
 
 export type MarketplaceEvidenceLink = {
   id: string;
   label: string;
   url: string;
+};
+
+export type MarketplaceSavedInvestorLead = {
+  id: string;
+  investor: MarketplaceInvestor;
+  action: MarketplaceInvestorActionRecord;
 };
 
 export function marketplaceInvestorCardId(investor: MarketplaceInvestor): string {
@@ -87,6 +96,68 @@ export function marketplaceInvestorCurationLabel(investor: MarketplaceInvestor):
   if (tier === "showcase") return "Showcase";
   if (tier === "qualified") return "Qualified";
   return null;
+}
+
+export function marketplaceInvestorActionIdentity(
+  action: MarketplaceInvestorActionRecord
+): string | null {
+  const targetKey = String(action.target_key || "").trim();
+  if (targetKey) return targetKey;
+
+  const sourceType = String(action.source_type || "").trim().toLowerCase();
+  const publicProfileId = String(action.public_profile_id || "").trim();
+  if (sourceType === "public_sec" && publicProfileId) return `public_sec:${publicProfileId}`;
+
+  const targetUserId = String(action.target_user_id || "").trim();
+  if (sourceType === "hushh_user" && targetUserId) return targetUserId;
+
+  return null;
+}
+
+export function marketplaceSavedInvestorLeadFromAction(
+  action: MarketplaceInvestorActionRecord
+): MarketplaceSavedInvestorLead | null {
+  if (String(action.status || "").toLowerCase() !== "shortlisted") return null;
+
+  const identity = marketplaceInvestorActionIdentity(action);
+  if (!identity) return null;
+
+  const profile = action.profile;
+  if (!profile || typeof profile !== "object" || Array.isArray(profile)) return null;
+
+  const profileRecord = profile as Record<string, unknown>;
+  const displayName = String(profileRecord.display_name || "").trim();
+  if (!displayName) return null;
+
+  return {
+    id: identity,
+    investor: {
+      ...(profile as MarketplaceInvestor),
+      id: String(profileRecord.id || identity),
+      source_type: action.source_type || String(profileRecord.source_type || ""),
+      user_id: action.target_user_id || String(profileRecord.user_id || ""),
+      public_profile_id:
+        action.public_profile_id || (profile as MarketplaceInvestor).public_profile_id,
+      display_name: displayName,
+    },
+    action,
+  };
+}
+
+export function marketplaceSavedInvestorLeadsFromActions(
+  actions: MarketplaceInvestorActionRecord[]
+): MarketplaceSavedInvestorLead[] {
+  const leads: MarketplaceSavedInvestorLead[] = [];
+  const seen = new Set<string>();
+
+  for (const action of actions) {
+    const lead = marketplaceSavedInvestorLeadFromAction(action);
+    if (!lead || seen.has(lead.id)) continue;
+    seen.add(lead.id);
+    leads.push(lead);
+  }
+
+  return leads;
 }
 
 const SEC_ACCESSION_PATTERN = /\b\d{10}-\d{2}-\d{6}\b/;

--- a/hushh-webapp/lib/marketplace/primary-card-label.ts
+++ b/hushh-webapp/lib/marketplace/primary-card-label.ts
@@ -7,6 +7,7 @@ export type MarketplacePrimaryCardLabelInput = {
   currentPersona: Persona;
   canConnect?: boolean;
   isInvestorShortlistable?: boolean;
+  isInvestorShortlisted?: boolean;
 };
 
 export function resolveMarketplacePrimaryCardLabel({
@@ -16,6 +17,7 @@ export function resolveMarketplacePrimaryCardLabel({
   currentPersona,
   canConnect = false,
   isInvestorShortlistable = false,
+  isInvestorShortlisted = false,
 }: MarketplacePrimaryCardLabelInput): string {
   if (isTestProfile) {
     return kind === "investor" && currentPersona === "ria" ? "Open workspace" : "Demo";
@@ -27,6 +29,7 @@ export function resolveMarketplacePrimaryCardLabel({
     return currentPersona === "investor" ? "Request advisory" : "Send request";
   }
 
+  if (isInvestorShortlisted) return "Saved lead";
   if (isInvestorShortlistable) return "Save lead";
   if (canConnect) return "Send request";
   return "View profile";


### PR DESCRIPTION
Description
When an RIA saves an investor lead, the UI displays a notification indicating that the lead has been saved to the RIA Deck/database-backed shortlist.

However, there is no clear or easily discoverable way for the RIA to navigate to and view these saved investor leads.

Investigate the existing RIA Deck persistence and retrieval flow. Reuse the existing database-backed source of truth rather than creating another saved-lead or shortlist implementation.

Steps To Reproduce
Open the RIA investor/client discovery experience.
Select an investor lead.
Click Save Lead.
Observe the confirmation/toast indicating that the lead was saved.
Try to locate the saved lead afterward.

Expected Behavior
The RIA should have a clear way to access and manage investor leads previously saved to the RIA Deck.