### PR TITLE
fix(one): disable static caching for signed-in routes

### DIFF
--- a/hushh-webapp/__tests__/app/one-layout-cache.contract.test.ts
+++ b/hushh-webapp/__tests__/app/one-layout-cache.contract.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+describe("/one layout cache policy", () => {
+  it("keeps signed-in One routes out of static HTML caching", () => {
+    const source = readFileSync(
+      path.join(repoRoot, "app", "one", "layout.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain('export const dynamic = "force-dynamic"');
+    expect(source).toContain("export const revalidate = 0");
+  });
+});

--- a/hushh-webapp/app/one/layout.tsx
+++ b/hushh-webapp/app/one/layout.tsx
@@ -3,6 +3,9 @@ import type { ReactNode } from "react";
 import { OneAuthGate } from "./one-auth-gate";
 import { HushhIntroGate } from "@/components/app-ui/HushhIntroGate";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 export default function OneLayout({ children }: { children: ReactNode }) {
   // HushhIntroGate sits one level above OneAuthGate (and therefore above
   // VaultLockGuard and every other auth/vault guard). It does not just


### PR DESCRIPTION
## Summary
- force the shared `/one` layout to render dynamically so signed-in One pages do not ship year-long cacheable HTML
- add a small contract test locking the cache policy

## Verification
- `npm run test -- __tests__/app/one-layout-cache.contract.test.ts`
- `npm run typecheck`

## UAT note
Live UAT `/one` routes were returning `Cache-Control: s-maxage=31536000`, which can keep users on stale HTML after a successful deployment. This PR fixes that visibility path before the next UAT deploy.