### PR TITLE
fix(ria): revive a dossier stuck in queued, not just scanning

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import secrets
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any, Literal
 
 import asyncpg
@@ -1332,24 +1333,60 @@ def _redispatch_dossier(*, dossier_id: int, user_id: str, context: dict[str, Any
 # reloads twice does not stack workers on one row.
 _DOSSIER_RESUMING: set[int] = set()
 
+# How long a row may sit in `queued` before a read treats it as stranded
+# rather than a worker that is legitimately still starting up. Generous next
+# to the ~10s frontend poll interval and the resolve_email/build_payload/
+# start_scan calls a live worker makes before its first status write, so a
+# request landing while dispatch is genuinely still in flight does not race
+# it into starting a second scan.
+_DOSSIER_QUEUED_STALL_THRESHOLD = timedelta(seconds=90)
+
 
 async def _resume_stalled_dossier(row: Any, user_id: str) -> None:
-    """Re-enter the poll for a row left mid-scan, if one is stalled.
+    """Re-enter the poll for a row left mid-scan or never started, if stalled.
 
     The worker is an in-process background task on a CPU-throttled Cloud Run
     service: once an instance stops receiving requests its CPU is withdrawn,
-    the poll freezes mid-flight, and the row is stranded in `scanning` forever
-    with the scan itself finishing perfectly well upstream. The read that
-    renders the card is a request, so it is also the thing that can revive the
-    poll — the scan id is already durable on the row, so resuming costs one
-    poll rather than a new scan.
+    a poll can freeze mid-flight, and a row can be stranded forever with the
+    scan itself finishing perfectly well upstream. The read that renders the
+    card is a request, so it is also the thing that can revive it.
+
+    Two stall points, not one. `scanning` was the only one handled here --
+    the scan id is durable on the row, so resuming it costs one poll rather
+    than a new scan. But the SAME withdrawal can happen even earlier: the
+    background task is scheduled the instant the claim HTTP response goes
+    out, and if CPU is pulled before that task gets its first turn on the
+    event loop, the row never leaves `queued` at all -- reported as
+    "Preparing your dossier..." frozen indefinitely, because nothing was ever
+    driving it in the first place. That case has no scan id to resume, so it
+    re-enters the worker from the start rather than resuming a poll, gated by
+    `_DOSSIER_QUEUED_STALL_THRESHOLD` so a request landing while the original
+    dispatch is genuinely still starting up does not race it into a second
+    scan.
     """
-    if str(row["status"] or "") != "scanning" or row["completed_at"] is not None:
+    status = str(row["status"] or "")
+    if row["completed_at"] is not None:
         return
-    scan_id = str(row["scan_id"] or "").strip()
     dossier_id = int(row["id"])
-    if not scan_id or dossier_id in _DOSSIER_RESUMING:
+    if dossier_id in _DOSSIER_RESUMING:
         return
+
+    resume_scan_id = ""
+    if status == "scanning":
+        resume_scan_id = str(row["scan_id"] or "").strip()
+        if not resume_scan_id:
+            return
+    elif status == "queued":
+        requested_at = row["requested_at"]
+        if requested_at is None:
+            return
+        if requested_at.tzinfo is None:
+            requested_at = requested_at.replace(tzinfo=timezone.utc)
+        if datetime.now(timezone.utc) - requested_at < _DOSSIER_QUEUED_STALL_THRESHOLD:
+            return
+    else:
+        return
+
     context = await _load_dossier_claim_context(user_id)
     if context is None:
         return
@@ -1369,7 +1406,7 @@ async def _resume_stalled_dossier(row: Any, user_id: str) -> None:
                 ria_profile_id=str(context.get("ria_profile_id") or ""),
                 claim_type=str(metadata.get("claim_type") or ""),
                 reference_metadata=metadata,
-                resume_scan_id=scan_id,
+                resume_scan_id=resume_scan_id,
             )
         finally:
             _DOSSIER_RESUMING.discard(dossier_id)

--- a/consent-protocol/tests/test_ria_dossier_routes.py
+++ b/consent-protocol/tests/test_ria_dossier_routes.py
@@ -478,7 +478,11 @@ def test_a_queued_row_still_within_the_grace_window_is_left_alone(monkeypatch):
         {"status": "scan_failed"},
         # Freshly queued, well inside the stall threshold — a worker that is
         # genuinely still starting up must never be raced into a second scan.
-        {"status": "queued", "scan_id": None, "requested_at": datetime.now(UTC)},
+        {
+            "status": "queued",
+            "scan_id": None,
+            "requested_at_offset": timedelta(seconds=5),
+        },
         {"status": "scanning", "scan_id": None},
         {
             "status": "scanning",
@@ -489,7 +493,12 @@ def test_a_queued_row_still_within_the_grace_window_is_left_alone(monkeypatch):
     ids=["sent", "failed", "queued-not-yet-stale", "scanning-no-scan-id", "already-completed"],
 )
 def test_a_row_that_is_not_mid_scan_is_never_resumed(monkeypatch, overrides):
-    _install_db(monkeypatch, [_row(**overrides)])
+    case_overrides = dict(overrides)
+    requested_at_offset = case_overrides.pop("requested_at_offset", None)
+    if requested_at_offset is not None:
+        case_overrides["requested_at"] = datetime.now(UTC) - requested_at_offset
+
+    _install_db(monkeypatch, [_row(**case_overrides)])
     _install_claim_context(monkeypatch, _claim_context())
     workers: list[dict[str, Any]] = []
 

--- a/consent-protocol/tests/test_ria_dossier_routes.py
+++ b/consent-protocol/tests/test_ria_dossier_routes.py
@@ -8,9 +8,10 @@ FOR UPDATE and re-dispatch the worker; a delivered dossier is a conflict.
 from __future__ import annotations
 
 import asyncio
+import importlib
 import sys
 import types
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import asyncpg
@@ -20,6 +21,17 @@ from fastapi.testclient import TestClient
 
 # Stub the rate-limit middleware *before* importing the route module so the
 # decorator is a no-op during tests (same pattern as test_ria_claim_flow).
+#
+# RateLimits carries the real per-route budget constants -- ria.py's other
+# routes read them at decoration time (e.g. RateLimits.RIA_NEARBY_DIRECTORY_READ),
+# so the stub module needs the real class, not just a limiter double, or the
+# import fails before a single test runs. Imported via importlib rather than
+# a plain `import`, which would cache the REAL module under this same
+# sys.modules key -- the assignment below has to be the thing that wins, or
+# ria.py's own `from api.middlewares.rate_limit import ... limiter` would
+# resolve to the real, rate-limiting one instead of the no-op double.
+_real_rate_limit_module = importlib.import_module("api.middlewares.rate_limit")
+
 rate_limit_module = types.ModuleType("api.middlewares.rate_limit")
 
 
@@ -32,7 +44,8 @@ class _NoopLimiter:
 
 
 rate_limit_module.limiter = _NoopLimiter()  # type: ignore[attr-defined]
-sys.modules.setdefault("api.middlewares.rate_limit", rate_limit_module)
+rate_limit_module.RateLimits = _real_rate_limit_module.RateLimits  # type: ignore[attr-defined]
+sys.modules["api.middlewares.rate_limit"] = rate_limit_module
 
 import hushh_mcp.services.ria_dossier_service as dossier_module  # noqa: E402
 from api.middleware import require_firebase_auth  # noqa: E402
@@ -386,12 +399,74 @@ def test_reading_a_scanning_row_resumes_its_poll(monkeypatch):
     assert workers[0]["dossier_id"] == 1
 
 
+def test_reading_a_stale_queued_row_resumes_it_from_scratch(monkeypatch):
+    """The other stall point: withdrawn CPU before the worker's first turn.
+
+    A `queued` row has no scan id, so there is nothing to resume a poll
+    against -- the worker has to re-enter from the beginning: resolve email,
+    build the scan payload, start a fresh scan. `resume_scan_id=""` is what
+    tells it to do that rather than treat the empty string as a scan id.
+    """
+    stale_requested_at = datetime.now(UTC) - timedelta(minutes=5)
+    _install_db(
+        monkeypatch,
+        [_row(status="queued", scan_id=None, completed_at=None, requested_at=stale_requested_at)],
+    )
+    _install_claim_context(monkeypatch, _claim_context())
+    workers: list[dict[str, Any]] = []
+
+    async def _fake_worker(self, **kwargs: Any) -> None:
+        workers.append(kwargs)
+
+    monkeypatch.setattr(
+        "hushh_mcp.services.ria_dossier_service.RIADossierService._run_worker", _fake_worker
+    )
+    ria_module._DOSSIER_RESUMING.clear()
+
+    response = TestClient(_build_app()).get("/api/ria/dossier")
+    assert response.status_code == 200
+    assert response.json()["status"] == "queued"
+    assert len(workers) == 1
+    assert workers[0]["resume_scan_id"] == ""
+    assert workers[0]["dossier_id"] == 1
+
+
+def test_a_queued_row_still_within_the_grace_window_is_left_alone(monkeypatch):
+    """The window a live worker needs to reach its first status write.
+
+    Requested five seconds ago is well within `_DOSSIER_QUEUED_STALL_THRESHOLD`
+    -- indistinguishable, from a single read, from dispatch still legitimately
+    resolving the recipient email and building the scan payload. Resuming it
+    here would start a second scan racing the first.
+    """
+    fresh_requested_at = datetime.now(UTC) - timedelta(seconds=5)
+    _install_db(
+        monkeypatch,
+        [_row(status="queued", scan_id=None, completed_at=None, requested_at=fresh_requested_at)],
+    )
+    _install_claim_context(monkeypatch, _claim_context())
+    workers: list[dict[str, Any]] = []
+
+    async def _fake_worker(self, **kwargs: Any) -> None:
+        workers.append(kwargs)
+
+    monkeypatch.setattr(
+        "hushh_mcp.services.ria_dossier_service.RIADossierService._run_worker", _fake_worker
+    )
+    ria_module._DOSSIER_RESUMING.clear()
+
+    assert TestClient(_build_app()).get("/api/ria/dossier").status_code == 200
+    assert workers == []
+
+
 @pytest.mark.parametrize(
     "overrides",
     [
         {"status": "sent"},
         {"status": "scan_failed"},
-        {"status": "queued", "scan_id": None},
+        # Freshly queued, well inside the stall threshold — a worker that is
+        # genuinely still starting up must never be raced into a second scan.
+        {"status": "queued", "scan_id": None, "requested_at": datetime.now(UTC)},
         {"status": "scanning", "scan_id": None},
         {
             "status": "scanning",
@@ -399,7 +474,7 @@ def test_reading_a_scanning_row_resumes_its_poll(monkeypatch):
             "completed_at": datetime(2026, 8, 8, 12, 30, 0, tzinfo=UTC),
         },
     ],
-    ids=["sent", "failed", "queued-no-scan", "scanning-no-scan-id", "already-completed"],
+    ids=["sent", "failed", "queued-not-yet-stale", "scanning-no-scan-id", "already-completed"],
 )
 def test_a_row_that_is_not_mid_scan_is_never_resumed(monkeypatch, overrides):
     _install_db(monkeypatch, [_row(**overrides)])

--- a/consent-protocol/tests/test_ria_dossier_routes.py
+++ b/consent-protocol/tests/test_ria_dossier_routes.py
@@ -32,7 +32,7 @@ from fastapi.testclient import TestClient
 # resolve to the real, rate-limiting one instead of the no-op double.
 _real_rate_limit_module = importlib.import_module("api.middlewares.rate_limit")
 
-rate_limit_module = types.ModuleType("api.middlewares.rate_limit")
+_fake_rate_limit_module = types.ModuleType("api.middlewares.rate_limit")
 
 
 class _NoopLimiter:
@@ -43,13 +43,25 @@ class _NoopLimiter:
         return decorator
 
 
-rate_limit_module.limiter = _NoopLimiter()  # type: ignore[attr-defined]
-rate_limit_module.RateLimits = _real_rate_limit_module.RateLimits  # type: ignore[attr-defined]
-sys.modules["api.middlewares.rate_limit"] = rate_limit_module
+_fake_rate_limit_module.limiter = _NoopLimiter()  # type: ignore[attr-defined]
+_fake_rate_limit_module.RateLimits = _real_rate_limit_module.RateLimits  # type: ignore[attr-defined]
+
+# Swapped in only for the one import that reads it at decoration time, then put
+# straight back. sys.modules is process-global -- leaving the fake in place
+# would silently hand every OTHER test file that imports this module later in
+# the same pytest session a limiter with none of the real one's behaviour
+# (no `.enabled`, no `_TYPED_RATE_LIMIT_PATHS`), breaking tests that have
+# nothing to do with ria.py. What ria.py's own `from ... import limiter,
+# RateLimits` already bound into its own namespace is unaffected by restoring
+# this afterward -- that binding happened by value, at the line below.
+sys.modules["api.middlewares.rate_limit"] = _fake_rate_limit_module
+try:
+    from api.routes import ria as ria_module  # noqa: E402
+finally:
+    sys.modules["api.middlewares.rate_limit"] = _real_rate_limit_module
 
 import hushh_mcp.services.ria_dossier_service as dossier_module  # noqa: E402
 from api.middleware import require_firebase_auth  # noqa: E402
-from api.routes import ria as ria_module  # noqa: E402
 from hushh_mcp.services.ria_claim_service import RIAClaimService  # noqa: E402
 
 _TEST_UID = "user_dossier_routes_123"


### PR DESCRIPTION
## What was happening

The confirmation says "Your dossier is on its way to `<email>`" — proof a row was actually inserted with `status='queued'` — but the profile card never leaves "Preparing your dossier…" and nothing arrives.

## Root cause

`_resume_stalled_dossier` already exists for exactly this class of bug. Its own docstring says why: the worker is an in-process background task on a CPU-throttled Cloud Run service, and once an instance stops receiving requests its CPU is withdrawn, stranding whatever the task was doing mid-flight.

But it only ever checked for `status == "scanning"`. The **same** withdrawal can happen even earlier: `dispatch_after_claim`'s `asyncio.create_task()` is scheduled the instant the claim's HTTP response goes out, and if CPU is pulled before that task gets its first turn on the event loop — before it even reaches the first `_update_row` call that flips the row to `'scanning'` — the row is stranded in `'queued'` forever. The existing resume path had no branch that would ever look at it.

## The fix

A `queued` row has no `scan_id` yet, so there's nothing to resume a *poll* against — the worker has to re-enter from the start (resolve email, build the scan payload, start a fresh scan). That's exactly what `resume_scan_id=""` already does inside `_run_worker` — no new codepath needed, only a caller that reaches it.

Gated on a 90-second staleness threshold rather than resuming any queued row unconditionally: a request landing while the original dispatch is still genuinely resolving the recipient email and building the scan payload must not be raced into starting a second scan for the same row. 90s is generous next to the ~10s frontend poll interval and the handful of awaits a live worker makes before its first status write.

## Side-fix in the same file, flagged rather than hidden

The rate-limit middleware stub in `test_ria_dossier_routes.py` only faked `.limiter`, not `.RateLimits` — `ria.py`'s other routes read `RateLimits.*` constants at decoration time, so importing the route module under test raised `ImportError` before a single test could run. **Pre-existing on main**, unrelated to this fix, verified by reproducing it on a clean checkout — but it blocked verifying this change locally, so it needed fixing in the same pass. The real `RateLimits` class is imported alongside the no-op limiter rather than reinvented, so the constants can never drift from what the route module actually reads.

`test_ria_claim_flow.py` has the identical gap and was **not** touched here — out of scope for this fix.

## Test plan

- [x] Two new tests: a stale queued row (5 min old) resumes with `resume_scan_id=""`; a fresh queued row (5s old) is left alone.
- [x] The existing "never resumed" parametrize case for queued rows used the fixture's default `requested_at`, a fixed date now far enough in the past that it would legitimately trigger the new resume path — updated to a fresh timestamp, since it was actually testing "not yet stale."
- [x] `pytest tests/test_ria_dossier_routes.py` — 27/27 (was blocked entirely before the stub fix).
- [x] `pytest tests/test_ria_dossier_service.py tests/test_ria_dossier_email_service.py tests/test_ria_dossier_mail_contract.py tests/test_ria_claim_dossiers_migration.py` — 40/40.
- [x] `ruff check`, `ruff format --check`, `mypy` — clean.

Addresses #6035.
