### PR TITLE
fix(connect): open My connections by default

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -1722,6 +1722,10 @@ describe("Connect — People", () => {
     // and rendering another is the exact shape of the original Connect search
     // bug, so the count is asserted here alongside the rows.
     expect(await screen.findByText("My RIAs (1)")).toBeTruthy();
+    expect(screen.getByTestId("connect-my-connections-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
     expect(screen.getByText("Verified Adviser")).toBeTruthy();
     expect(screen.queryByText("Ordinary Person")).toBeNull();
   });
@@ -2044,6 +2048,30 @@ describe("Connect — the phone-width geometry QA reported", () => {
 
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("does not open the RIAs disclosure just because People opens by default", async () => {
+    render(<ConnectPageClient />);
+    await revealPeopleDirectory();
+
+    expect(screen.getByTestId("connect-my-connections-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+
+    chooseDirectory("RIAs");
+
+    expect(await screen.findByText("My RIAs (0)")).toBeTruthy();
+    expect(screen.getByTestId("connect-my-connections-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+
+    fireEvent.click(screen.getByTestId("connect-my-connections-toggle"));
+    expect(screen.getByTestId("connect-my-connections-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
   });
 
   it("gives Connections the same row rhythm as Circles beside it", async () => {

--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -583,13 +583,8 @@ describe("Connect — People", () => {
     expect(await screen.findByText("Current Person")).toBeTruthy();
     expect(mocks.listConnectionsPage).toHaveBeenCalledTimes(1);
 
-    // My connections is a disclosure now, closed on arrival. Refresh only
-    // exists against a list you can see -- a refresh control over a collapsed
-    // panel reloads something nobody is looking at.
-    expect(screen.queryByRole("button", { name: "Refresh contacts" })).toBeNull();
-    fireEvent.click(
-      screen.getByTestId("connect-my-connections-toggle"),
-    );
+    // My connections is a disclosure, open by default -- Refresh exists
+    // against a list you can already see, with no click needed to reach it.
 
     // Refresh is a control, not part of the heading text. It used to be a
     // child of the `title` node, which SettingsGroup renders inside an element
@@ -1964,19 +1959,21 @@ describe("Connect — the phone-width geometry QA reported", () => {
     );
     expect(list).toBeTruthy();
 
-    // Closed on arrival, which is the point: twelve people no longer push the
-    // search field -- the reason the screen exists -- below the fold.
-    expect(list!.className).toContain("hidden");
-    expect(list!.className).not.toContain("max-h-[232px]");
-
-    fireEvent.click(screen.getByTestId("connect-my-connections-toggle"));
-
-    // Opened, it is the same scroll region it always was.
+    // Open on arrival: the directory/search half is collapsed behind its
+    // own "Add people" button now, so there is no search field on the fold
+    // left for a long connections list to push down.
     expect(list!.className).not.toContain("hidden");
     expect(list!.className).toContain("max-h-[232px]");
     expect(list!.className).toContain("overflow-y-auto");
     expect(list!.className).toContain("overscroll-contain");
     expect(list!.className).toContain("sm:max-h-[320px]");
+
+    fireEvent.click(screen.getByTestId("connect-my-connections-toggle"));
+
+    // Still collapsible -- someone may still want it out of the way, only
+    // the default changed.
+    expect(list!.className).toContain("hidden");
+    expect(list!.className).not.toContain("max-h-[232px]");
   });
 
   it("puts Sync with the directory picker and Select on the directory", async () => {
@@ -2020,17 +2017,18 @@ describe("Connect — the phone-width geometry QA reported", () => {
     ).toBe(true);
   });
 
-  it("opens My connections only when asked, and says so to a screen reader", async () => {
-    // "Connections wala ek accordion tab ki tarah ho jo click krne pe he open
-    // ho ... currently it looks long for me." A disclosure, so the state has to
-    // be announced rather than only drawn -- a chevron is not an affordance to
-    // anyone who cannot see it.
+  it("opens My connections by default, and says so to a screen reader", async () => {
+    // A disclosure either way, so the state has to be announced rather than
+    // only drawn -- a chevron is not an affordance to anyone who cannot see
+    // it. Defaults open now that the directory/search half collapses behind
+    // its own "Add people" button -- nothing left on the fold to protect by
+    // shutting this one too.
     render(<ConnectPageClient />);
     await revealPeopleDirectory();
     await screen.findByPlaceholderText("Search people");
 
     const toggle = screen.getByTestId("connect-my-connections-toggle");
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
     expect(toggle).toHaveAttribute(
       "aria-controls",
       "connect-my-connections-panel",
@@ -2042,10 +2040,10 @@ describe("Connect — the phone-width geometry QA reported", () => {
     ).not.toBeNull();
 
     fireEvent.click(toggle);
-    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
 
     fireEvent.click(toggle);
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
   });
 
   it("gives Connections the same row rhythm as Circles beside it", async () => {

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -913,7 +913,7 @@ export default function ConnectPageClient() {
   const directoryAudience = CONNECT_TAB_AUDIENCE[tab];
   const isAdvisorTab = tab === "advisors";
   /**
-   * "My connections" is a disclosure. Open by default.
+   * "My connections" is a disclosure. The People tab opens it by default.
    *
    * Originally closed, on the reasoning that it was two stacked lists of
    * people on one screen -- the ones you already know, and the ones you are
@@ -924,12 +924,25 @@ export default function ConnectPageClient() {
    * down. Reported: arriving on Connect with both sections visibly shut read
    * as the screen having nothing on it.
    *
-   * Still a disclosure rather than always-rendered-open, because the scroll
-   * region a hundred connections need is real and someone may still prefer
-   * it out of the way -- only the DEFAULT changed. Not remembered per person,
-   * for the same reason the earlier default was not: it should not drift.
+   * Advisors keeps its own closed default: the verified-advisor directory is
+   * the primary work there, so opening "My RIAs" first would push that task
+   * away. Each directory keeps its own disclosure state while this page is
+   * mounted, so a manual toggle does not leak across tabs.
    */
-  const [connectionsOpen, setConnectionsOpen] = useState(true);
+  const [connectionsOpenByTab, setConnectionsOpenByTab] = useState<
+    Record<ConnectTab, boolean>
+  >({
+    people: true,
+    advisors: false,
+    nearby: false,
+  });
+  const connectionsOpen = connectionsOpenByTab[tab];
+  const toggleConnectionsOpen = useCallback(() => {
+    setConnectionsOpenByTab((openByTab) => ({
+      ...openByTab,
+      [tab]: !openByTab[tab],
+    }));
+  }, [tab]);
   const connectionsHeading = isAdvisorTab
     ? `My RIAs (${connectionsTotalCount})`
     : `My connections (${connectionsTotalCount})`;
@@ -2511,7 +2524,7 @@ export default function ConnectPageClient() {
                           data-testid="connect-my-connections-toggle"
                           aria-expanded={connectionsOpen}
                           aria-controls="connect-my-connections-panel"
-                          onClick={() => setConnectionsOpen((open) => !open)}
+                          onClick={toggleConnectionsOpen}
                           className="-mx-1 flex min-h-11 min-w-0 flex-1 items-center gap-1.5 rounded-[10px] px-1 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
                         >
                           <span className="min-w-0 truncate">

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -913,22 +913,23 @@ export default function ConnectPageClient() {
   const directoryAudience = CONNECT_TAB_AUDIENCE[tab];
   const isAdvisorTab = tab === "advisors";
   /**
-   * "My connections" is a disclosure, closed until asked for.
+   * "My connections" is a disclosure. Open by default.
    *
-   * Reported: "Connections wala ek accordion tab ki tarah ho jo click krne pe
-   * he open ho ... currently it looks long for me".
+   * Originally closed, on the reasoning that it was two stacked lists of
+   * people on one screen -- the ones you already know, and the ones you are
+   * looking for -- and the first pushed the search box below the fold on a
+   * phone. That reasoning no longer holds: the directory/search half is now
+   * ITSELF collapsed behind "Add people" (see showPeopleDirectory above), so
+   * there is nothing left on the fold for a long connections list to push
+   * down. Reported: arriving on Connect with both sections visibly shut read
+   * as the screen having nothing on it.
    *
-   * It was two stacked lists of people on one screen -- the ones you already
-   * know, and the ones you are looking for -- and the first one pushed the
-   * second below the fold on a phone even though the second is what the screen
-   * is FOR. Searching is the reason someone opens Connect; reviewing who you
-   * already have is the occasional visit.
-   *
-   * Closed by default rather than remembering the last state: the default is
-   * the answer to "what is this screen for", and it should not drift per
-   * person. The scroll region it had is unchanged and simply lives inside now.
+   * Still a disclosure rather than always-rendered-open, because the scroll
+   * region a hundred connections need is real and someone may still prefer
+   * it out of the way -- only the DEFAULT changed. Not remembered per person,
+   * for the same reason the earlier default was not: it should not drift.
    */
-  const [connectionsOpen, setConnectionsOpen] = useState(false);
+  const [connectionsOpen, setConnectionsOpen] = useState(true);
   const connectionsHeading = isAdvisorTab
     ? `My RIAs (${connectionsTotalCount})`
     : `My connections (${connectionsTotalCount})`;


### PR DESCRIPTION
## What was happening

Reported after testing #6341: opening Connect, both sections read as visibly shut — the directory (behind "Add people") and the connections list (behind its own disclosure) — so the screen looked empty on arrival.

## Why the old default doesn't hold any more

"My connections" was deliberately closed by default. The reasoning is recorded in the code it replaces: it was two stacked lists of people on one screen, and a long connections list pushed the search box below the fold on a phone.

That reasoning no longer applies. The directory/search half is now **itself** collapsed behind "Add people" (#6189/#6341) — there's nothing left on the fold for a long connections list to push down. The crowding problem #6341 fixed one way also removed the justification for this one being closed.

## The fix

Default flipped to open. Still a real disclosure, not always-rendered-open — someone with a hundred connections may still want the scroll region out of the way, so it stays collapsible. Only the default changed, and it's not remembered per person, for the same reason the earlier default wasn't: it should not drift.

## Test plan

- [x] Three tests encoded the old default directly and needed their premise updated, not just resynced: the `aria-expanded` test, the scrollable-list test (open/hidden assertions were exact inverses of the new default), and the refresh-contacts test, which no longer needs a click to reach a control that's now visible on arrival.
- [x] `npx vitest run __tests__/app/connect/page-client.test.tsx` — 81/81.
- [x] `npx tsc --noEmit`, `eslint --max-warnings=0` — clean.
