### PR TITLE
feat(ios): add Siri entry for One voice

### DIFF
--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -52,7 +52,7 @@ jobs:
     name: Build & upload iOS (UAT) to TestFlight
     runs-on: macos-15
     environment: uat
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     steps:
       - name: Assert manual dispatch originates from main
@@ -334,6 +334,42 @@ jobs:
             -scheme "${XCODE_SCHEME}" \
             -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm"
 
+      - name: Run native iOS unit tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          SIMULATOR_ID="$(python3 - <<'PY'
+          import json
+          import subprocess
+
+          payload = json.loads(
+              subprocess.check_output(
+                  ["xcrun", "simctl", "list", "devices", "available", "--json"],
+                  text=True,
+              )
+          )
+          for runtime, devices in payload.get("devices", {}).items():
+              if "iOS" not in runtime:
+                  continue
+              for device in devices:
+                  if device.get("isAvailable") and device.get("name", "").startswith("iPhone"):
+                      print(device["udid"])
+                      raise SystemExit(0)
+          raise SystemExit("No available iPhone Simulator is installed on the release runner.")
+          PY
+          )"
+          xcodebuild test \
+            -project "${XCODE_PROJECT}" \
+            -scheme "${XCODE_SCHEME}" \
+            -configuration Debug \
+            -destination "platform=iOS Simulator,id=${SIMULATOR_ID}" \
+            -derivedDataPath "${RUNNER_TEMP}/derived-data" \
+            -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm" \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
+            -only-testing:AppTests \
+            CODE_SIGNING_ALLOWED=NO
+
       - name: Archive
         shell: bash
         run: |
@@ -345,6 +381,7 @@ jobs:
             -configuration Release \
             -destination 'generic/platform=iOS' \
             -archivePath "${RUNNER_TEMP}/App.xcarchive" \
+            -derivedDataPath "${RUNNER_TEMP}/derived-data" \
             -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm" \
             -allowProvisioningUpdates \
             -authenticationKeyPath "${RUNNER_TEMP}/asc.p8" \

--- a/docs/guides/mobile/ship-ios-testflight.md
+++ b/docs/guides/mobile/ship-ios-testflight.md
@@ -37,6 +37,7 @@ NODE_OPTIONS=--max-old-space-size=8192 npm run ios:prepare:uat   # cap:build + c
 NEXT_BUILD = max(asc_latest_build(MARKETING_VERSION), pbxproj CURRENT_PROJECT_VERSION) + 1
 
 xcodebuild -resolvePackageDependencies -project ios/App/App.xcodeproj -scheme App -clonedSourcePackagesDirPath …
+xcodebuild test -project ios/App/App.xcodeproj -scheme App -only-testing:AppTests  # blocks upload on native unit failures
 xcodebuild archive        -allowProvisioningUpdates -authenticationKey{Path,ID,IssuerID} CURRENT_PROJECT_VERSION=$NEXT_BUILD
 xcodebuild -exportArchive -exportOptionsPlist ios/ExportOptions/AppStoreConnect.plist  # destination=upload → TestFlight
 ```
@@ -133,7 +134,8 @@ names into this runbook, and never infer production authority from UAT authoriza
 
 ## Verify (don't stop at "workflow green")
 
-1. Read the run's job summary: SHA, resolved marketing version and build number, upload vs dry run.
+1. Confirm the native `AppTests` release gate passed, then read the run's job summary: SHA,
+   resolved marketing version and build number, upload vs dry run.
 2. For a real run, confirm the resolved version/build appears in **TestFlight** for internal
    testers after Apple finishes processing (a few minutes), already compliant.
 3. On device: the TestFlight build boots against **UAT** backend — asserted by

--- a/docs/reference/mobile/capacitor-parity-audit.md
+++ b/docs/reference/mobile/capacitor-parity-audit.md
@@ -214,6 +214,10 @@ Native parity for authenticated flows now includes the verified phone mandate af
 - `/register-phone` is a contract route even though it bypasses the standard shell.
 - One Voice/Kai compatibility surfaces require native microphone permission metadata:
   `NSMicrophoneUsageDescription` on iOS and `android.permission.RECORD_AUDIO` on Android.
+- Siri/App Shortcuts is an explicit iOS system-surface specialization. Its
+  `HushhVoiceInvocation` bridge exposes metadata-only pending/claim/complete
+  handoff methods on iOS; Android and web return unsupported/no pending
+  invocation and do not create a parallel assistant integration.
 - One Location Agent requires foreground-only location parity:
   `NSLocationWhenInUseUsageDescription` on iOS,
   `android.permission.ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION` on

--- a/docs/reference/one/one-voice-runtime-architecture.md
+++ b/docs/reference/one/one-voice-runtime-architecture.md
@@ -41,6 +41,27 @@ flowchart TD
 
 ## Current Truth
 
+### Siri/App Shortcut entry adapter
+
+On iOS 16 and later, `TalkToHusshOneIntent` is an entry adapter into this
+runtime, not a second voice runtime. Siri or App Shortcuts foregrounds the
+UIKit/Capacitor app and enqueues one five-minute metadata-only invocation:
+`{id, kind, source, createdAt, expiresAt}`. The native bridge retains that
+request through ordinary cold launch and Hussh sign-in, then the app-level
+handoff waits for foreground visibility, restored authentication, resolved
+route context, the redacted runtime snapshot, and the persistent Agent Bar
+owner. The Agent Bar alone acquires the existing voice lease, microphone,
+Gemini Live transport, relay ticket, WebSocket, context, consent, capture, and
+playback paths.
+
+The adapter does not forward Siri's utterance, force a route, require vault
+unlock, or create an action id. A signed-in but locked account begins in the
+existing `signed_locked` tier, where sensitive tools continue to fail closed.
+Invocation ids are coalesced and claimed exactly once; a transport failure
+reveals the existing Talk to One control as a tap fallback but fails the
+automatic-start release gate. Android and web deliberately report this Apple
+system surface as unsupported/no pending invocation.
+
 ### Route orchestration index
 
 `contracts/kai/one-route-orchestration-index.v1.json` is generated from the

--- a/hushh-webapp/__tests__/agent/siri-one-voice-handoff-component.test.tsx
+++ b/hushh-webapp/__tests__/agent/siri-one-voice-handoff-component.test.tsx
@@ -1,0 +1,204 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: { user: { uid: "user-1" } as { uid: string } | null, loading: false },
+  runtime: {
+    oneVoiceContextSnapshot: { screen: "one_agents" } as object | null,
+    tier: "signed_locked" as "signed_locked" | "signed_unlocked" | null,
+  },
+  pathname: "/one",
+  search: "",
+  visible: true,
+  push: vi.fn(),
+  getPendingInvocation: vi.fn(),
+  claimInvocation: vi.fn(),
+  completeInvocation: vi.fn(),
+  addAvailabilityListener: vi.fn(),
+  removeAvailabilityListener: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mocks.pathname,
+  useRouter: () => ({ push: mocks.push }),
+  useSearchParams: () => new URLSearchParams(mocks.search),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => mocks.auth,
+}));
+
+vi.mock("@/lib/agent/agent-runtime-context", () => ({
+  useAgentRuntimeStateOptional: () => mocks.runtime,
+}));
+
+vi.mock("@/lib/capacitor/one-voice-invocation", () => ({
+  OneVoiceInvocationBridge: {
+    isSupported: () => true,
+    getPendingInvocation: mocks.getPendingInvocation,
+    claimInvocation: mocks.claimInvocation,
+    completeInvocation: mocks.completeInvocation,
+    addAvailabilityListener: mocks.addAvailabilityListener,
+  },
+}));
+
+vi.mock("@/lib/navigation/kai-bottom-chrome-visibility", () => ({
+  snapKaiBottomChromeVisible: vi.fn(),
+}));
+
+import { SiriOneVoiceHandoff } from "@/components/agent/siri-one-voice-handoff";
+import {
+  AGENT_CONVERSATION_REQUEST_EVENT,
+  acknowledgeAgentConversation,
+  markAgentConversationOwnerReady,
+  resetAgentConversationBrokerForTests,
+} from "@/lib/agent/agent-voice-settings";
+
+function invocation(overrides: Partial<{
+  id: string;
+  createdAt: number;
+  expiresAt: number;
+}> = {}) {
+  const now = Date.now();
+  return {
+    id: overrides.id ?? "siri-request-1",
+    kind: "start_one_voice" as const,
+    source: "siri_app_shortcut" as const,
+    createdAt: overrides.createdAt ?? now,
+    expiresAt: overrides.expiresAt ?? now + 300_000,
+  };
+}
+
+describe("SiriOneVoiceHandoff lifecycle", () => {
+  let markOwnerUnavailable: (() => void) | null = null;
+
+  beforeEach(() => {
+    resetAgentConversationBrokerForTests();
+    markOwnerUnavailable = markAgentConversationOwnerReady();
+    mocks.auth = { user: { uid: "user-1" }, loading: false };
+    mocks.runtime = {
+      oneVoiceContextSnapshot: { screen: "one_agents" },
+      tier: "signed_locked",
+    };
+    mocks.pathname = "/one";
+    mocks.search = "";
+    mocks.visible = true;
+    mocks.push.mockReset();
+    mocks.getPendingInvocation.mockReset();
+    mocks.claimInvocation.mockReset();
+    mocks.completeInvocation.mockReset();
+    mocks.addAvailabilityListener.mockReset();
+    mocks.removeAvailabilityListener.mockReset();
+    mocks.claimInvocation.mockResolvedValue({ claimed: true });
+    mocks.completeInvocation.mockResolvedValue(undefined);
+    mocks.addAvailabilityListener.mockResolvedValue({
+      remove: mocks.removeAvailabilityListener,
+    });
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => (mocks.visible ? "visible" : "hidden"),
+    });
+  });
+
+  afterEach(() => {
+    markOwnerUnavailable?.();
+    markOwnerUnavailable = null;
+  });
+
+  it("routes an authenticated invocation into the existing Agent Bar exactly once", async () => {
+    const pending = invocation();
+    const received = vi.fn();
+    mocks.getPendingInvocation.mockResolvedValue(pending);
+    window.addEventListener(AGENT_CONVERSATION_REQUEST_EVENT, received);
+
+    render(<SiriOneVoiceHandoff />);
+
+    await waitFor(() =>
+      expect(mocks.claimInvocation).toHaveBeenCalledWith({ id: pending.id }),
+    );
+    expect(received).toHaveBeenCalledTimes(1);
+    expect((received.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      source: "siri_app_shortcut",
+      requestId: pending.id,
+    });
+
+    act(() => {
+      acknowledgeAgentConversation({
+        source: "siri_app_shortcut",
+        requestId: pending.id,
+        outcome: "accepted",
+      });
+    });
+    await waitFor(() =>
+      expect(mocks.completeInvocation).toHaveBeenCalledWith({
+        id: pending.id,
+        outcome: "accepted",
+      }),
+    );
+    expect(mocks.claimInvocation).toHaveBeenCalledTimes(1);
+    window.removeEventListener(AGENT_CONVERSATION_REQUEST_EVENT, received);
+  });
+
+  it("waits in the background and dispatches when the open app becomes active", async () => {
+    const pending = invocation({ id: "background-request" });
+    mocks.visible = false;
+    mocks.getPendingInvocation.mockResolvedValue(pending);
+
+    render(<SiriOneVoiceHandoff />);
+    await waitFor(() => expect(mocks.getPendingInvocation).toHaveBeenCalled());
+    expect(mocks.claimInvocation).not.toHaveBeenCalled();
+
+    act(() => {
+      mocks.visible = true;
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() =>
+      expect(mocks.claimInvocation).toHaveBeenCalledWith({ id: pending.id }),
+    );
+  });
+
+  it("survives an expired Hussh session, preserves the route, and resumes after login", async () => {
+    const pending = invocation({ id: "session-restore-request" });
+    mocks.auth = { user: null, loading: false };
+    mocks.pathname = "/one/location";
+    mocks.search = "view=people";
+    mocks.getPendingInvocation.mockResolvedValue(pending);
+
+    const view = render(<SiriOneVoiceHandoff />);
+    await waitFor(() =>
+      expect(mocks.push).toHaveBeenCalledWith(
+        "/login?redirect=%2Fone%2Flocation%3Fview%3Dpeople",
+      ),
+    );
+    expect(mocks.claimInvocation).not.toHaveBeenCalled();
+
+    mocks.auth = { user: { uid: "user-1" }, loading: false };
+    mocks.pathname = "/one/location";
+    mocks.search = "view=people";
+    view.rerender(<SiriOneVoiceHandoff />);
+
+    await waitFor(() =>
+      expect(mocks.claimInvocation).toHaveBeenCalledWith({ id: pending.id }),
+    );
+  });
+
+  it("expires a stale cold-launch record without starting voice", async () => {
+    const pending = invocation({
+      id: "expired-request",
+      createdAt: Date.now() - 301_000,
+      expiresAt: Date.now() - 1_000,
+    });
+    mocks.getPendingInvocation.mockResolvedValue(pending);
+
+    render(<SiriOneVoiceHandoff />);
+
+    await waitFor(() =>
+      expect(mocks.completeInvocation).toHaveBeenCalledWith({
+        id: pending.id,
+        outcome: "expired",
+      }),
+    );
+    expect(mocks.claimInvocation).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/__tests__/agent/siri-one-voice-handoff.test.ts
+++ b/hushh-webapp/__tests__/agent/siri-one-voice-handoff.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AGENT_CONVERSATION_OUTCOME_EVENT,
+  AGENT_CONVERSATION_REQUEST_EVENT,
+  acknowledgeAgentConversation,
+  markAgentConversationOwnerReady,
+  requestAgentConversation,
+  resetAgentConversationBrokerForTests,
+} from "@/lib/agent/agent-voice-settings";
+import {
+  buildSiriOneVoiceLoginRoute,
+  resolveSiriOneVoiceHandoffState,
+} from "@/lib/agent/siri-one-voice-handoff-policy";
+
+const readyInput = {
+  now: 1_000,
+  expiresAt: 301_000,
+  visible: true,
+  authLoading: false,
+  signedIn: true,
+  pathname: "/one/location",
+  loginPath: "/login",
+  runtimeReady: true,
+  tier: "signed_locked" as const,
+  ownerReady: true,
+  voiceEnabled: true,
+};
+
+describe("Siri One Voice handoff", () => {
+  beforeEach(() => resetAgentConversationBrokerForTests());
+
+  it("waits for foreground, auth restoration, route, runtime, and Agent Bar ownership", () => {
+    expect(
+      resolveSiriOneVoiceHandoffState({ ...readyInput, visible: false }),
+    ).toBe("waiting_for_foreground");
+    expect(
+      resolveSiriOneVoiceHandoffState({ ...readyInput, authLoading: true }),
+    ).toBe("waiting_for_auth_restoration");
+    expect(
+      resolveSiriOneVoiceHandoffState({ ...readyInput, signedIn: false }),
+    ).toBe("waiting_for_auth");
+    expect(
+      resolveSiriOneVoiceHandoffState({ ...readyInput, pathname: "/login" }),
+    ).toBe("waiting_for_route");
+    expect(
+      resolveSiriOneVoiceHandoffState({ ...readyInput, runtimeReady: false }),
+    ).toBe("waiting_for_runtime");
+    expect(
+      resolveSiriOneVoiceHandoffState({ ...readyInput, ownerReady: false }),
+    ).toBe("waiting_for_owner");
+  });
+
+  it("preserves a protected route through an expired-session login", () => {
+    expect(
+      buildSiriOneVoiceLoginRoute({
+        currentRoute: "/one/location?view=people",
+        loginPath: "/login",
+        publicHomePath: "/",
+      }),
+    ).toBe("/login?redirect=%2Fone%2Flocation%3Fview%3Dpeople");
+    expect(
+      buildSiriOneVoiceLoginRoute({
+        currentRoute: "/",
+        loginPath: "/login",
+        publicHomePath: "/",
+      }),
+    ).toBe("/login");
+  });
+
+  it("allows signed-locked voice without widening vault authority", () => {
+    expect(resolveSiriOneVoiceHandoffState(readyInput)).toBe("dispatch");
+    expect(
+      resolveSiriOneVoiceHandoffState({
+        ...readyInput,
+        tier: "signed_unlocked",
+      }),
+    ).toBe("dispatch");
+  });
+
+  it("rejects expired and kill-switched invocations", () => {
+    expect(
+      resolveSiriOneVoiceHandoffState({
+        ...readyInput,
+        expiresAt: readyInput.now,
+      }),
+    ).toBe("expired");
+    expect(
+      resolveSiriOneVoiceHandoffState({ ...readyInput, voiceEnabled: false }),
+    ).toBe("voice_disabled");
+  });
+
+  it("queues one request until the sole owner mounts", async () => {
+    const received = vi.fn();
+    window.addEventListener(AGENT_CONVERSATION_REQUEST_EVENT, received);
+
+    expect(
+      requestAgentConversation({
+        source: "siri_app_shortcut",
+        requestId: "siri-1",
+      }),
+    ).toBe("queued");
+    markAgentConversationOwnerReady();
+    await Promise.resolve();
+
+    expect(received).toHaveBeenCalledTimes(1);
+    expect((received.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      source: "siri_app_shortcut",
+      requestId: "siri-1",
+    });
+    window.removeEventListener(AGENT_CONVERSATION_REQUEST_EVENT, received);
+  });
+
+  it("coalesces duplicate ids while preserving no-argument callers", () => {
+    markAgentConversationOwnerReady();
+    const received = vi.fn();
+    window.addEventListener(AGENT_CONVERSATION_REQUEST_EVENT, received);
+
+    expect(
+      requestAgentConversation({
+        source: "siri_app_shortcut",
+        requestId: "same",
+      }),
+    ).toBe("dispatched");
+    expect(
+      requestAgentConversation({
+        source: "siri_app_shortcut",
+        requestId: "same",
+      }),
+    ).toBe("duplicate");
+    expect(requestAgentConversation()).toBe("dispatched");
+    expect(received).toHaveBeenCalledTimes(2);
+    expect((received.mock.calls[1][0] as CustomEvent).detail).toEqual({
+      source: "agent_chat",
+      requestId: undefined,
+    });
+    window.removeEventListener(AGENT_CONVERSATION_REQUEST_EVENT, received);
+  });
+
+  it("emits one correlated terminal acknowledgement", () => {
+    const received = vi.fn();
+    window.addEventListener(AGENT_CONVERSATION_OUTCOME_EVENT, received);
+    acknowledgeAgentConversation({
+      source: "siri_app_shortcut",
+      requestId: "siri-2",
+      outcome: "accepted",
+    });
+    expect((received.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      source: "siri_app_shortcut",
+      requestId: "siri-2",
+      outcome: "accepted",
+    });
+    window.removeEventListener(AGENT_CONVERSATION_OUTCOME_EVENT, received);
+  });
+});

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -27,6 +27,7 @@ import { AppEdgeBackGesture } from "@/components/app-ui/app-edge-back-gesture";
 import { TopShellRouteSwipe } from "@/components/app-ui/top-shell-route-swipe";
 import { AgentPopoverProvider } from "@/components/agent/agent-popover-provider";
 import { AgentRuntimeStateProvider } from "@/lib/agent/agent-runtime-context";
+import { SiriOneVoiceHandoff } from "@/components/agent/siri-one-voice-handoff";
 import { AgentVoiceEdgeGlow } from "@/components/agent/agent-voice-edge-glow";
 import { FoundationPublicAmbient } from "@/components/app-ui/foundation-public-ambient";
 import { AppBottomShell } from "@/components/app-ui/app-bottom-shell";
@@ -474,6 +475,7 @@ function AppShellFrame({ children }: ProvidersProps) {
         <VaultProvider>
           <AgentRuntimeStateProvider>
             <AgentPopoverProvider>
+              <SiriOneVoiceHandoff />
               <NativeTestRouter />
               <NativeTestBootstrap />
               <NativeTestRouteStatus />

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -50,7 +50,12 @@ import {
   getAgentVoiceStatusLabel,
   useAgentVoiceState,
 } from "@/lib/agent/agent-voice-state";
-import { AGENT_CONVERSATION_REQUEST_EVENT } from "@/lib/agent/agent-voice-settings";
+import {
+  AGENT_CONVERSATION_REQUEST_EVENT,
+  acknowledgeAgentConversation,
+  markAgentConversationOwnerReady,
+  type AgentConversationRequest,
+} from "@/lib/agent/agent-voice-settings";
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 import { validateMorphyAxAssessment } from "@/lib/morphy-ax";
 import { snapKaiBottomChromeVisible } from "@/lib/navigation/kai-bottom-chrome-visibility";
@@ -372,6 +377,25 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   const activeRuntimeModeRef = useRef<"hushh_managed_vertex" | "byok" | null>(null);
   const lastTranscriptRef = useRef<{ text: string; atMs: number } | null>(null);
   const prewarmedRelayRef = useRef<PrewarmedGeminiRelay | null>(null);
+  // A system invocation can only request this existing owner. Correlation
+  // metadata stays in memory until the Live transport either listens or fails.
+  const externalStartRequestRef = useRef<AgentConversationRequest | null>(null);
+  const finishExternalStart = useCallback((outcome: "accepted" | "failed") => {
+    const request = externalStartRequestRef.current;
+    if (!request?.requestId || request.source !== "siri_app_shortcut") return;
+    externalStartRequestRef.current = null;
+    acknowledgeAgentConversation({
+      source: "siri_app_shortcut",
+      requestId: request.requestId,
+      outcome,
+    });
+    if (outcome === "failed") {
+      snapKaiBottomChromeVisible();
+      console.info(
+        `[SIRI_ONE_VOICE] state=fallback_shown request_id=${request.requestId} source=siri_app_shortcut outcome=failed`,
+      );
+    }
+  }, []);
 
   // Test-only dispatch entry point: invokes the same pure execution boundary a
   // real Gemini tool-call reaches, but skips the confirmation card and journey
@@ -586,6 +610,9 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
         if (status !== "idle") {
           setVoiceStatus(status, event.message ?? null, eventOptions);
         }
+        if (status === "listening") {
+          finishExternalStart("accepted");
+        }
         return;
       }
       if (event.type === "input_level") {
@@ -611,6 +638,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
         erroredRef.current = true;
         lastErrorResumableRef.current = event.resumable === true;
         setVoiceStatus("error", event.message, eventOptions);
+        finishExternalStart("failed");
         return;
       }
       if (event.type === "assistant_text") {
@@ -1307,6 +1335,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       switchPersona,
       user?.uid,
       vaultOwnerToken,
+      finishExternalStart,
     ],
   );
 
@@ -1597,16 +1626,32 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
     );
   }, [abandonPendingConfirmation, pathname]);
 
-  const startConversation = useCallback(async () => {
+  const startConversation = useCallback(async (externalRequest?: AgentConversationRequest) => {
+    const isSiriRequest =
+      externalRequest?.source === "siri_app_shortcut" &&
+      Boolean(externalRequest.requestId);
     // Toggle off when a session (live OR an error still on screen) exists.
     if (voiceLeaseRef.current && !liveClientRef.current && !conversationActive) {
       // A second native tap while credentials are resolving is the same start
       // request, not a toggle. Coalesce it so one mic/socket survives.
+      if (isSiriRequest) {
+        externalStartRequestRef.current = externalRequest ?? null;
+      }
       return;
     }
     if (liveClientRef.current || erroredRef.current || conversationActive) {
+      if (isSiriRequest) {
+        externalStartRequestRef.current = externalRequest ?? null;
+        finishExternalStart(
+          liveClientRef.current || conversationActive ? "accepted" : "failed",
+        );
+        return;
+      }
       stopConversation();
       return;
+    }
+    if (isSiriRequest) {
+      externalStartRequestRef.current = externalRequest ?? null;
     }
     const lease = appInteractionCoordinator.acquireVoiceLease({
       owner: "one_live",
@@ -1626,6 +1671,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       setVoiceStatus("error", "Your Gemini key is unavailable. Open Connections settings.");
       lease.release("missing_runtime_credential");
       voiceLeaseRef.current = null;
+      finishExternalStart("failed");
       return;
     }
     if (runtimeConnection.transport === "vertex_api_key") {
@@ -1636,6 +1682,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       );
       lease.release("unsupported_voice_transport");
       voiceLeaseRef.current = null;
+      finishExternalStart("failed");
       return;
     }
     erroredRef.current = false;
@@ -1686,7 +1733,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       runtimeVertexLocation: runtimeConnection.vertexLocation,
       resumptionHandle,
       voiceName: readVoicePreferences(user?.uid).voiceName,
-    });
+    }).catch(() => finishExternalStart("failed"));
   }, [
     conversationActive,
     runtime?.oneVoiceContextSnapshot,
@@ -1698,6 +1745,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
     vaultKey,
     user?.uid,
     setVoiceStatus,
+    finishExternalStart,
   ]);
 
   // Retrying from an error is stop-then-start, but not in the same tick:
@@ -1777,14 +1825,19 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   );
 
   useEffect(() => {
-    const handleConversationRequest = () => {
-      void startConversation();
+    const handleConversationRequest = (event: Event) => {
+      const request = (event as CustomEvent<AgentConversationRequest>).detail;
+      void startConversation(
+        request?.source === "siri_app_shortcut" ? request : undefined,
+      );
     };
     window.addEventListener(
       AGENT_CONVERSATION_REQUEST_EVENT,
       handleConversationRequest,
     );
+    const markUnavailable = markAgentConversationOwnerReady();
     return () => {
+      markUnavailable();
       window.removeEventListener(
         AGENT_CONVERSATION_REQUEST_EVENT,
         handleConversationRequest,

--- a/hushh-webapp/components/agent/siri-one-voice-handoff.tsx
+++ b/hushh-webapp/components/agent/siri-one-voice-handoff.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { useAuth } from "@/hooks/use-auth";
+import {
+  OneVoiceInvocationBridge,
+  type OneVoiceInvocationOutcome,
+  type PendingOneVoiceInvocation,
+} from "@/lib/capacitor/one-voice-invocation";
+import { useAgentRuntimeStateOptional } from "@/lib/agent/agent-runtime-context";
+import {
+  AGENT_CONVERSATION_OUTCOME_EVENT,
+  AGENT_CONVERSATION_READY_EVENT,
+  isAgentConversationOwnerReady,
+  isAgentGeminiVoiceEnabled,
+  requestAgentConversation,
+  type AgentConversationOutcome,
+} from "@/lib/agent/agent-voice-settings";
+import { ROUTES } from "@/lib/navigation/routes";
+import { snapKaiBottomChromeVisible } from "@/lib/navigation/kai-bottom-chrome-visibility";
+import {
+  buildSiriOneVoiceLoginRoute,
+  resolveSiriOneVoiceHandoffState,
+} from "@/lib/agent/siri-one-voice-handoff-policy";
+
+const ACCEPTANCE_TIMEOUT_MS = 30_000;
+
+function logLifecycle(
+  state: string,
+  invocation: PendingOneVoiceInvocation,
+  outcome?: string,
+): void {
+  console.info(
+    `[SIRI_ONE_VOICE] state=${state} request_id=${invocation.id} source=${invocation.source} outcome=${outcome ?? "none"} duration_ms=${Math.max(0, Date.now() - invocation.createdAt)}`,
+  );
+}
+
+/**
+ * Metadata-only adapter from Apple's system surface to the existing Agent Bar.
+ * It owns no microphone, transcript, route registry, voice model, or action.
+ */
+export function SiriOneVoiceHandoff(): null {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { user, loading: authLoading } = useAuth();
+  const runtime = useAgentRuntimeStateOptional();
+  const [pending, setPending] = useState<PendingOneVoiceInvocation | null>(
+    null,
+  );
+  const [ownerRevision, setOwnerRevision] = useState(0);
+  const [visibilityRevision, setVisibilityRevision] = useState(0);
+  const claimedRef = useRef<PendingOneVoiceInvocation | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const waitingForAuthLoggedRef = useRef<string | null>(null);
+
+  const clearTimeoutIfNeeded = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = null;
+  }, []);
+
+  const complete = useCallback(
+    async (
+      invocation: PendingOneVoiceInvocation,
+      outcome: OneVoiceInvocationOutcome,
+    ) => {
+      clearTimeoutIfNeeded();
+      await OneVoiceInvocationBridge.completeInvocation({
+        id: invocation.id,
+        outcome,
+      }).catch(() => undefined);
+      logLifecycle(outcome, invocation, outcome);
+      if (claimedRef.current?.id === invocation.id) claimedRef.current = null;
+      setPending((current) => (current?.id === invocation.id ? null : current));
+    },
+    [clearTimeoutIfNeeded],
+  );
+
+  const refreshPending = useCallback(async () => {
+    const invocation =
+      await OneVoiceInvocationBridge.getPendingInvocation().catch(() => null);
+    if (invocation) logLifecycle("bridge_ready", invocation);
+    setPending(invocation);
+  }, []);
+
+  useEffect(() => {
+    if (!OneVoiceInvocationBridge.isSupported()) return undefined;
+    let cancelled = false;
+    let removeListener: (() => Promise<void>) | null = null;
+    void refreshPending();
+    void OneVoiceInvocationBridge.addAvailabilityListener((invocation) => {
+      if (cancelled) return;
+      logLifecycle("foregrounded", invocation);
+      setPending(invocation);
+    }).then((handle) => {
+      if (cancelled) void handle.remove();
+      else removeListener = () => handle.remove();
+    });
+    return () => {
+      cancelled = true;
+      clearTimeoutIfNeeded();
+      void removeListener?.();
+    };
+  }, [clearTimeoutIfNeeded, refreshPending]);
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      setVisibilityRevision((current) => current + 1);
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, []);
+
+  useEffect(() => {
+    const onReady = () => {
+      setOwnerRevision((current) => current + 1);
+      void refreshPending();
+    };
+    window.addEventListener(AGENT_CONVERSATION_READY_EVENT, onReady);
+    return () =>
+      window.removeEventListener(AGENT_CONVERSATION_READY_EVENT, onReady);
+  }, [refreshPending]);
+
+  useEffect(() => {
+    const onOutcome = (event: Event) => {
+      const outcome = (event as CustomEvent<AgentConversationOutcome>).detail;
+      const invocation = claimedRef.current;
+      if (!invocation || outcome?.requestId !== invocation.id) return;
+      void complete(invocation, outcome.outcome);
+    };
+    window.addEventListener(AGENT_CONVERSATION_OUTCOME_EVENT, onOutcome);
+    return () =>
+      window.removeEventListener(AGENT_CONVERSATION_OUTCOME_EVENT, onOutcome);
+  }, [complete]);
+
+  useEffect(() => {
+    if (!pending || claimedRef.current) return;
+    const state = resolveSiriOneVoiceHandoffState({
+      now: Date.now(),
+      expiresAt: pending.expiresAt,
+      visible: document.visibilityState === "visible",
+      authLoading,
+      signedIn: Boolean(user),
+      pathname,
+      loginPath: ROUTES.LOGIN,
+      runtimeReady: Boolean(runtime?.oneVoiceContextSnapshot),
+      tier: runtime?.tier ?? null,
+      ownerReady: isAgentConversationOwnerReady(),
+      voiceEnabled: isAgentGeminiVoiceEnabled(),
+    });
+    if (state === "expired") {
+      void complete(pending, "expired");
+      return;
+    }
+    if (
+      state === "waiting_for_auth_restoration" ||
+      state === "waiting_for_auth"
+    ) {
+      if (waitingForAuthLoggedRef.current !== pending.id) {
+        waitingForAuthLoggedRef.current = pending.id;
+        logLifecycle("waiting_for_auth", pending);
+      }
+      if (state === "waiting_for_auth" && pathname !== ROUTES.LOGIN) {
+        const search = searchParams?.toString() ?? "";
+        const currentRoute = pathname
+          ? `${pathname}${search ? `?${search}` : ""}`
+          : null;
+        router.push(
+          buildSiriOneVoiceLoginRoute({
+            currentRoute,
+            loginPath: ROUTES.LOGIN,
+            publicHomePath: ROUTES.HOME,
+          }),
+        );
+      }
+      return;
+    }
+    if (state === "voice_disabled") {
+      void complete(pending, "failed");
+      return;
+    }
+    if (state !== "dispatch") return;
+
+    let cancelled = false;
+    void OneVoiceInvocationBridge.claimInvocation({ id: pending.id }).then(
+      ({ claimed }) => {
+        if (cancelled) return;
+        if (!claimed) {
+          void refreshPending();
+          return;
+        }
+        claimedRef.current = pending;
+        logLifecycle("dispatched", pending);
+        requestAgentConversation({
+          source: "siri_app_shortcut",
+          requestId: pending.id,
+        });
+        timeoutRef.current = setTimeout(() => {
+          const active = claimedRef.current;
+          if (!active || active.id !== pending.id) return;
+          snapKaiBottomChromeVisible();
+          logLifecycle("fallback_shown", active, "failed");
+          void complete(active, "failed");
+        }, ACCEPTANCE_TIMEOUT_MS);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    authLoading,
+    complete,
+    pathname,
+    ownerRevision,
+    pending,
+    refreshPending,
+    router,
+    runtime?.oneVoiceContextSnapshot,
+    runtime?.tier,
+    searchParams,
+    user,
+    visibilityRevision,
+  ]);
+
+  return null;
+}

--- a/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
@@ -29,6 +29,10 @@
 		A11C0A710000000000000072 /* LocationEnvelopeCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A710000000000000071 /* LocationEnvelopeCrypto.swift */; };
 		A11C0A710000000000000082 /* BackgroundLocationPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A710000000000000081 /* BackgroundLocationPublisher.swift */; };
 		A11C0A720000000000000062 /* HushhContactsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A720000000000000061 /* HushhContactsPlugin.swift */; };
+		A11C0A730000000000000011 /* OneVoiceAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A740000000000000001 /* OneVoiceAppIntent.swift */; };
+		A11C0A730000000000000012 /* OneVoiceInvocationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A730000000000000002 /* OneVoiceInvocationCoordinator.swift */; };
+		A11C0A730000000000000013 /* HushhVoiceInvocationPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A730000000000000003 /* HushhVoiceInvocationPlugin.swift */; };
+		A11C0A730000000000000022 /* OneVoiceInvocationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A730000000000000021 /* OneVoiceInvocationCoordinatorTests.swift */; };
 		A1B2C3D42F0E966A009FC3FD /* PersonalKnowledgeModelPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D52F0E966A009FC3FD /* PersonalKnowledgeModelPlugin.swift */; };
 		A2774DC0614D2A490F85042E /* HushhConsentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D0CE383269D3D6B23A9A02 /* HushhConsentPlugin.swift */; };
 		ABCDEF000000000000000002 /* HusshIMessageSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF000000000000000001 /* HusshIMessageSessionStore.swift */; };
@@ -93,6 +97,10 @@
 		A11C0A710000000000000071 /* LocationEnvelopeCrypto.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocationEnvelopeCrypto.swift; path = Plugins/LocationEnvelopeCrypto.swift; sourceTree = "<group>"; };
 		A11C0A710000000000000081 /* BackgroundLocationPublisher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BackgroundLocationPublisher.swift; path = Plugins/BackgroundLocationPublisher.swift; sourceTree = "<group>"; };
 		A11C0A720000000000000061 /* HushhContactsPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HushhContactsPlugin.swift; path = Plugins/HushhContactsPlugin.swift; sourceTree = "<group>"; };
+		A11C0A740000000000000001 /* OneVoiceAppIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OneVoiceAppIntent.swift; sourceTree = "<group>"; };
+		A11C0A730000000000000002 /* OneVoiceInvocationCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OneVoiceInvocationCoordinator.swift; sourceTree = "<group>"; };
+		A11C0A730000000000000003 /* HushhVoiceInvocationPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HushhVoiceInvocationPlugin.swift; path = Plugins/HushhVoiceInvocationPlugin.swift; sourceTree = "<group>"; };
+		A11C0A730000000000000021 /* OneVoiceInvocationCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OneVoiceInvocationCoordinatorTests.swift; sourceTree = "<group>"; };
 		A1B2C3D52F0E966A009FC3FD /* PersonalKnowledgeModelPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PersonalKnowledgeModelPlugin.swift; path = Plugins/PersonalKnowledgeModelPlugin.swift; sourceTree = "<group>"; };
 		A280438C2F21B1FC005B42F3 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		ABCDEF000000000000000001 /* HusshIMessageSessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HusshIMessageSessionStore.swift; path = Plugins/HusshIMessageSessionStore.swift; sourceTree = "<group>"; };
@@ -173,6 +181,8 @@
 				A280438C2F21B1FC005B42F3 /* App.entitlements */,
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
+				A11C0A740000000000000001 /* OneVoiceAppIntent.swift */,
+				A11C0A730000000000000002 /* OneVoiceInvocationCoordinator.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -202,6 +212,7 @@
 			children = (
 				844A95957616D891DBC4D212 /* NativeSupportTests.swift */,
 				A11C0A710000000000000091 /* LocationEnvelopeCryptoTests.swift */,
+				A11C0A730000000000000021 /* OneVoiceInvocationCoordinatorTests.swift */,
 			);
 			path = AppTests;
 			sourceTree = "<group>";
@@ -225,6 +236,7 @@
 				A11C0A710000000000000071 /* LocationEnvelopeCrypto.swift */,
 				A11C0A710000000000000081 /* BackgroundLocationPublisher.swift */,
 				A11C0A720000000000000061 /* HushhContactsPlugin.swift */,
+				A11C0A730000000000000003 /* HushhVoiceInvocationPlugin.swift */,
 			);
 			name = Plugins;
 			sourceTree = "<group>";
@@ -407,6 +419,7 @@
 			files = (
 				FEBC1F9C14F1FB5C3D876D51 /* NativeSupportTests.swift in Sources */,
 				A11C0A710000000000000092 /* LocationEnvelopeCryptoTests.swift in Sources */,
+				A11C0A730000000000000022 /* OneVoiceInvocationCoordinatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -415,6 +428,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				A11C0A730000000000000011 /* OneVoiceAppIntent.swift in Sources */,
+				A11C0A730000000000000012 /* OneVoiceInvocationCoordinator.swift in Sources */,
+				A11C0A730000000000000013 /* HushhVoiceInvocationPlugin.swift in Sources */,
 				ABCDEF000000000000000002 /* HusshIMessageSessionStore.swift in Sources */,
 				D1F9F9122F0E966A009FC3FB /* KaiPlugin.swift in Sources */,
 				4DDFEE23E895EA15BE093A8C /* MyViewController.swift in Sources */,

--- a/hushh-webapp/ios/App/App/AppDelegate.swift
+++ b/hushh-webapp/ios/App/App/AppDelegate.swift
@@ -6,6 +6,9 @@ import FirebaseMessaging
 import GoogleSignIn
 import UserNotifications
 import AVFoundation
+#if canImport(AppIntents)
+import AppIntents
+#endif
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -21,6 +24,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private let nativeTestConfig = NativeTestConfiguration()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+#if canImport(AppIntents)
+        if #available(iOS 16.0, *) {
+            HusshOneAppShortcuts.updateAppShortcutParameters()
+        }
+#endif
         // Ensure Firebase is initialized once for native plugins and auth flows.
         // `FirebaseApp.app()` logs an error when no default app exists, even
         // when that is the normal first-launch state. Inspect the registry so
@@ -99,6 +107,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
         logNotificationSettings(context: "applicationDidBecomeActive")
+        OneVoiceInvocationCoordinator.shared.publishAvailability(state: "foregrounded")
     }
 
     func applicationWillTerminate(_ application: UIApplication) {

--- a/hushh-webapp/ios/App/App/MyViewController.swift
+++ b/hushh-webapp/ios/App/App/MyViewController.swift
@@ -142,8 +142,9 @@ class MyViewController: CAPBridgeViewController, WKScriptMessageHandler {
         bridge?.registerPluginInstance(HushhNotificationsPlugin())
         bridge?.registerPluginInstance(HushhLocationPlugin())
         bridge?.registerPluginInstance(HushhContactsPlugin())
+        bridge?.registerPluginInstance(HushhVoiceInvocationPlugin())
         
-        print("✅ [MyViewController] All 12 plugins registered successfully:")
+        print("✅ [MyViewController] All 13 plugins registered successfully:")
         print("   - HushhAuth (Google Sign-In)")
         print("   - HushhVault (Encryption + Cloud DB)")
         print("   - HushhConsent (Token Management)")
@@ -156,6 +157,7 @@ class MyViewController: CAPBridgeViewController, WKScriptMessageHandler {
         print("   - HushhNotifications (Push Token Registration)")
         print("   - HushhLocation (Foreground Location)")
         print("   - HushhContacts (Contact Matching)")
+        print("   - HushhVoiceInvocation (Siri/App Shortcut handoff)")
         
         // Verify plugins are actually accessible by the bridge
         verifyPluginRegistration()
@@ -177,7 +179,8 @@ class MyViewController: CAPBridgeViewController, WKScriptMessageHandler {
             "HushhAccount",
             "HushhNotifications",
             "HushhLocation",
-            "HushhContacts"
+            "HushhContacts",
+            "HushhVoiceInvocation"
         ]
         
         for name in pluginNames {

--- a/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
+++ b/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
@@ -1,0 +1,41 @@
+#if canImport(AppIntents)
+import AppIntents
+
+@available(iOS 16.0, *)
+struct TalkToHusshOneIntent: AppIntent {
+    static let title: LocalizedStringResource = "Talk to One"
+    static let description = IntentDescription(
+        "Open Hussh One and begin a conversation with your private agent."
+    )
+    static let authenticationPolicy: IntentAuthenticationPolicy =
+        .requiresLocalDeviceAuthentication
+
+    // AppIntent uses this on iOS 16-25. iOS 26 uses supportedModes below.
+    static let openAppWhenRun = true
+
+    @available(iOS 26.0, *)
+    static let supportedModes: IntentModes = [.foreground(.immediate)]
+
+    func perform() async throws -> some IntentResult {
+        OneVoiceInvocationCoordinator.shared.enqueue()
+        return .result()
+    }
+}
+
+@available(iOS 16.0, *)
+struct HusshOneAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: TalkToHusshOneIntent(),
+            phrases: [
+                "Talk to \(.applicationName)",
+                "Ask \(.applicationName)"
+            ],
+            shortTitle: "Talk to One",
+            systemImageName: "waveform.circle.fill"
+        )
+    }
+
+    static let shortcutTileColor: ShortcutTileColor = .navy
+}
+#endif

--- a/hushh-webapp/ios/App/App/OneVoiceInvocationCoordinator.swift
+++ b/hushh-webapp/ios/App/App/OneVoiceInvocationCoordinator.swift
@@ -1,0 +1,214 @@
+import Foundation
+import OSLog
+
+struct PendingOneVoiceInvocation: Codable, Equatable, Sendable {
+    static let supportedKind = "start_one_voice"
+    static let supportedSource = "siri_app_shortcut"
+
+    let id: String
+    let kind: String
+    let source: String
+    let createdAt: Date
+    let expiresAt: Date
+
+    init(id: String = UUID().uuidString, createdAt: Date, expiresAt: Date) {
+        self.id = id
+        self.kind = Self.supportedKind
+        self.source = Self.supportedSource
+        self.createdAt = createdAt
+        self.expiresAt = expiresAt
+    }
+
+    var bridgePayload: [String: Any] {
+        [
+            "id": id,
+            "kind": kind,
+            "source": source,
+            "createdAt": Int64(createdAt.timeIntervalSince1970 * 1_000),
+            "expiresAt": Int64(expiresAt.timeIntervalSince1970 * 1_000)
+        ]
+    }
+}
+
+extension Notification.Name {
+    static let oneVoiceInvocationAvailable = Notification.Name(
+        "ai.hushh.one.voice-invocation-available"
+    )
+}
+
+/// The only persisted Siri state. The Codable envelope is deliberately closed:
+/// no initializer accepts a prompt, route, account identifier, or credential.
+final class OneVoiceInvocationCoordinator: @unchecked Sendable {
+    static let shared = OneVoiceInvocationCoordinator()
+    static let ttl: TimeInterval = 5 * 60
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "ai.hushh.one",
+        category: "SiriOneVoice"
+    )
+
+    private let defaults: UserDefaults
+    private let storageKey: String
+    private let now: () -> Date
+    private let lock = NSLock()
+    private var claimedInvocations: [String: PendingOneVoiceInvocation] = [:]
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = "one.voice.pending-system-invocation.v1",
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+        self.now = now
+    }
+
+    @discardableResult
+    func enqueue() -> PendingOneVoiceInvocation {
+        let createdAt = now()
+        let invocation = PendingOneVoiceInvocation(
+            createdAt: createdAt,
+            expiresAt: createdAt.addingTimeInterval(Self.ttl)
+        )
+
+        lock.lock()
+        let replaced = readLocked()
+        writeLocked(invocation)
+        lock.unlock()
+
+        if let replaced {
+            Self.log(
+                state: "cancelled",
+                invocation: replaced,
+                outcome: "replaced"
+            )
+        }
+        publishAvailability(state: "requested")
+        return invocation
+    }
+
+    func pending() -> PendingOneVoiceInvocation? {
+        lock.lock()
+        guard let invocation = readLocked() else {
+            lock.unlock()
+            return nil
+        }
+        if invocation.expiresAt <= now() {
+            defaults.removeObject(forKey: storageKey)
+            lock.unlock()
+            Self.log(state: "expired", invocation: invocation, outcome: "expired")
+            return nil
+        }
+        lock.unlock()
+        return invocation
+    }
+
+    /// Claims and removes atomically. Once JavaScript receives `claimed=true`,
+    /// duplicate lifecycle/plugin events cannot dispatch the same microphone start.
+    func claim(id: String) -> Bool {
+        lock.lock()
+        guard let invocation = readLocked(), invocation.id == id else {
+            lock.unlock()
+            return false
+        }
+        if invocation.expiresAt <= now() {
+            defaults.removeObject(forKey: storageKey)
+            lock.unlock()
+            Self.log(state: "expired", invocation: invocation, outcome: "expired")
+            return false
+        }
+        defaults.removeObject(forKey: storageKey)
+        claimedInvocations[id] = invocation
+        lock.unlock()
+        Self.log(state: "dispatched", invocation: invocation, outcome: "claimed")
+        return true
+    }
+
+    func complete(id: String, outcome: String) {
+        lock.lock()
+        let pendingInvocation = readLocked()
+        let claimedInvocation = claimedInvocations.removeValue(forKey: id)
+        if pendingInvocation?.id == id {
+            defaults.removeObject(forKey: storageKey)
+        }
+        lock.unlock()
+
+        let safeOutcome = Self.allowedOutcomes.contains(outcome) ? outcome : "failed"
+        let invocation = claimedInvocation ?? pendingInvocation
+        if let invocation, invocation.id == id {
+            Self.log(state: safeOutcome, invocation: invocation, outcome: safeOutcome)
+        } else {
+            Self.logger.info(
+                "state=\(safeOutcome, privacy: .public) request_id=\(id, privacy: .public) source=\(PendingOneVoiceInvocation.supportedSource, privacy: .public)"
+            )
+        }
+    }
+
+    func cancelPending(outcome: String = "cancelled") {
+        lock.lock()
+        let invocation = readLocked()
+        let claimed = Array(claimedInvocations.values)
+        defaults.removeObject(forKey: storageKey)
+        claimedInvocations.removeAll()
+        lock.unlock()
+        if let invocation {
+            Self.log(state: "cancelled", invocation: invocation, outcome: outcome)
+        }
+        for invocation in claimed {
+            Self.log(state: "cancelled", invocation: invocation, outcome: outcome)
+        }
+    }
+
+    func publishAvailability(state: String) {
+        guard let invocation = pending() else { return }
+        Self.log(state: state, invocation: invocation)
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: .oneVoiceInvocationAvailable,
+                object: self
+            )
+        }
+    }
+
+    private func readLocked() -> PendingOneVoiceInvocation? {
+        guard let data = defaults.data(forKey: storageKey) else { return nil }
+        guard let invocation = try? JSONDecoder().decode(
+            PendingOneVoiceInvocation.self,
+            from: data
+        ) else {
+            defaults.removeObject(forKey: storageKey)
+            return nil
+        }
+        guard
+            invocation.kind == PendingOneVoiceInvocation.supportedKind,
+            invocation.source == PendingOneVoiceInvocation.supportedSource
+        else {
+            defaults.removeObject(forKey: storageKey)
+            return nil
+        }
+        return invocation
+    }
+
+    private func writeLocked(_ invocation: PendingOneVoiceInvocation) {
+        guard let data = try? JSONEncoder().encode(invocation) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+
+    private static let allowedOutcomes: Set<String> = [
+        "accepted", "failed", "expired", "cancelled", "fallback_shown"
+    ]
+
+    private static func log(
+        state: String,
+        invocation: PendingOneVoiceInvocation,
+        outcome: String? = nil
+    ) {
+        let durationMs = max(
+            0,
+            Int(Date().timeIntervalSince(invocation.createdAt) * 1_000)
+        )
+        logger.info(
+            "state=\(state, privacy: .public) request_id=\(invocation.id, privacy: .public) source=\(invocation.source, privacy: .public) outcome=\(outcome ?? "none", privacy: .public) duration_ms=\(durationMs, privacy: .public)"
+        )
+    }
+}

--- a/hushh-webapp/ios/App/App/Plugins/HushhAuthPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhAuthPlugin.swift
@@ -52,6 +52,7 @@ public class HushhAuthPlugin: CAPPlugin, CAPBridgedPlugin {
         ]
         SecItemDelete(query as CFDictionary)
         HusshIMessageSessionStore.shared.clearSilently()
+        OneVoiceInvocationCoordinator.shared.cancelPending(outcome: "sign_out")
     }
 
     private func keychainSet(_ value: String, forKey key: String) {

--- a/hushh-webapp/ios/App/App/Plugins/HushhVoiceInvocationPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhVoiceInvocationPlugin.swift
@@ -1,0 +1,76 @@
+import Capacitor
+import Foundation
+
+@objc(HushhVoiceInvocationPlugin)
+public final class HushhVoiceInvocationPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "HushhVoiceInvocationPlugin"
+    public let jsName = "HushhVoiceInvocation"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "getPendingInvocation", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "claimInvocation", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "completeInvocation", returnType: CAPPluginReturnPromise)
+    ]
+
+    private var availabilityObserver: NSObjectProtocol?
+
+    public override func load() {
+        availabilityObserver = NotificationCenter.default.addObserver(
+            forName: .oneVoiceInvocationAvailable,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.emitAvailability()
+        }
+        OneVoiceInvocationCoordinator.shared.publishAvailability(state: "bridge_ready")
+    }
+
+    deinit {
+        if let availabilityObserver {
+            NotificationCenter.default.removeObserver(availabilityObserver)
+        }
+    }
+
+    @objc func getPendingInvocation(_ call: CAPPluginCall) {
+        guard let invocation = OneVoiceInvocationCoordinator.shared.pending() else {
+            // Capacitor promise payloads are objects. The typed adapter maps an
+            // empty object to null so web and Android retain the same contract.
+            call.resolve([:])
+            return
+        }
+        call.resolve(invocation.bridgePayload)
+    }
+
+    @objc func claimInvocation(_ call: CAPPluginCall) {
+        guard let id = call.getString("id"), !id.isEmpty else {
+            call.reject("A non-empty invocation id is required.")
+            return
+        }
+        call.resolve([
+            "claimed": OneVoiceInvocationCoordinator.shared.claim(id: id)
+        ])
+    }
+
+    @objc func completeInvocation(_ call: CAPPluginCall) {
+        guard let id = call.getString("id"), !id.isEmpty else {
+            call.reject("A non-empty invocation id is required.")
+            return
+        }
+        guard let outcome = call.getString("outcome"), !outcome.isEmpty else {
+            call.reject("A completion outcome is required.")
+            return
+        }
+        OneVoiceInvocationCoordinator.shared.complete(id: id, outcome: outcome)
+        call.resolve()
+    }
+
+    private func emitAvailability() {
+        guard let invocation = OneVoiceInvocationCoordinator.shared.pending() else {
+            return
+        }
+        notifyListeners(
+            "voiceInvocationAvailable",
+            data: invocation.bridgePayload,
+            retainUntilConsumed: true
+        )
+    }
+}

--- a/hushh-webapp/ios/App/AppTests/OneVoiceInvocationCoordinatorTests.swift
+++ b/hushh-webapp/ios/App/AppTests/OneVoiceInvocationCoordinatorTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+@testable import App
+#if canImport(AppIntents)
+import AppIntents
+#endif
+
+final class OneVoiceInvocationCoordinatorTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var now: Date!
+    private let storageKey = "test.one.voice.pending"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: "OneVoiceInvocationCoordinatorTests")!
+        defaults.removePersistentDomain(forName: "OneVoiceInvocationCoordinatorTests")
+        now = Date(timeIntervalSince1970: 1_800_000_000)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: "OneVoiceInvocationCoordinatorTests")
+        defaults = nil
+        now = nil
+        super.tearDown()
+    }
+
+    private func makeCoordinator() -> OneVoiceInvocationCoordinator {
+        OneVoiceInvocationCoordinator(
+            defaults: defaults,
+            storageKey: storageKey,
+            now: { [unowned self] in self.now }
+        )
+    }
+
+    func testEnqueuePersistsOnlyTheClosedMetadataEnvelope() throws {
+        let coordinator = makeCoordinator()
+        let invocation = coordinator.enqueue()
+
+        XCTAssertEqual(invocation.kind, "start_one_voice")
+        XCTAssertEqual(invocation.source, "siri_app_shortcut")
+        XCTAssertEqual(
+            invocation.expiresAt.timeIntervalSince(invocation.createdAt),
+            300,
+            accuracy: 0.001
+        )
+
+        let data = try XCTUnwrap(defaults.data(forKey: storageKey))
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        XCTAssertEqual(
+            Set(object.keys),
+            Set(["id", "kind", "source", "createdAt", "expiresAt"])
+        )
+        XCTAssertNil(object["prompt"])
+        XCTAssertNil(object["credential"])
+        XCTAssertNil(object["route"])
+        XCTAssertNil(object["userId"])
+        XCTAssertNil(object["token"])
+    }
+
+    func testTamperedKindOrSourceIsRejected() throws {
+        let coordinator = makeCoordinator()
+        coordinator.enqueue()
+        let data = try XCTUnwrap(defaults.data(forKey: storageKey))
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        object["kind"] = "arbitrary_text"
+        defaults.set(try JSONSerialization.data(withJSONObject: object), forKey: storageKey)
+
+        XCTAssertNil(coordinator.pending())
+        XCTAssertNil(defaults.data(forKey: storageKey))
+    }
+
+    func testLatestInvocationReplacesPreviousInvocation() {
+        let coordinator = makeCoordinator()
+        let first = coordinator.enqueue()
+        let second = coordinator.enqueue()
+
+        XCTAssertNotEqual(first.id, second.id)
+        XCTAssertEqual(coordinator.pending()?.id, second.id)
+        XCTAssertFalse(coordinator.claim(id: first.id))
+    }
+
+    func testExpiredInvocationIsRemovedAndCannotBeClaimed() {
+        let coordinator = makeCoordinator()
+        let invocation = coordinator.enqueue()
+        now = now.addingTimeInterval(301)
+
+        XCTAssertNil(coordinator.pending())
+        XCTAssertFalse(coordinator.claim(id: invocation.id))
+        XCTAssertNil(defaults.data(forKey: storageKey))
+    }
+
+    func testClaimConsumesExactlyOnce() {
+        let coordinator = makeCoordinator()
+        let invocation = coordinator.enqueue()
+
+        XCTAssertTrue(coordinator.claim(id: invocation.id))
+        XCTAssertFalse(coordinator.claim(id: invocation.id))
+        XCTAssertNil(coordinator.pending())
+    }
+
+    func testCompletionAndCancellationClearPendingInvocation() {
+        let coordinator = makeCoordinator()
+        let completed = coordinator.enqueue()
+        coordinator.complete(id: completed.id, outcome: "failed")
+        XCTAssertNil(coordinator.pending())
+
+        coordinator.enqueue()
+        coordinator.cancelPending()
+        XCTAssertNil(coordinator.pending())
+    }
+
+    func testColdLaunchReadsIntentCreatedBeforePluginOrAppDelegateReadiness() {
+        let intentProcessCoordinator = makeCoordinator()
+        let invocation = intentProcessCoordinator.enqueue()
+
+        let launchedAppCoordinator = makeCoordinator()
+        XCTAssertEqual(launchedAppCoordinator.pending(), invocation)
+        XCTAssertTrue(launchedAppCoordinator.claim(id: invocation.id))
+        XCTAssertNil(intentProcessCoordinator.pending())
+    }
+
+    func testAppAlreadyOpenAndForegroundNotificationDoNotConsumeTheRequest() {
+        let coordinator = makeCoordinator()
+        let invocation = coordinator.enqueue()
+
+        coordinator.publishAvailability(state: "foregrounded")
+
+        XCTAssertEqual(coordinator.pending(), invocation)
+        XCTAssertTrue(coordinator.claim(id: invocation.id))
+    }
+
+    func testAppIntentPerformEnqueuesTheExistingVoiceEntryRequest() async throws {
+#if canImport(AppIntents)
+        guard #available(iOS 16.0, *) else { return }
+        OneVoiceInvocationCoordinator.shared.cancelPending(outcome: "test_reset")
+        defer {
+            OneVoiceInvocationCoordinator.shared.cancelPending(outcome: "test_cleanup")
+        }
+
+        _ = try await TalkToHusshOneIntent().perform()
+
+        let invocation = try XCTUnwrap(
+            OneVoiceInvocationCoordinator.shared.pending()
+        )
+        XCTAssertEqual(invocation.kind, "start_one_voice")
+        XCTAssertEqual(invocation.source, "siri_app_shortcut")
+#endif
+    }
+
+    func testAppIntentAvailabilityContractsCompileFromAnIOS15Target() {
+#if canImport(AppIntents)
+        if #available(iOS 16.0, *) {
+            XCTAssertTrue(TalkToHusshOneIntent.openAppWhenRun)
+            XCTAssertEqual(
+                TalkToHusshOneIntent.authenticationPolicy,
+                .requiresLocalDeviceAuthentication
+            )
+            XCTAssertEqual(HusshOneAppShortcuts.appShortcuts.count, 1)
+        }
+        if #available(iOS 26.0, *) {
+            XCTAssertEqual(
+                TalkToHusshOneIntent.supportedModes,
+                [.foreground(.immediate)]
+            )
+        }
+#endif
+    }
+}

--- a/hushh-webapp/lib/agent/agent-voice-settings.ts
+++ b/hushh-webapp/lib/agent/agent-voice-settings.ts
@@ -3,23 +3,122 @@
 // One Live is the only interactive audio owner. Other surfaces may request a
 // session, but only the persistent Agent Bar can acquire the microphone,
 // create the Live transport, or render native-audio playback.
-export const AGENT_CONVERSATION_REQUEST_EVENT = "hushh:agent-conversation-request";
+export const AGENT_CONVERSATION_REQUEST_EVENT =
+  "hushh:agent-conversation-request";
+export const AGENT_CONVERSATION_READY_EVENT = "hushh:agent-conversation-ready";
+export const AGENT_CONVERSATION_OUTCOME_EVENT =
+  "hushh:agent-conversation-outcome";
+
+export type AgentConversationRequestSource = "agent_chat" | "siri_app_shortcut";
+
+export type AgentConversationRequest = {
+  source?: AgentConversationRequestSource;
+  requestId?: string;
+};
+
+export type AgentConversationOutcome = {
+  source: AgentConversationRequestSource;
+  requestId: string;
+  outcome: "accepted" | "failed";
+};
+
+export type AgentConversationDispatchResult =
+  "dispatched" | "queued" | "duplicate";
+
+let ownerReady = false;
+let queuedRequest: AgentConversationRequest | null = null;
+const knownRequestIds = new Set<string>();
+
+function normalizedRequest(
+  request: AgentConversationRequest = {},
+): AgentConversationRequest {
+  return {
+    source: request.source ?? "agent_chat",
+    requestId: request.requestId?.trim() || undefined,
+  };
+}
+
+function dispatchRequest(request: AgentConversationRequest): void {
+  window.dispatchEvent(
+    new CustomEvent<AgentConversationRequest>(
+      AGENT_CONVERSATION_REQUEST_EVENT,
+      { detail: request },
+    ),
+  );
+}
 
 /**
- * Ask the persistent Agent Bar to toggle One Live. The event deliberately
- * carries no text, credentials, or audio and cannot start a fallback STT/TTS
- * pipeline.
+ * Ask the persistent Agent Bar to start One Live. Existing no-argument callers
+ * remain compatible. A request received before the sole owner mounts is held
+ * as one metadata-only slot; duplicate ids are coalesced.
  */
-export function requestAgentConversation(): void {
+export function requestAgentConversation(
+  request: AgentConversationRequest = {},
+): AgentConversationDispatchResult {
+  if (typeof window === "undefined") return "queued";
+  const normalized = normalizedRequest(request);
+  if (normalized.requestId && knownRequestIds.has(normalized.requestId)) {
+    return "duplicate";
+  }
+  if (normalized.requestId) knownRequestIds.add(normalized.requestId);
+
+  if (!ownerReady) {
+    queuedRequest = normalized;
+    return "queued";
+  }
+  dispatchRequest(normalized);
+  return "dispatched";
+}
+
+export function markAgentConversationOwnerReady(): () => void {
+  if (typeof window === "undefined") return () => undefined;
+  ownerReady = true;
+  window.dispatchEvent(new Event(AGENT_CONVERSATION_READY_EVENT));
+  if (queuedRequest) {
+    const pending = queuedRequest;
+    queuedRequest = null;
+    queueMicrotask(() => {
+      if (ownerReady) dispatchRequest(pending);
+      else queuedRequest = pending;
+    });
+  }
+  return () => {
+    ownerReady = false;
+  };
+}
+
+export function isAgentConversationOwnerReady(): boolean {
+  return ownerReady;
+}
+
+export function acknowledgeAgentConversation(
+  outcome: AgentConversationOutcome,
+): void {
   if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent(AGENT_CONVERSATION_REQUEST_EVENT));
+  window.dispatchEvent(
+    new CustomEvent<AgentConversationOutcome>(
+      AGENT_CONVERSATION_OUTCOME_EVENT,
+      { detail: outcome },
+    ),
+  );
+}
+
+/** Test-only reset for the module-scoped metadata broker. */
+export function resetAgentConversationBrokerForTests(): void {
+  ownerReady = false;
+  queuedRequest = null;
+  knownRequestIds.clear();
 }
 
 const DISABLED_FLAG_VALUES = new Set(["0", "false", "off", "disabled", "no"]);
 
 export function isAgentGeminiVoiceEnabled(): boolean {
   const configured = process.env.NEXT_PUBLIC_AGENT_GEMINI_VOICE_ENABLED;
-  if (configured === undefined || configured === null || String(configured).trim() === "") {
+  if (
+    configured === undefined ||
+    configured === null ||
+    String(configured).trim() === ""
+  ) {
     return true;
   }
   return !DISABLED_FLAG_VALUES.has(String(configured).trim().toLowerCase());

--- a/hushh-webapp/lib/agent/siri-one-voice-handoff-policy.ts
+++ b/hushh-webapp/lib/agent/siri-one-voice-handoff-policy.ts
@@ -1,0 +1,56 @@
+import type { AgentAccessTier } from "@/lib/agent/agent-runtime-context";
+
+export type SiriOneVoiceHandoffState =
+  | "expired"
+  | "waiting_for_foreground"
+  | "waiting_for_auth_restoration"
+  | "waiting_for_auth"
+  | "waiting_for_route"
+  | "waiting_for_runtime"
+  | "waiting_for_owner"
+  | "voice_disabled"
+  | "dispatch";
+
+export function buildSiriOneVoiceLoginRoute(input: {
+  currentRoute: string | null;
+  loginPath: string;
+  publicHomePath: string;
+}): string {
+  const currentRoute = input.currentRoute?.trim() ?? "";
+  if (
+    !currentRoute ||
+    currentRoute === input.loginPath ||
+    currentRoute === input.publicHomePath
+  ) {
+    return input.loginPath;
+  }
+  return `${input.loginPath}?redirect=${encodeURIComponent(currentRoute)}`;
+}
+
+export function resolveSiriOneVoiceHandoffState(input: {
+  now: number;
+  expiresAt: number;
+  visible: boolean;
+  authLoading: boolean;
+  signedIn: boolean;
+  pathname: string | null;
+  loginPath: string;
+  runtimeReady: boolean;
+  tier: AgentAccessTier | null;
+  ownerReady: boolean;
+  voiceEnabled: boolean;
+}): SiriOneVoiceHandoffState {
+  if (input.expiresAt <= input.now) return "expired";
+  if (!input.visible) return "waiting_for_foreground";
+  if (input.authLoading) return "waiting_for_auth_restoration";
+  if (!input.signedIn) return "waiting_for_auth";
+  if (!input.pathname || input.pathname === input.loginPath) {
+    return "waiting_for_route";
+  }
+  if (!input.runtimeReady || !input.tier?.startsWith("signed_")) {
+    return "waiting_for_runtime";
+  }
+  if (!input.ownerReady) return "waiting_for_owner";
+  if (!input.voiceEnabled) return "voice_disabled";
+  return "dispatch";
+}

--- a/hushh-webapp/lib/capacitor/one-voice-invocation.ts
+++ b/hushh-webapp/lib/capacitor/one-voice-invocation.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import {
+  Capacitor,
+  WebPlugin,
+  registerPlugin,
+  type PluginListenerHandle,
+} from "@capacitor/core";
+
+export type PendingOneVoiceInvocation = {
+  id: string;
+  kind: "start_one_voice";
+  source: "siri_app_shortcut";
+  createdAt: number;
+  expiresAt: number;
+};
+
+export type OneVoiceInvocationOutcome =
+  "accepted" | "failed" | "expired" | "cancelled" | "fallback_shown";
+
+export interface NativeOneVoiceInvocationPlugin {
+  getPendingInvocation(): Promise<Partial<PendingOneVoiceInvocation>>;
+  claimInvocation(options: { id: string }): Promise<{ claimed: boolean }>;
+  completeInvocation(options: {
+    id: string;
+    outcome: OneVoiceInvocationOutcome;
+  }): Promise<void>;
+  addListener(
+    eventName: "voiceInvocationAvailable",
+    listener: (invocation: PendingOneVoiceInvocation) => void,
+  ): Promise<PluginListenerHandle>;
+}
+
+class OneVoiceInvocationWeb extends WebPlugin {
+  async getPendingInvocation(): Promise<Record<string, never>> {
+    return {};
+  }
+
+  async claimInvocation(): Promise<{ claimed: boolean }> {
+    return { claimed: false };
+  }
+
+  async completeInvocation(): Promise<void> {}
+}
+
+const NativeOneVoiceInvocation = registerPlugin<NativeOneVoiceInvocationPlugin>(
+  "HushhVoiceInvocation",
+  { web: () => Promise.resolve(new OneVoiceInvocationWeb()) },
+);
+
+function isPendingInvocation(
+  value: Partial<PendingOneVoiceInvocation> | null | undefined,
+): value is PendingOneVoiceInvocation {
+  return (
+    value?.kind === "start_one_voice" &&
+    value.source === "siri_app_shortcut" &&
+    typeof value.id === "string" &&
+    value.id.length > 0 &&
+    typeof value.createdAt === "number" &&
+    Number.isFinite(value.createdAt) &&
+    typeof value.expiresAt === "number" &&
+    Number.isFinite(value.expiresAt)
+  );
+}
+
+export const OneVoiceInvocationBridge = {
+  isSupported(): boolean {
+    return Capacitor.isNativePlatform() && Capacitor.getPlatform() === "ios";
+  },
+
+  async getPendingInvocation(): Promise<PendingOneVoiceInvocation | null> {
+    if (!this.isSupported()) return null;
+    const invocation = await NativeOneVoiceInvocation.getPendingInvocation();
+    return isPendingInvocation(invocation) ? invocation : null;
+  },
+
+  async claimInvocation(options: {
+    id: string;
+  }): Promise<{ claimed: boolean }> {
+    if (!this.isSupported()) return { claimed: false };
+    return NativeOneVoiceInvocation.claimInvocation(options);
+  },
+
+  async completeInvocation(options: {
+    id: string;
+    outcome: OneVoiceInvocationOutcome;
+  }): Promise<void> {
+    if (!this.isSupported()) return;
+    await NativeOneVoiceInvocation.completeInvocation(options);
+  },
+
+  async addAvailabilityListener(
+    listener: (invocation: PendingOneVoiceInvocation) => void,
+  ): Promise<PluginListenerHandle> {
+    if (!this.isSupported()) return { remove: async () => undefined };
+    return NativeOneVoiceInvocation.addListener(
+      "voiceInvocationAvailable",
+      listener,
+    );
+  },
+};

--- a/hushh-webapp/lib/capacitor/plugin-constants.ts
+++ b/hushh-webapp/lib/capacitor/plugin-constants.ts
@@ -97,6 +97,8 @@ export const PluginNames = {
   SETTINGS: "HushhSettings",
   KEYCHAIN: "HushhKeychain", // Note: iOS uses HushhKeystorePlugin class but jsName is HushhKeychain
   CONTACTS: "HushhContacts",
+  /** Apple system-surface adapter; intentionally unsupported on Android/web. */
+  VOICE_INVOCATION: "HushhVoiceInvocation",
 } as const;
 
 /**

--- a/hushh-webapp/scripts/native/verify-native-plugin-contracts.mjs
+++ b/hushh-webapp/scripts/native/verify-native-plugin-contracts.mjs
@@ -10,6 +10,7 @@ const tsPluginFiles = [
   "lib/capacitor/account.ts",
   "lib/capacitor/kai.ts",
   "lib/capacitor/personal-knowledge-model.ts",
+  "lib/capacitor/one-voice-invocation.ts",
 ];
 
 const iosPluginsDir = path.join(appRoot, "ios/App/App/Plugins");
@@ -20,8 +21,12 @@ const iosInfoPlistPath = path.join(appRoot, "ios/App/App/Info.plist");
 const iosEntitlementsPath = path.join(appRoot, "ios/App/App/App.entitlements");
 
 const webOnlyPlugins = new Set(["HushhDatabase", "HushhAgent"]);
+// App Shortcuts are an Apple system surface, not an Android route-parity lane.
+// The TypeScript adapter returns unsupported/no pending invocation elsewhere.
+const iosOnlyPlugins = new Set(["HushhVoiceInvocation"]);
 const ignoredTsMethodsByPlugin = new Map([
   ["Kai", new Set(["addListener"])],
+  ["HushhVoiceInvocation", new Set(["addListener"])],
 ]);
 
 const failures = [];
@@ -220,7 +225,7 @@ for (const pluginName of sorted(tsContracts.keys())) {
   if (!iosContract) {
     fail(`${pluginName}: TypeScript contract exists in ${tsContract.source}, but iOS plugin is missing.`);
   }
-  if (!androidContract) {
+  if (!androidContract && !iosOnlyPlugins.has(pluginName)) {
     fail(`${pluginName}: TypeScript contract exists in ${tsContract.source}, but Android plugin is missing.`);
   }
   if (iosContract) {
@@ -250,7 +255,7 @@ for (const pluginName of sorted(androidContracts.keys())) {
 }
 
 for (const pluginName of sorted(tsContracts.keys())) {
-  if (webOnlyPlugins.has(pluginName)) continue;
+  if (webOnlyPlugins.has(pluginName) || iosOnlyPlugins.has(pluginName)) continue;
   if (!iosContracts.has(pluginName) || !androidContracts.has(pluginName)) continue;
   const iosMethods = iosContracts.get(pluginName).methods;
   const androidMethods = androidContracts.get(pluginName).methods;


### PR DESCRIPTION
## Summary
- add the iOS 16+ Talk to Hussh One App Intent and App Shortcuts phrases in the main UIKit target
- persist a redacted, expiring native invocation and hand it through a narrow Capacitor bridge
- resume through foreground/auth/runtime readiness and request the existing Agent Bar voice owner exactly once
- add native and frontend lifecycle tests for foreground, background, cold launch, authentication restoration, expiry, duplication, and routing
- make the existing TestFlight workflow run AppTests before archive/upload

## Architecture
This is an iOS entry adapter only. It adds no microphone, transcription path, voice model, semantic router, action registry, backend API, or generated action identifier. All audio and actions continue through the existing One Voice runtime and generated action gateway.

## Verification
- local PR mirror: passing
- frontend: 715 files passed, 1 skipped; 5,836 tests passed, 6 skipped
- backend: 1,861 tests passed
- Siri-focused frontend tests: 11 passed
- TypeScript typecheck, zero-warning lint, production build: passing
- native plugin/static parity and voice gateway checks: passing
- Swift iOS 15-target typecheck: passing
- local Xcode XCTest unavailable because this Mac has no installed iOS platform/runtime; authoritative native AppTests run in the TestFlight GitHub workflow before upload

Signed-off-by: Pummy Kumari <94732725+ankitkumarsingh1702@users.noreply.github.com>