### PR TITLE
fix(ria): keep marketplace detail modal below header

### DIFF
--- a/hushh-webapp/__tests__/app/marketplace/page-card-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/app/marketplace/page-card-layout.contract.test.ts
@@ -85,4 +85,17 @@ describe("marketplace client card layout contract", () => {
     expect(source).toContain('toast.success("Saved lead removed from the RIA deck.")');
     expect(source).not.toContain("localStorage.setItem(key, JSON.stringify([...savedInvestorLeads");
   });
+
+  it("keeps investor detail modal below the fixed Connect header", () => {
+    const source = readMarketplacePage();
+
+    expect(source).toContain(
+      'contentClassName="md:top-[calc(var(--top-shell-mask-visible-height)+1rem)] md:max-h-[calc(100dvh-var(--top-shell-mask-visible-height)-2rem)] md:translate-y-0"',
+    );
+    expect(source).toContain('selectedProfile?.kind === "investor" && selectedInvestor');
+    expect(source).toContain("Fit summary");
+    expect(source).toContain("Evidence");
+    expect(source).toContain("Save lead");
+    expect(source).toContain("View connections");
+  });
 });

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1703,6 +1703,7 @@ export default function MarketplacePage() {
             ? selectedAdvisor?.headline || RIA_COPY.connect.detail.description
             : selectedInvestor?.headline || RIA_COPY.connect.detail.description
         }
+        contentClassName="md:top-[calc(var(--top-shell-mask-visible-height)+1rem)] md:max-h-[calc(100dvh-var(--top-shell-mask-visible-height)-2rem)] md:translate-y-0"
       >
         <div className="space-y-4">
           {selectedProfile?.kind === "ria" && selectedRiaLoading ? (


### PR DESCRIPTION
## Summary

- Keeps the RIA Marketplace Connect investor detail modal below the fixed top app header on desktop.
- Uses the existing `--top-shell-mask-visible-height` top chrome token to set the desktop modal top and max-height.
- Adds a focused marketplace contract test confirming the modal keeps top clearance and still includes the investor title path, Fit summary, Evidence, Save lead, and View connections content.

## Root cause

`SettingsDetailPanel` uses the shared centered `DialogContent` primitive on desktop. That primitive positions itself at `top-[50%]` with `translate-y-[-50%]` against the full viewport. The Marketplace Connect page also has a fixed top header, so a tall investor detail modal can be centered into the header area and clip the title under the fixed chrome.

## Validation

- `npm.cmd test -- __tests__/app/marketplace/page-card-layout.contract.test.ts`
- `npx.cmd eslint app\marketplace\page.tsx __tests__\app\marketplace\page-card-layout.contract.test.ts --max-warnings=0`
- `npm.cmd run typecheck`
- `npm.cmd run verify:design-system`
- `npm.cmd run verify:docs`
- `npm.cmd run verify:cache`
- `git diff --check origin/main`

## Scope

No backend, API, saved-lead behavior, SEC evidence behavior, labels, actions, width, radius, shadow, or backdrop behavior changed.
