### PR TITLE
fix(location): align tab content spacing

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/people-hub.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/people-hub.test.tsx
@@ -134,6 +134,31 @@ describe("PeopleHub requests sent manage surface", () => {
     ).toBeInTheDocument();
   });
 
+  it("starts Circle content at the shared tab pane top", () => {
+    render(
+      <PeopleHub
+        vm={vm()}
+        onAddConnections={vi.fn()}
+        onInvite={vi.fn()}
+        onCreateCircle={vi.fn()}
+        onJoinCircle={vi.fn()}
+        onOpenCircle={vi.fn()}
+        focusedInviteId={null}
+        onDismissFocusedInvite={vi.fn()}
+        onStartShare={vi.fn()}
+      />,
+    );
+
+    const hub = screen.getByTestId("one-location-people-hub");
+    const sectionStack = hub.firstElementChild as HTMLElement | null;
+    const circles = screen.getByTestId("one-location-named-circles");
+
+    expect(hub).not.toHaveClass("pt-5");
+    expect(hub).not.toHaveClass("sm:pt-9");
+    expect(sectionStack).toHaveClass("space-y-7", "sm:space-y-10");
+    expect(sectionStack?.firstElementChild).toBe(circles);
+  });
+
   it("uses quick extension actions instead of the old duration editor", () => {
     render(
       <PeopleHub

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -3484,7 +3484,7 @@ export function PeopleHub({
   );
 
   return (
-    <div className="pt-5 sm:pt-9" data-testid="one-location-people-hub">
+    <div data-testid="one-location-people-hub">
       <div className="space-y-7 sm:space-y-10">
         <CirclesSection
           circles={vm.circles}


### PR DESCRIPTION
## Summary

- Align the Location People/Circles tab content with the Now and Links tab pane start position.
- Remove the People/Circles-only top padding that made Circles start lower than the other Location tabs.
- Add a focused regression test guarding against that People-only top padding coming back.

## Verification

- `npm run test -- components/one-location/redesign/__tests__/people-hub.test.tsx` — 5 passed
- `npx eslint components/one-location/redesign/location-redesign-hub.tsx components/one-location/redesign/__tests__/people-hub.test.tsx` — passed
- `npm run typecheck` — passed
- `npx playwright test e2e/one-location-tab-strip.layout.spec.ts --project=chromium` — 10 passed
- `git diff --check` — passed
