### PR TITLE
fix(connect): clarify circles and people sections

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -124,19 +124,27 @@ function chooseDirectory(name: "People" | "RIAs" | "Around you") {
   fireEvent.click(screen.getByRole("menuitemradio", { name }));
 }
 
-// The People-tab directory is now collapsed behind "Add people" until asked
-// for -- see app/connect/page-client.tsx. Almost every test in this file used
-// to synchronize on the mount-time fetch that gate removed on purpose;
-// this is the drop-in replacement: it waits for the page to be interactively
-// ready, reveals the section, and waits for the fetch it triggers, which is
-// what the old `await waitFor(() => expect(mocks.searchDirectory)...)` was
-// really standing in for in every case that did not also assert on that
-// specific mount-time call.
-async function revealPeopleDirectory() {
-  fireEvent.click(
-    await screen.findByRole("button", { name: "Add people" }),
-  );
+// People is always visible. Most tests need only wait for its mount-time read
+// before interacting with the rendered directory.
+async function waitForPeopleDirectory() {
   await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalled());
+}
+
+function openMyConnections() {
+  const toggle = screen.getByTestId("connect-my-connections-toggle");
+  if (toggle.getAttribute("aria-expanded") !== "true") {
+    fireEvent.click(toggle);
+  }
+  return toggle;
+}
+
+async function waitForConnectionsSummary(label: string, count: number) {
+  const toggle = screen.getByTestId("connect-my-connections-toggle");
+  await waitFor(() => {
+    expect(toggle).toHaveTextContent(label);
+    expect(toggle).toHaveTextContent(String(count));
+  });
+  return toggle;
 }
 
 vi.mock("sonner", () => ({
@@ -255,46 +263,65 @@ beforeEach(() => {
 });
 
 describe("Connect — People, arriving on the tab", () => {
-  it("does not fetch or show the directory until asked", async () => {
-    // The report: the People tab opened straight onto a page of strangers.
-    // Your own connections still render on arrival -- that half was never
-    // broken -- but the directory itself waits for an explicit ask.
+  it("shows People immediately and leaves My connections closed", async () => {
     render(<ConnectPageClient />);
+    await waitForPeopleDirectory();
 
-    await screen.findByRole("button", { name: "Add people" });
-    expect(mocks.searchDirectory).not.toHaveBeenCalled();
-    expect(screen.queryByLabelText("Search people")).toBeNull();
-    expect(screen.queryByText("Person 0")).toBeNull();
+    expect(
+      screen.getByRole("heading", { name: "People", level: 2 }),
+    ).toBeTruthy();
+    expect(screen.getByLabelText("Search people")).toBeTruthy();
+    expect(await screen.findByText("Person 0")).toBeTruthy();
+    expect(screen.queryByTestId("connect-add-people")).toBeNull();
+    expect(screen.getByTestId("connect-my-connections-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
   });
 
-  it("reveals the directory once Add people is tapped, and focuses search", async () => {
+  it("keeps People as a section instead of a second disclosure", async () => {
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
-    expect(await screen.findByText("Person 0")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Add people" })).toBeNull();
-    expect(screen.getByLabelText("Search people")).toHaveFocus();
+    const peopleHeading = screen.getByRole("heading", {
+      name: "People",
+      level: 2,
+    });
+    expect(peopleHeading).not.toHaveAttribute("aria-expanded");
+    expect(peopleHeading).not.toHaveAttribute("aria-controls");
+    expect(peopleHeading.querySelector("button")).toBeNull();
+
+    const connectionsToggle = screen.getByTestId(
+      "connect-my-connections-toggle",
+    );
+    expect(connectionsToggle.closest('[role="heading"]')).toBeNull();
+  });
+
+  it("uses an opaque surface for the directory picker menu", async () => {
+    render(<ConnectPageClient />);
+    await waitForPeopleDirectory();
+
+    fireEvent.click(screen.getByRole("button", { name: /Current directory:/ }));
+    const menu = screen.getByRole("menu");
+    expect(menu.className).toContain(
+      "bg-[color:var(--app-card-surface-default-solid)]",
+    );
+    expect(menu.className).not.toContain(
+      "bg-[color:var(--app-card-surface-standard)]",
+    );
   });
 
   it("browses on the Advisors tab by design", async () => {
-    // Only the People tab's unsearched browse was the reported problem.
-    // Searching a directory of verified advisors is the whole point of that
-    // tab, so it is unaffected -- no "Add people" button, no reveal needed.
     render(<ConnectPageClient />);
     chooseDirectory("RIAs");
 
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalled());
-    expect(
-      screen.queryByRole("button", { name: "Add people" }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Add people" })).toBeNull();
   });
 
-  it("reopens the directory on remount when a search was left active", async () => {
-    // A search is an explicit ask made in an earlier visit, restored from
-    // sessionStorage -- it must reopen the section it belongs to, not sit
-    // invisible behind a button that looks like nothing was ever searched.
+  it("restores a search into the always-visible directory on remount", async () => {
     const { unmount } = render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     fireEvent.change(screen.getByLabelText("Search people"), {
       target: { value: "Ada" },
     });
@@ -345,13 +372,13 @@ describe("Connect — People", () => {
     ]);
 
     render(<ConnectPageClient />);
+    openMyConnections();
 
     const myConnections = await screen.findByTestId(
       "connect-my-connections-group",
     );
-    const connectionName = await within(myConnections).findByText(
-      "Scoped Friend",
-    );
+    const connectionName =
+      await within(myConnections).findByText("Scoped Friend");
     const connectionAction = connectionName.closest("button");
     expect(connectionAction).toBeTruthy();
 
@@ -406,7 +433,12 @@ describe("Connect — People", () => {
 
     render(<ConnectPageClient />);
 
-    expect(await screen.findByText("My connections (5000)")).toBeTruthy();
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("connect-my-connections-toggle"),
+      ).toHaveTextContent("5000"),
+    );
+    openMyConnections();
     fireEvent.click(
       screen.getByRole("button", { name: "Load more connections" }),
     );
@@ -473,6 +505,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
 
     expect(await screen.findByText("Current Person")).toBeTruthy();
+    openMyConnections();
     fireEvent.click(
       screen.getByRole("button", { name: "Load more connections" }),
     );
@@ -583,33 +616,20 @@ describe("Connect — People", () => {
     expect(await screen.findByText("Current Person")).toBeTruthy();
     expect(mocks.listConnectionsPage).toHaveBeenCalledTimes(1);
 
-    // My connections is a disclosure, open by default -- Refresh exists
-    // against a list you can already see, with no click needed to reach it.
-
-    // Refresh is a control, not part of the heading text. It used to be a
-    // child of the `title` node, which SettingsGroup renders inside an element
-    // carrying `role="heading"` -- a button there is folded into the heading's
-    // accessible name and is never offered as something to press. The two
-    // assertions below are what keep it out: the heading's name is the plain
-    // text, and the button is not a descendant of it.
-    const connectionsHeading = screen
-      .getAllByRole("heading")
-      .find((node) => node.textContent?.includes("connections"));
-    expect(connectionsHeading).toBeTruthy();
     expect(
-      connectionsHeading?.contains(
-        screen.getByRole("button", { name: "Refresh contacts" }),
-      ),
-    ).toBe(false);
-    expect(connectionsHeading?.textContent).not.toContain("Refresh");
+      screen.queryByRole("button", { name: "Refresh connections" }),
+    ).toBeNull();
+    openMyConnections();
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh contacts" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh connections" }),
+    );
 
     await waitFor(() =>
       expect(mocks.listConnectionsPage).toHaveBeenCalledTimes(2),
     );
     const refreshingButton = screen.getByRole("button", {
-      name: "Refresh contacts",
+      name: "Refresh connections",
     }) as HTMLButtonElement;
     expect(refreshingButton.disabled).toBe(true);
     expect(refreshingButton).toHaveAttribute("aria-busy", "true");
@@ -638,7 +658,7 @@ describe("Connect — People", () => {
     expect(await screen.findByText("Refreshed Person")).toBeTruthy();
     expect(screen.queryByText("Current Person")).toBeNull();
     const refreshButton = screen.getByRole("button", {
-      name: "Refresh contacts",
+      name: "Refresh connections",
     }) as HTMLButtonElement;
     expect(refreshButton.disabled).toBe(false);
     expect(refreshButton).toHaveAttribute("aria-busy", "false");
@@ -707,6 +727,7 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
 
     expect(await screen.findByText("First Person")).toBeTruthy();
+    openMyConnections();
     fireEvent.click(
       screen.getByRole("button", { name: "Load more connections" }),
     );
@@ -731,7 +752,7 @@ describe("Connect — People", () => {
 
   it("asks for a bounded sample before anyone has searched", async () => {
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     // The reported problem was the whole register arriving unprompted. The
     // unsearched surface must ask for a capped set, and no query.
     expect(mocks.searchDirectory.mock.calls[0][0]).toMatchObject({
@@ -749,7 +770,7 @@ describe("Connect — People", () => {
     // left the rest of the directory unreachable. Both now hold: a screenful
     // by default, and a way through it.
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     expect(await screen.findByText("Search by name.")).toBeTruthy();
     expect(
@@ -768,7 +789,7 @@ describe("Connect — People", () => {
     // the reader had already scrolled past -- and the field itself arrived
     // before anything on screen had said what it searched.
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const supporting = await screen.findByText("Search by name.");
     const heading = screen.getByRole("heading", { name: "People", level: 2 });
@@ -792,7 +813,7 @@ describe("Connect — People", () => {
 
   it("keeps load-more inside the grouped list as a compact row", async () => {
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const row = await screen.findByTestId("connect-load-more-row");
     expect(row.className).not.toContain("flex-col");
@@ -805,7 +826,7 @@ describe("Connect — People", () => {
 
   it("asks the server for the next batch the reader loads", async () => {
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Load 20 more people" }),
@@ -843,16 +864,14 @@ describe("Connect — People", () => {
     });
 
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     expect(await screen.findByText("Person 0")).toBeTruthy();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Load 20 more people" }),
     );
 
-    await waitFor(() =>
-      expect(screen.getByText("Loading more…")).toBeTruthy(),
-    );
+    await waitFor(() => expect(screen.getByText("Loading more…")).toBeTruthy());
     expect(screen.getByText("Person 0")).toBeTruthy();
     expect(screen.queryByText("Finding people…")).toBeNull();
 
@@ -872,7 +891,7 @@ describe("Connect — People", () => {
 
   it("opens the full directory once a name is typed", async () => {
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     fireEvent.change(screen.getByLabelText("Search people"), {
       target: { value: "Person 9" },
@@ -901,7 +920,7 @@ describe("Connect — People", () => {
     // React state, not URL state, so it used to come back empty even
     // though the person had just been searching (issue #5921).
     const { unmount } = render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     fireEvent.change(screen.getByLabelText("Search people"), {
       target: { value: "Person 9" },
@@ -923,7 +942,7 @@ describe("Connect — People", () => {
 
   it("clears the stored search query once the box is emptied", async () => {
     const { unmount } = render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     fireEvent.change(screen.getByLabelText("Search people"), {
       target: { value: "Person 9" },
@@ -938,9 +957,9 @@ describe("Connect — People", () => {
     unmount();
 
     render(<ConnectPageClient />);
-    // Nothing was left in storage to restore, so the section is collapsed
-    // again on this fresh mount -- reveal it before checking the field.
-    await revealPeopleDirectory();
+    // Nothing was left in storage to restore, so the always-visible search
+    // returns empty on this fresh mount.
+    await waitForPeopleDirectory();
     expect(
       (screen.getByLabelText("Search people") as HTMLInputElement).value,
     ).toBe("");
@@ -962,7 +981,7 @@ describe("Connect — People", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     fireEvent.change(screen.getByLabelText("Search people"), {
       target: { value: "R" },
@@ -988,7 +1007,7 @@ describe("Connect — People", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     fireEvent.change(screen.getByLabelText("Search people"), {
       target: { value: "N" },
@@ -1020,7 +1039,7 @@ describe("Connect — People", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     fireEvent.change(screen.getByLabelText("Search people"), {
       target: { value: "N" },
@@ -1071,7 +1090,7 @@ describe("Connect — People", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     fireEvent.change(screen.getByLabelText("Search people"), {
       target: { value: "n" },
@@ -1113,7 +1132,7 @@ describe("Connect — People", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     fireEvent.change(screen.getByLabelText("Search people"), {
       target: { value: "Zzz" },
@@ -1125,7 +1144,7 @@ describe("Connect — People", () => {
 
   it("asks for page one once when the query changes while paged", async () => {
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Load 20 more people" }),
@@ -1150,7 +1169,7 @@ describe("Connect — People", () => {
 
   it("runs a spoken name through the governed Connect search handler", async () => {
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const search = resolveLocalOnboardingHandler("connect.search_people");
     expect(search).not.toBeNull();
@@ -1175,7 +1194,7 @@ describe("Connect — People", () => {
     });
     mocks.sendRequest.mockResolvedValue({ id: "request-9" });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const sendRequest = resolveLocalOnboardingHandler("connect.send_request");
     expect(sendRequest).not.toBeNull();
@@ -1213,7 +1232,7 @@ describe("Connect — People", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const sendRequest = resolveLocalOnboardingHandler("connect.send_request");
     expect(sendRequest).not.toBeNull();
@@ -1248,7 +1267,7 @@ describe("Connect — People", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const sendRequest = resolveLocalOnboardingHandler("connect.send_request");
     const result = await sendRequest!({ person: "Ankit Kumar Singh" });
@@ -1291,7 +1310,7 @@ describe("Connect — People", () => {
     });
     mocks.sendRequest.mockResolvedValue({ id: "request-10" });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const sendRequest = resolveLocalOnboardingHandler("connect.send_request");
     let result:
@@ -1327,7 +1346,7 @@ describe("Connect — People", () => {
     });
     mocks.sendRequest.mockResolvedValue({ id: "request-9" });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const sendRequest = resolveLocalOnboardingHandler("connect.send_request");
     let result:
@@ -1354,7 +1373,7 @@ describe("Connect — People", () => {
     });
     mocks.sendRequest.mockResolvedValue({ id: "request-9" });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const sendRequest = resolveLocalOnboardingHandler("connect.send_request");
     let result:
@@ -1375,7 +1394,7 @@ describe("Connect — People", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const sendRequest = resolveLocalOnboardingHandler("connect.send_request");
     let result:
@@ -1395,7 +1414,7 @@ describe("Connect — People", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const sendRequest = resolveLocalOnboardingHandler("connect.send_request");
     expect(sendRequest).not.toBeNull();
@@ -1407,7 +1426,7 @@ describe("Connect — People", () => {
 
   it("says who was searched for when a search matches nobody", async () => {
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     mocks.searchDirectory.mockResolvedValue({
       items: [],
@@ -1432,7 +1451,7 @@ describe("Connect — People", () => {
     });
     mocks.sendRequest.mockResolvedValue({ id: "request" });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     expect(await screen.findByText("Bulk person 0")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Select people" }));
@@ -1492,7 +1511,7 @@ describe("Connect — People", () => {
     // page happened to show, so a selection only existed while its own row did.
     // Paging is not deselecting.
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     expect(await screen.findByText("Person 0")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Select people" }));
@@ -1549,7 +1568,7 @@ describe("Connect — People", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     expect(await screen.findByText("Connected Carl")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Select people" }));
@@ -1577,7 +1596,7 @@ describe("Connect — People", () => {
     // as the answer, and the page's own surface contract -- an explicit
     // capability review for every connection request -- was failing against it.
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     expect(await screen.findByText("Person 0")).toBeTruthy();
 
     fireEvent.click(screen.getAllByRole("button", { name: "Connect" })[0]!);
@@ -1631,7 +1650,7 @@ describe("Connect — People", () => {
     mocks.sendRequest.mockResolvedValue({ id: "request" });
 
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     expect(await screen.findByText("Ada Advisor")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Select people" }));
@@ -1669,7 +1688,7 @@ describe("Connect — People", () => {
     // first one unreachable. The tab therefore asks the server for its own
     // half of the directory.
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     expect(mocks.searchDirectory).toHaveBeenLastCalledWith(
       expect.objectContaining({ audience: "people" }),
     );
@@ -1712,7 +1731,8 @@ describe("Connect — People", () => {
 
     render(<ConnectPageClient />);
 
-    expect(await screen.findByText("My connections (2)")).toBeTruthy();
+    await waitForConnectionsSummary("My connections", 2);
+    openMyConnections();
     expect(screen.getByText("Verified Adviser")).toBeTruthy();
     expect(screen.getByText("Ordinary Person")).toBeTruthy();
 
@@ -1721,11 +1741,9 @@ describe("Connect — People", () => {
     // The heading counts the list it is actually showing. Counting one list
     // and rendering another is the exact shape of the original Connect search
     // bug, so the count is asserted here alongside the rows.
-    expect(await screen.findByText("My RIAs (1)")).toBeTruthy();
-    expect(screen.getByTestId("connect-my-connections-toggle")).toHaveAttribute(
-      "aria-expanded",
-      "false",
-    );
+    const riaToggle = await waitForConnectionsSummary("My RIAs", 1);
+    expect(riaToggle).toHaveAttribute("aria-expanded", "false");
+    openMyConnections();
     expect(screen.getByText("Verified Adviser")).toBeTruthy();
     expect(screen.queryByText("Ordinary Person")).toBeNull();
   });
@@ -1781,7 +1799,8 @@ describe("Connect — People", () => {
     expect(await screen.findByText("People Only Row")).toBeTruthy();
     chooseDirectory("RIAs");
 
-    expect(await screen.findByText("My RIAs (0)")).toBeTruthy();
+    await waitForConnectionsSummary("My RIAs", 0);
+    openMyConnections();
     expect(screen.queryByText("People Only Row")).toBeNull();
   });
 
@@ -1800,11 +1819,12 @@ describe("Connect — People", () => {
     ]);
 
     render(<ConnectPageClient />);
-    expect(await screen.findByText("My connections (1)")).toBeTruthy();
+    await waitForConnectionsSummary("My connections", 1);
 
     chooseDirectory("RIAs");
 
-    expect(await screen.findByText("My RIAs (0)")).toBeTruthy();
+    await waitForConnectionsSummary("My RIAs", 0);
+    openMyConnections();
     expect(screen.queryByText("Unannotated Person")).toBeNull();
     expect(screen.getByText("No RIAs yet")).toBeTruthy();
   });
@@ -1824,7 +1844,7 @@ describe("Connect — removing a connection", () => {
     // question -- it must not also answer it.
     mocks.listConnections.mockResolvedValue([RASHID]);
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const remove = resolveLocalOnboardingHandler("connect.remove_connection");
     const result = await remove!({ person: "Rashid" });
@@ -1849,7 +1869,7 @@ describe("Connect — removing a connection", () => {
     mocks.listConnections.mockResolvedValue([RASHID]);
     mocks.removeConnection.mockResolvedValue({});
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const remove = resolveLocalOnboardingHandler("connect.remove_connection");
     let result: Awaited<ReturnType<NonNullable<typeof remove>>> | undefined;
@@ -1889,7 +1909,7 @@ describe("Connect — removing a connection", () => {
       },
     ]);
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const remove = resolveLocalOnboardingHandler("connect.remove_connection");
     const result = await remove!({ person: "Rashid" });
@@ -1923,6 +1943,7 @@ describe("Connect — the phone-width geometry QA reported", () => {
       },
     ]);
     render(<ConnectPageClient />);
+    openMyConnections();
 
     const remove = await screen.findByRole("button", {
       name: "Remove connection with Abdul Rashid",
@@ -1956,17 +1977,22 @@ describe("Connect — the phone-width geometry QA reported", () => {
     );
 
     const { container } = render(<ConnectPageClient />);
-    expect(await screen.findByText("My connections (12)")).toBeTruthy();
+    await waitForConnectionsSummary("My connections", 12);
 
     const list = container.querySelector(
       '[data-testid="connect-my-connections-group"] [data-inset-separators="true"]',
     );
+    const panel = screen.getByTestId("connect-my-connections-panel");
     expect(list).toBeTruthy();
 
-    // Open on arrival: the directory/search half is collapsed behind its
-    // own "Add people" button now, so there is no search field on the fold
-    // left for a long connections list to push down.
-    expect(list!.className).not.toContain("hidden");
+    // The compact summary row is closed on arrival, so a long connection list
+    // cannot push the always-visible People directory below the fold.
+    expect(panel).toHaveAttribute("hidden");
+    expect(list!.className).not.toContain("max-h-[232px]");
+
+    openMyConnections();
+
+    expect(panel).not.toHaveAttribute("hidden");
     expect(list!.className).toContain("max-h-[232px]");
     expect(list!.className).toContain("overflow-y-auto");
     expect(list!.className).toContain("overscroll-contain");
@@ -1974,9 +2000,7 @@ describe("Connect — the phone-width geometry QA reported", () => {
 
     fireEvent.click(screen.getByTestId("connect-my-connections-toggle"));
 
-    // Still collapsible -- someone may still want it out of the way, only
-    // the default changed.
-    expect(list!.className).toContain("hidden");
+    expect(panel).toHaveAttribute("hidden");
     expect(list!.className).not.toContain("max-h-[232px]");
   });
 
@@ -1992,7 +2016,7 @@ describe("Connect — the phone-width geometry QA reported", () => {
      * not a scroll away, above a list it does not touch.
      */
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     await screen.findByPlaceholderText("Search people");
 
     const stickyHeader = screen.getByTestId("connect-sticky-header");
@@ -2021,53 +2045,72 @@ describe("Connect — the phone-width geometry QA reported", () => {
     ).toBe(true);
   });
 
-  it("opens My connections by default, and says so to a screen reader", async () => {
+  it("starts My connections closed and exposes an accessible disclosure", async () => {
     // A disclosure either way, so the state has to be announced rather than
     // only drawn -- a chevron is not an affordance to anyone who cannot see
-    // it. Defaults open now that the directory/search half collapses behind
-    // its own "Add people" button -- nothing left on the fold to protect by
-    // shutting this one too.
+    // it. The controlled panel remains in the DOM while closed so focus and
+    // list state survive a close/open cycle.
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     await screen.findByPlaceholderText("Search people");
 
     const toggle = screen.getByTestId("connect-my-connections-toggle");
-    expect(toggle).toHaveAttribute("aria-expanded", "true");
-    expect(toggle).toHaveAttribute(
-      "aria-controls",
-      "connect-my-connections-panel",
+    const panel = screen.getByTestId("connect-my-connections-panel");
+    expect(toggle.tagName).toBe("BUTTON");
+    expect(toggle).toHaveAttribute("type", "button");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(toggle.getAttribute("aria-controls")).toBe(panel.id);
+    expect(panel).toHaveAttribute("role", "region");
+    expect(panel).toHaveAttribute(
+      "aria-labelledby",
+      "connect-my-connections-trigger",
     );
-    // The panel it names exists whether or not it is showing, so the reference
-    // is never dangling.
-    expect(
-      document.getElementById("connect-my-connections-panel"),
-    ).not.toBeNull();
+    expect(panel).toHaveAttribute("hidden");
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(panel).not.toHaveAttribute("hidden");
 
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute("aria-expanded", "false");
-
-    fireEvent.click(toggle);
-    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(panel).toHaveAttribute("hidden");
   });
 
-  it("does not open the RIAs disclosure just because People opens by default", async () => {
+  it("keeps disclosure state isolated across People and RIAs", async () => {
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     expect(screen.getByTestId("connect-my-connections-toggle")).toHaveAttribute(
       "aria-expanded",
-      "true",
+      "false",
     );
+    openMyConnections();
 
     chooseDirectory("RIAs");
 
-    expect(await screen.findByText("My RIAs (0)")).toBeTruthy();
+    await waitForConnectionsSummary("My RIAs", 0);
+    await waitFor(() =>
+      expect(mocks.searchDirectory).toHaveBeenLastCalledWith(
+        expect.objectContaining({ audience: "ria" }),
+      ),
+    );
     expect(screen.getByTestId("connect-my-connections-toggle")).toHaveAttribute(
       "aria-expanded",
       "false",
     );
 
     fireEvent.click(screen.getByTestId("connect-my-connections-toggle"));
+    expect(screen.getByTestId("connect-my-connections-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+
+    chooseDirectory("People");
+    await waitFor(() =>
+      expect(mocks.searchDirectory).toHaveBeenLastCalledWith(
+        expect.objectContaining({ audience: "people" }),
+      ),
+    );
     expect(screen.getByTestId("connect-my-connections-toggle")).toHaveAttribute(
       "aria-expanded",
       "true",
@@ -2092,7 +2135,7 @@ describe("Connect — the phone-width geometry QA reported", () => {
      * lined up exactly.
      */
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     await screen.findByPlaceholderText("Search people");
 
     fireEvent.click(screen.getByTestId("connect-my-connections-toggle"));
@@ -2110,7 +2153,7 @@ describe("Connect — the phone-width geometry QA reported", () => {
 
   it("asks for the search field in two words", async () => {
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     expect(await screen.findByPlaceholderText("Search people")).toBeTruthy();
     expect(screen.queryByPlaceholderText("Search people by name")).toBeNull();
   });
@@ -2119,7 +2162,7 @@ describe("Connect — the phone-width geometry QA reported", () => {
     // 44px of right padding held back from a field whose only content is its
     // placeholder is 44px the placeholder does not get.
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     const field = (await screen.findByPlaceholderText(
       "Search people",
     )) as HTMLInputElement;
@@ -2147,7 +2190,7 @@ describe("Connect — the phone-width geometry QA reported", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const cancel = await screen.findByRole("button", {
       name: "Cancel your request to Smirthika Dharmalingam",
@@ -2164,7 +2207,7 @@ describe("Connect — the phone-width geometry QA reported", () => {
 
   it("keeps the selection toggle compact and accessible", async () => {
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     const toggle = await screen.findByRole("button", {
       name: "Select people",
     });
@@ -2198,7 +2241,7 @@ describe("Connect — inviting someone who is not on One yet", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
     fireEvent.change(screen.getByLabelText("Search people"), {
       target: { value: query },
     });
@@ -2355,7 +2398,7 @@ describe("Connect — inviting someone who is not on One yet", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     expect(await screen.findByText("No people yet")).toBeTruthy();
     expect(screen.queryByText("Invite them to One")).toBeNull();
@@ -2371,7 +2414,7 @@ describe("Connect — inviting someone who is not on One yet", () => {
       page: 1,
     });
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     chooseDirectory("RIAs");
     fireEvent.change(screen.getByLabelText("Search people"), {
@@ -2397,7 +2440,7 @@ describe("Connect — inviting someone who is not on One yet", () => {
 describe("Connect — Circles", () => {
   it("opens on People when the URL says nothing", async () => {
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     // The default is not written to the URL on mount: doing that would eat one
     // router.back() step for every arrival.
@@ -2418,6 +2461,7 @@ describe("Connect — Circles", () => {
     expect(
       screen.queryByRole("button", { name: /Current directory:/ }),
     ).toBeNull();
+    expect(mocks.searchDirectory).not.toHaveBeenCalled();
   });
 
   it("names the default surface explicitly, so back to People navigates", async () => {
@@ -2440,7 +2484,7 @@ describe("Connect — Circles", () => {
     // runs before the navigation, so it is observable in this render even
     // though the mocked URL does not change.
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Select people" }),
@@ -2454,9 +2498,7 @@ describe("Connect — Circles", () => {
     await waitFor(() => expect(mocks.routerPush).toHaveBeenCalled());
     expect(String(mocks.routerPush.mock.calls[0][0])).toContain("tab=circles");
     // Back to a plain list, with nothing armed against it.
-    expect(
-      screen.getByRole("button", { name: "Select people" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Select people" })).toBeTruthy();
   });
 
   it("keeps directory tab switches local while Circles stays linkable", async () => {
@@ -2464,7 +2506,7 @@ describe("Connect — Circles", () => {
     // Circles writes the route-backed surface, so ordinary directory switches
     // do not add browser history noise.
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     chooseDirectory("RIAs");
 
@@ -2544,6 +2586,20 @@ describe("Connect — contact sync", () => {
     );
   });
 
+  it("does not offer it on Around you", async () => {
+    mocks.listConnections.mockResolvedValue([]);
+    render(<ConnectPageClient />);
+
+    await screen.findByRole("button", { name: "Sync contacts" });
+    chooseDirectory("Around you");
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Sync contacts" }),
+      ).toBeNull(),
+    );
+  });
+
   it("hides it when no contact source is reachable", async () => {
     // A desktop browser with no picker and no Google client configured. A
     // button whose only function is to explain that it cannot work is worse
@@ -2552,7 +2608,7 @@ describe("Connect — contact sync", () => {
     mocks.listConnections.mockResolvedValue([]);
     try {
       render(<ConnectPageClient />);
-      await revealPeopleDirectory();
+      await waitForPeopleDirectory();
 
       await screen.findByRole("heading", { name: "People" });
       await waitFor(() =>
@@ -2574,7 +2630,7 @@ describe("Connect — contact sync", () => {
     // offered as something to press.
     mocks.listConnections.mockResolvedValue([]);
     render(<ConnectPageClient />);
-    await revealPeopleDirectory();
+    await waitForPeopleDirectory();
 
     const sync = await screen.findByRole("button", {
       name: "Sync contacts",

--- a/hushh-webapp/app/connect/connect-surface-layout.ts
+++ b/hushh-webapp/app/connect/connect-surface-layout.ts
@@ -1,0 +1,11 @@
+export const CONNECT_DIRECTORY_MENU_CLASSNAME =
+  "absolute left-0 top-full z-30 mt-1 w-[184px] overflow-hidden rounded-[14px] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] p-1 shadow-[0_10px_30px_rgba(0,0,0,0.10)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.35)]";
+
+export const CONNECT_CONNECTIONS_SUMMARY_TRAILING_CLASSNAME =
+  "flex shrink-0 items-center gap-2";
+
+export const CONNECT_CONNECTIONS_SUMMARY_COUNT_CLASSNAME =
+  "min-w-5 text-right text-[14px] font-medium tabular-nums text-[color:var(--app-secondary-label)]";
+
+export const CONNECT_CONNECTIONS_SUMMARY_CHEVRON_CLASSNAME =
+  "h-4 w-4 shrink-0 text-[color:var(--app-secondary-label)] transition-transform duration-200 ease-out motion-reduce:transition-none group-data-[state=open]/connections:rotate-180";

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -13,7 +13,7 @@ import {
   RefreshCw,
   Search as SearchIcon,
   Share2,
-  UserPlus,
+  UsersRound,
   X,
 } from "lucide-react";
 
@@ -37,6 +37,11 @@ import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-ac
 import { useScrollReset } from "@/lib/navigation/use-scroll-reset";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import {
   Dialog,
   DialogContent,
@@ -82,6 +87,12 @@ import {
   CONNECT_SEARCH_PLACEHOLDER,
   CONNECT_SELECT_TOGGLE_CLASSNAME,
 } from "./connect-search-layout";
+import {
+  CONNECT_CONNECTIONS_SUMMARY_CHEVRON_CLASSNAME,
+  CONNECT_CONNECTIONS_SUMMARY_COUNT_CLASSNAME,
+  CONNECT_CONNECTIONS_SUMMARY_TRAILING_CLASSNAME,
+  CONNECT_DIRECTORY_MENU_CLASSNAME,
+} from "./connect-surface-layout";
 import { cn } from "@/lib/utils";
 import { ContactSourceBadge } from "@/components/connections/contact-source-badge";
 
@@ -289,8 +300,6 @@ const CONNECT_ROW_ACTION_CLASSNAME =
   "h-8 min-h-8 rounded-2xl px-2.5 text-[14px] font-semibold leading-[18px]";
 const CONNECT_INLINE_BUTTON_CLASSNAME =
   "h-8 min-h-8 rounded-2xl px-3 text-[14px] font-semibold leading-[18px]";
-const CONNECT_REFRESH_BUTTON_CLASSNAME =
-  "h-8 min-h-8 w-8 min-w-8 rounded-full p-0 text-muted-foreground hover:text-foreground disabled:opacity-70";
 
 /** Maximum number of connection requests the People bulk action can send. */
 const MAX_BULK_CONNECTION_REQUESTS = 10;
@@ -528,9 +537,23 @@ export default function ConnectPageClient() {
   const loadMoreDirectoryRef = useRef<HTMLDivElement | null>(null);
   const [directoryMenuOpen, setDirectoryMenuOpen] = useState(false);
   const [query, setQuery] = useState<string>(readStoredConnectSearchQuery);
+  const [searchFocusRequest, setSearchFocusRequest] = useState(0);
+  const handledSearchFocusRequestRef = useRef(0);
   useEffect(() => {
     writeStoredConnectSearchQuery(query);
   }, [query]);
+  useEffect(() => {
+    if (
+      searchFocusRequest === handledSearchFocusRequestRef.current ||
+      surface !== "all" ||
+      tab !== "people" ||
+      !searchInputRef.current
+    ) {
+      return;
+    }
+    searchInputRef.current.focus();
+    handledSearchFocusRequestRef.current = searchFocusRequest;
+  }, [searchFocusRequest, surface, tab]);
   const debouncedQuery = useDebouncedValue(query, 300);
 
   const [people, setPeople] = useState<DirectoryPerson[]>([]);
@@ -873,28 +896,13 @@ export default function ConnectPageClient() {
     };
   }, [connectionAudience, loadOutgoingRequestIds, refreshConnectionsFirstPage]);
 
-  // The directory is every account on Hussh, so listing all of it unprompted
-  // stops being useful as soon as sign-ups outgrow a screen or two: the person
-  // you came to connect with is buried among strangers, and paging through them
-  // is the tedious part.
   const trimmedQuery = debouncedQuery.trim();
   const hasQuery = trimmedQuery.length > 0;
-  // Reported: the People tab opened straight onto that unfiltered directory --
-  // a page of 20 strangers before anyone had asked to see one. Your own
-  // connections render separately, above this, and were never the problem.
-  //
-  // Explicit ask, tracked in state rather than derived from `hasQuery` alone
-  // (`peopleDirectoryRevealed`), plus `hasQuery` itself as a second, independent
-  // reason: a search restored from `readStoredConnectSearchQuery` on a fresh
-  // mount is also an explicit ask, just one made in an earlier visit, and it
-  // must reopen the section it belongs to rather than sit invisible.
-  //
-  // Advisors and Nearby keep browsing on arrival -- unaffected. Searching a
-  // verified-advisor directory or nearby businesses is the whole point of
-  // those tabs, not a fallback for not knowing who you want.
-  const [peopleDirectoryRevealed, setPeopleDirectoryRevealed] = useState(false);
-  const showPeopleDirectory =
-    tab !== "people" || peopleDirectoryRevealed || hasQuery;
+  // People and RIAs are directories, so their search and first result page are
+  // always visible. Around you owns a separate directory component and should
+  // not trigger this request behind that surface. Circles also replaces the
+  // directory entirely, so a direct Circles URL must not fetch it in secret.
+  const shouldLoadDirectory = surface === "all" && tab !== "nearby";
 
   // A new query, or a new page size, is a new result set: go back to page one
   // rather than asking for page 4 of something the reader has just redefined.
@@ -913,39 +921,29 @@ export default function ConnectPageClient() {
   const directoryAudience = CONNECT_TAB_AUDIENCE[tab];
   const isAdvisorTab = tab === "advisors";
   /**
-   * "My connections" is a disclosure. The People tab opens it by default.
-   *
-   * Originally closed, on the reasoning that it was two stacked lists of
-   * people on one screen -- the ones you already know, and the ones you are
-   * looking for -- and the first pushed the search box below the fold on a
-   * phone. That reasoning no longer holds: the directory/search half is now
-   * ITSELF collapsed behind "Add people" (see showPeopleDirectory above), so
-   * there is nothing left on the fold for a long connections list to push
-   * down. Reported: arriving on Connect with both sections visibly shut read
-   * as the screen having nothing on it.
-   *
-   * Advisors keeps its own closed default: the verified-advisor directory is
-   * the primary work there, so opening "My RIAs" first would push that task
-   * away. Each directory keeps its own disclosure state while this page is
-   * mounted, so a manual toggle does not leak across tabs.
+   * "My connections" is the only disclosure on this surface. It starts closed
+   * so the always-visible People directory remains the primary task on a phone.
+   * Each directory keeps its own disclosure state while this page is mounted,
+   * so a manual toggle does not leak across tabs.
    */
   const [connectionsOpenByTab, setConnectionsOpenByTab] = useState<
     Record<ConnectTab, boolean>
   >({
-    people: true,
+    people: false,
     advisors: false,
     nearby: false,
   });
   const connectionsOpen = connectionsOpenByTab[tab];
-  const toggleConnectionsOpen = useCallback(() => {
-    setConnectionsOpenByTab((openByTab) => ({
-      ...openByTab,
-      [tab]: !openByTab[tab],
-    }));
-  }, [tab]);
-  const connectionsHeading = isAdvisorTab
-    ? `My RIAs (${connectionsTotalCount})`
-    : `My connections (${connectionsTotalCount})`;
+  const setConnectionsOpen = useCallback(
+    (open: boolean) => {
+      setConnectionsOpenByTab((openByTab) => ({
+        ...openByTab,
+        [tab]: open,
+      }));
+    },
+    [tab],
+  );
+  const connectionsHeading = isAdvisorTab ? "My RIAs" : "My connections";
   const handleRefreshConnections = useCallback(() => {
     if (connectionsRefreshingFirstPage) return;
     void refreshConnectionsFirstPage({ audience: connectionAudience });
@@ -1019,9 +1017,7 @@ export default function ConnectPageClient() {
     let cancelled = false;
     async function run() {
       if (!user) return;
-      // Collapsed on the People tab: no reason to ask the server for a page
-      // of strangers nobody has asked to see yet.
-      if (!showPeopleDirectory) {
+      if (!shouldLoadDirectory) {
         setLoading(false);
         setError(null);
         return;
@@ -1080,7 +1076,7 @@ export default function ConnectPageClient() {
     currentPage,
     pageSize,
     directoryAudience,
-    showPeopleDirectory,
+    shouldLoadDirectory,
     // A contact sync can connect people who are sitting in this list right
     // now. Their rows carry a `relationship` the server decided before the
     // sync ran, so without this the directory keeps offering "Connect" to
@@ -1088,16 +1084,6 @@ export default function ConnectPageClient() {
     // refused. Bumping the nonce re-asks the server for the same page.
     directoryRefreshNonce,
   ]);
-
-  // Single place that focuses the search box on reveal, rather than the two
-  // call sites (this button, the search-people voice handler) each doing it
-  // inline. Inline worked for search-people before this change because the
-  // input was always already mounted; now the input often does not exist
-  // until this exact state flips, so focusing has to wait for the render
-  // that mounts it rather than fire in the same tick as the state update.
-  useEffect(() => {
-    if (peopleDirectoryRevealed) searchInputRef.current?.focus();
-  }, [peopleDirectoryRevealed]);
 
   const selectSurface = useCallback(
     (next: ConnectSurface) => {
@@ -1907,12 +1893,10 @@ export default function ConnectPageClient() {
     selectSurface("all");
     setTab("people");
     setQuery(person);
-    // A spoken search is an explicit ask too, same as tapping "Add people" --
-    // set alongside `hasQuery` so the section is guaranteed open even on the
-    // very first search of a session, before the reveal-focus effect has ever
-    // run. Focus itself is that effect's job now, once the input this needs
-    // to focus has actually mounted (see the comment beside it).
-    setPeopleDirectoryRevealed(true);
+    // The input can still be unmounted when this command starts from Circles
+    // or Around you. Record the request and let the effect above focus it only
+    // after the directory surface has actually rendered.
+    setSearchFocusRequest((request) => request + 1);
     return {
       status: "succeeded",
       summary: "Searching Connect for the name you gave.",
@@ -2409,7 +2393,7 @@ export default function ConnectPageClient() {
                       {directoryMenuOpen ? (
                         <div
                           role="menu"
-                          className="absolute left-0 top-full z-30 mt-1 w-[184px] overflow-hidden rounded-[14px] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-standard)] p-1 shadow-[0_10px_30px_rgba(0,0,0,0.10)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
+                          className={CONNECT_DIRECTORY_MENU_CLASSNAME}
                         >
                           {CONNECT_DIRECTORY_TABS.map((option) => {
                             const active = tab === option.value;
@@ -2466,7 +2450,7 @@ export default function ConnectPageClient() {
                     client configured -- the one case where there is genuinely
                     nothing to read.
                   */}
-                  {!isAdvisorTab && contactSync.available ? (
+                  {tab === "people" && contactSync.available ? (
                     <Button
                       type="button"
                       variant="none"
@@ -2506,245 +2490,260 @@ export default function ConnectPageClient() {
                   <NearbyDirectories getIdToken={getIdToken} />
                 ) : (
                   <div className="space-y-4 sm:space-y-5">
-                    <SettingsGroup
-                      // The heading IS the toggle, which is what a disclosure
-                      // is -- so it carries `aria-expanded` and `aria-controls`
-                      // and the group's own `title` stays a plain label rather
-                      // than becoming a second thing to press.
-                      //
-                      // `<button>` inside `title` would be the mistake the
-                      // `titleAction` note below records: a control rendered
-                      // inside a `role="heading"` node is folded into the
-                      // heading's accessible name and never offered as a
-                      // control. So the button IS the title node, and the
-                      // heading role moves onto it.
-                      title={
-                        <button
-                          type="button"
-                          data-testid="connect-my-connections-toggle"
-                          aria-expanded={connectionsOpen}
-                          aria-controls="connect-my-connections-panel"
-                          onClick={toggleConnectionsOpen}
-                          className="-mx-1 flex min-h-11 min-w-0 flex-1 items-center gap-1.5 rounded-[10px] px-1 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
-                        >
-                          <span className="min-w-0 truncate">
-                            {connectionsHeading}
-                          </span>
-                          <ChevronDown
-                            aria-hidden="true"
-                            className={cn(
-                              "h-4 w-4 shrink-0 text-[color:var(--app-secondary-label)] transition-transform duration-200 ease-out motion-reduce:transition-none",
-                              connectionsOpen && "rotate-180",
-                            )}
-                          />
-                        </button>
-                      }
-                      // Refresh sits in `titleAction`, not inside `title`. It used
-                      // to be a child of the title node, which `SettingsGroup`
-                      // renders inside an element carrying `role="heading"` -- and
-                      // a control there is not a control. A screen reader folds its
-                      // label into the heading's accessible name, so the heading
-                      // announced as "Your connections Refresh contacts", and the
-                      // button itself was never offered as something to press.
-                      titleAction={
-                        connectionsOpen ? (
-                        <Button
-                          type="button"
-                          variant="none"
-                          effect="fade"
-                          size="sm"
-                          aria-label="Refresh contacts"
-                          aria-busy={connectionsRefreshingFirstPage}
-                          title="Refresh contacts"
-                          disabled={connectionsRefreshingFirstPage}
-                          onClick={handleRefreshConnections}
-                          className={CONNECT_REFRESH_BUTTON_CLASSNAME}
-                        >
-                          <RefreshCw
-                            aria-hidden="true"
-                            className={cn(
-                              "h-3.5 w-3.5",
-                              connectionsRefreshingFirstPage && "animate-spin",
-                            )}
-                          />
-                        </Button>
-                        ) : null
-                      }
-                      separatorInset
-                      // Collapsed, the group is its header and nothing else --
-                      // `hidden` rather than unmounting, so the scroll position
-                      // and any in-flight row state survive a close/open, and
-                      // the panel keeps a stable node for `aria-controls` to
-                      // point at whether or not it is showing.
-                      contentClassName={cn(
-                        !connectionsOpen && "hidden",
-                        connectionsOpen && sortedConnections.length > 0
-                          ? "max-h-[232px] overflow-y-auto overscroll-contain sm:max-h-[320px]"
-                          : undefined,
-                      )}
-                      contentId="connect-my-connections-panel"
-                      testId="connect-my-connections-group"
+                    <Collapsible
+                      open={connectionsOpen}
+                      onOpenChange={setConnectionsOpen}
+                      className="group/connections space-y-2"
                     >
-                      {sortedConnections.length === 0 ? (
+                      <SettingsGroup testId="connect-my-connections-disclosure">
                         <SettingsRow
-                          // No description. "Connections appear here." explained what
-                          // an empty list already showed, and the obvious replacement
-                          // -- pointing at the search box -- is the sentence the
-                          // directory section directly below already carries. Saying
-                          // it twice on one screen is what made it noise the first
-                          // time. The title is the whole message.
-                          title={
-                            isAdvisorTab ? "No RIAs yet" : "No connections yet"
-                          }
+                          asChild
+                          icon={UsersRound}
+                          iconTone="indigo"
+                          title={connectionsHeading}
                           density="compact"
-                          disabled
-                        />
-                      ) : (
-                        sortedConnections.map((connection) => (
-                          <SettingsRow
-                            key={connection.connectionId}
-                            leading={
-                              <ConnectionPersonAvatar
-                                photoUrl={connection.photoUrl ?? null}
-                                label={
+                          trailing={
+                            <span
+                              className={
+                                CONNECT_CONNECTIONS_SUMMARY_TRAILING_CLASSNAME
+                              }
+                            >
+                              <span
+                                className={
+                                  CONNECT_CONNECTIONS_SUMMARY_COUNT_CLASSNAME
+                                }
+                              >
+                                {connectionsTotalCount}
+                              </span>
+                              <ChevronDown
+                                aria-hidden="true"
+                                className={
+                                  CONNECT_CONNECTIONS_SUMMARY_CHEVRON_CLASSNAME
+                                }
+                              />
+                            </span>
+                          }
+                        >
+                          <CollapsibleTrigger
+                            id="connect-my-connections-trigger"
+                            data-testid="connect-my-connections-toggle"
+                          />
+                        </SettingsRow>
+                      </SettingsGroup>
+
+                      <CollapsibleContent
+                        forceMount
+                        data-testid="connect-my-connections-panel"
+                        role="region"
+                        aria-labelledby="connect-my-connections-trigger"
+                        hidden={!connectionsOpen}
+                        className="space-y-2 data-[state=closed]:hidden"
+                      >
+                        <div className="flex justify-end px-1">
+                          <Button
+                            type="button"
+                            variant="none"
+                            effect="fade"
+                            size="sm"
+                            aria-label="Refresh connections"
+                            aria-busy={connectionsRefreshingFirstPage}
+                            title="Refresh connections"
+                            disabled={connectionsRefreshingFirstPage}
+                            onClick={handleRefreshConnections}
+                            className={cn(
+                              CONNECT_INLINE_BUTTON_CLASSNAME,
+                              "h-11 min-h-11",
+                            )}
+                          >
+                            <RefreshCw
+                              aria-hidden="true"
+                              className={cn(
+                                "mr-1.5 h-3.5 w-3.5",
+                                connectionsRefreshingFirstPage &&
+                                  "animate-spin",
+                              )}
+                            />
+                            {connectionsRefreshingFirstPage
+                              ? "Refreshing\u2026"
+                              : "Refresh"}
+                          </Button>
+                        </div>
+
+                        <SettingsGroup
+                          separatorInset
+                          contentClassName={cn(
+                            connectionsOpen && sortedConnections.length > 0
+                              ? "max-h-[232px] overflow-y-auto overscroll-contain sm:max-h-[320px]"
+                              : undefined,
+                          )}
+                          testId="connect-my-connections-group"
+                        >
+                          {sortedConnections.length === 0 ? (
+                            <SettingsRow
+                              // No description. "Connections appear here." explained what
+                              // an empty list already showed, and the obvious replacement
+                              // -- pointing at the search box -- is the sentence the
+                              // directory section directly below already carries. Saying
+                              // it twice on one screen is what made it noise the first
+                              // time. The title is the whole message.
+                              title={
+                                isAdvisorTab
+                                  ? "No RIAs yet"
+                                  : "No connections yet"
+                              }
+                              density="compact"
+                              disabled
+                            />
+                          ) : (
+                            sortedConnections.map((connection) => (
+                              <SettingsRow
+                                key={connection.connectionId}
+                                leading={
+                                  <ConnectionPersonAvatar
+                                    photoUrl={connection.photoUrl ?? null}
+                                    label={
+                                      connection.displayName ||
+                                      connection.userId
+                                    }
+                                    verified={Boolean(connection.isRia)}
+                                    // Compact rows, so the 58px separator inset
+                                    // they draw lands on the text -- the same
+                                    // rhythm the Circles tab beside this one has.
+                                    size="compact"
+                                  />
+                                }
+                                // Deliberately NOT stackTrailingOnMobile. That prop drops
+                                // the trailing control onto its own line below the name on
+                                // every phone (`sm:` is 640px, so "mobile" here is every
+                                // iPhone), and it was doing so for a single 72px "Remove"
+                                // that had room to sit inline all along -- a connection
+                                // read as two rows, and the list lost its right-hand
+                                // column. The People list below has never stacked; these
+                                // two lists sit on the same screen and now agree.
+                                title={
+                                  <span className="flex min-w-0 items-center gap-1.5">
+                                    <span className="min-w-0 truncate">
+                                      {connection.displayName ||
+                                        connection.userId}
+                                    </span>
+                                    {connection.connectedFromContacts ? (
+                                      <ContactSourceBadge />
+                                    ) : null}
+                                  </span>
+                                }
+                                // SettingsRow derives `data-voice-label` from a string
+                                // title, and this one is now an element so it can truncate.
+                                // Passing the name keeps the attribute the row already had.
+                                voiceLabel={
                                   connection.displayName || connection.userId
                                 }
-                                verified={Boolean(connection.isRia)}
-                                // Compact rows, so the 58px separator inset
-                                // they draw lands on the text -- the same
-                                // rhythm the Circles tab beside this one has.
-                                size="compact"
-                              />
-                            }
-                            // Deliberately NOT stackTrailingOnMobile. That prop drops
-                            // the trailing control onto its own line below the name on
-                            // every phone (`sm:` is 640px, so "mobile" here is every
-                            // iPhone), and it was doing so for a single 72px "Remove"
-                            // that had room to sit inline all along -- a connection
-                            // read as two rows, and the list lost its right-hand
-                            // column. The People list below has never stacked; these
-                            // two lists sit on the same screen and now agree.
-                            title={
-                              <span className="flex min-w-0 items-center gap-1.5">
-                                <span className="min-w-0 truncate">
-                                  {connection.displayName || connection.userId}
-                                </span>
-                                {connection.connectedFromContacts ? (
-                                  <ContactSourceBadge />
-                                ) : null}
-                              </span>
-                            }
-                            // SettingsRow derives `data-voice-label` from a string
-                            // title, and this one is now an element so it can truncate.
-                            // Passing the name keeps the attribute the row already had.
-                            voiceLabel={
-                              connection.displayName || connection.userId
-                            }
-                            density="compact"
-                            onClick={
-                              connection.publicPersonRef
-                                ? () =>
-                                    router.push(
-                                      buildPersonProfileRoute(
-                                        connection.publicPersonRef!,
-                                        { from: ROUTES.CONNECT },
-                                      ),
-                                    )
-                                : undefined
-                            }
-                            trailing={
-                              <span className="flex shrink-0 items-center justify-end gap-1.5 whitespace-nowrap">
-                                {pendingRemoveId === connection.connectionId ? (
-                                  <>
-                                    <Button
-                                      type="button"
-                                      variant="destructive"
-                                      effect="fill"
-                                      size="sm"
-                                      className={
-                                        CONNECT_INLINE_BUTTON_CLASSNAME
-                                      }
-                                      disabled={
-                                        busyId === connection.connectionId
-                                      }
-                                      onClick={(event) => {
-                                        event.stopPropagation();
-                                        void handleRemove(connection);
-                                      }}
-                                    >
-                                      {busyId === connection.connectionId
-                                        ? "Removing…"
-                                        : "Confirm"}
-                                    </Button>
-                                    <Button
-                                      type="button"
-                                      variant="none"
-                                      effect="fade"
-                                      size="sm"
-                                      className={
-                                        CONNECT_INLINE_BUTTON_CLASSNAME
-                                      }
-                                      disabled={
-                                        busyId === connection.connectionId
-                                      }
-                                      onClick={(event) => {
-                                        event.stopPropagation();
-                                        setPendingRemoveId(null);
-                                      }}
-                                    >
-                                      Cancel
-                                    </Button>
-                                  </>
-                                ) : (
-                                  <Button
-                                    type="button"
-                                    variant="none"
-                                    effect="fade"
-                                    size="sm"
-                                    onClick={(event) => {
-                                      event.stopPropagation();
-                                      setPendingRemoveId(
-                                        connection.connectionId,
-                                      );
-                                    }}
-                                    aria-label={`Remove connection with ${connection.displayName || connection.userId}`}
-                                    className={cn(
-                                      CONNECT_INLINE_BUTTON_CLASSNAME,
-                                      "text-muted-foreground hover:text-destructive",
+                                density="compact"
+                                onClick={
+                                  connection.publicPersonRef
+                                    ? () =>
+                                        router.push(
+                                          buildPersonProfileRoute(
+                                            connection.publicPersonRef!,
+                                            { from: ROUTES.CONNECT },
+                                          ),
+                                        )
+                                    : undefined
+                                }
+                                trailing={
+                                  <span className="flex shrink-0 items-center justify-end gap-1.5 whitespace-nowrap">
+                                    {pendingRemoveId ===
+                                    connection.connectionId ? (
+                                      <>
+                                        <Button
+                                          type="button"
+                                          variant="destructive"
+                                          effect="fill"
+                                          size="sm"
+                                          className={
+                                            CONNECT_INLINE_BUTTON_CLASSNAME
+                                          }
+                                          disabled={
+                                            busyId === connection.connectionId
+                                          }
+                                          onClick={(event) => {
+                                            event.stopPropagation();
+                                            void handleRemove(connection);
+                                          }}
+                                        >
+                                          {busyId === connection.connectionId
+                                            ? "Removing…"
+                                            : "Confirm"}
+                                        </Button>
+                                        <Button
+                                          type="button"
+                                          variant="none"
+                                          effect="fade"
+                                          size="sm"
+                                          className={
+                                            CONNECT_INLINE_BUTTON_CLASSNAME
+                                          }
+                                          disabled={
+                                            busyId === connection.connectionId
+                                          }
+                                          onClick={(event) => {
+                                            event.stopPropagation();
+                                            setPendingRemoveId(null);
+                                          }}
+                                        >
+                                          Cancel
+                                        </Button>
+                                      </>
+                                    ) : (
+                                      <Button
+                                        type="button"
+                                        variant="none"
+                                        effect="fade"
+                                        size="sm"
+                                        onClick={(event) => {
+                                          event.stopPropagation();
+                                          setPendingRemoveId(
+                                            connection.connectionId,
+                                          );
+                                        }}
+                                        aria-label={`Remove connection with ${connection.displayName || connection.userId}`}
+                                        className={cn(
+                                          CONNECT_INLINE_BUTTON_CLASSNAME,
+                                          "text-muted-foreground hover:text-destructive",
+                                        )}
+                                      >
+                                        Remove
+                                      </Button>
                                     )}
-                                  >
-                                    Remove
-                                  </Button>
-                                )}
-                              </span>
-                            }
-                          />
-                        ))
-                      )}
-                    </SettingsGroup>
+                                  </span>
+                                }
+                              />
+                            ))
+                          )}
+                        </SettingsGroup>
 
-                    {connectionsHasMore ? (
-                      <div className="flex justify-center">
-                        <Button
-                          type="button"
-                          variant="none"
-                          effect="fill"
-                          size="sm"
-                          className={CONNECT_PAGER_BUTTON_CLASSNAME}
-                          disabled={
-                            connectionsLoadingMore ||
-                            connectionsRefreshingFirstPage
-                          }
-                          onClick={() => void handleLoadMoreConnections()}
-                        >
-                          {connectionsLoadingMore
-                            ? "Loading…"
-                            : "Load more connections"}
-                        </Button>
-                      </div>
-                    ) : null}
+                        {connectionsHasMore ? (
+                          <div className="flex justify-center">
+                            <Button
+                              type="button"
+                              variant="none"
+                              effect="fill"
+                              size="sm"
+                              className={CONNECT_PAGER_BUTTON_CLASSNAME}
+                              disabled={
+                                connectionsLoadingMore ||
+                                connectionsRefreshingFirstPage
+                              }
+                              onClick={() => void handleLoadMoreConnections()}
+                            >
+                              {connectionsLoadingMore
+                                ? "Loading…"
+                                : "Load more connections"}
+                            </Button>
+                          </div>
+                        ) : null}
+                      </CollapsibleContent>
+                    </Collapsible>
 
-                    {showPeopleDirectory ? (
                     <div className="space-y-4">
                       <SettingsGroup
                         title={CONNECT_TAB_LABEL[tab]}
@@ -2841,7 +2840,9 @@ export default function ConnectPageClient() {
                                 ref={searchInputRef}
                                 type="text"
                                 value={query}
-                              onChange={(event) => setQuery(event.target.value)}
+                                onChange={(event) =>
+                                  setQuery(event.target.value)
+                                }
                                 placeholder={CONNECT_SEARCH_PLACEHOLDER}
                                 aria-label="Search people"
                                 data-voice-control-id="one-connect-search"
@@ -2878,10 +2879,14 @@ export default function ConnectPageClient() {
                                     });
                                   }, 300);
                                   const dismiss = () => field.blur();
-                                window.addEventListener("touchmove", dismiss, {
+                                  window.addEventListener(
+                                    "touchmove",
+                                    dismiss,
+                                    {
                                       passive: true,
                                       once: true,
-                                });
+                                    },
+                                  );
                                   field.addEventListener(
                                     "blur",
                                     () =>
@@ -3224,26 +3229,6 @@ export default function ConnectPageClient() {
                           )}
                       </SettingsGroup>
                     </div>
-                    ) : (
-                      <SettingsGroup>
-                        <SettingsRow
-                          leading={
-                            <span
-                              aria-hidden="true"
-                              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-accent-surface)] text-[color:var(--app-accent)]"
-                            >
-                              <UserPlus className="h-4 w-4" />
-                            </span>
-                          }
-                          title="Add people"
-                          description="Search Hussh for someone to connect with."
-                          chevron
-                          onClick={() => setPeopleDirectoryRevealed(true)}
-                          testId="connect-add-people"
-                          ariaLabel="Add people"
-                        />
-                      </SettingsGroup>
-                    )}
                   </div>
                 )}
               </>

--- a/hushh-webapp/components/one-location/redesign/__tests__/circles-section-subtitle.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/circles-section-subtitle.test.tsx
@@ -119,7 +119,7 @@ describe("the circle row's second line", () => {
     expect(screen.getByTestId("one-location-circle-neutral-mark")).toBeTruthy();
   });
 
-  it("separates circles created by you, joined circles, and built-in circles", () => {
+  it("groups every Circle by ownership, including built-in Circles", () => {
     renderCircles([
       circle({ id: "joined_1", name: "Road Trip", role: "member" }),
       circle({ id: "owned_1", name: "Family", role: "owner" }),
@@ -131,9 +131,17 @@ describe("the circle row's second line", () => {
       }),
       circle({ id: "owned_2", name: "Close Friends", role: "owner" }),
       circle({
-        id: "built_in_sms",
+        id: "owned_sms",
         name: "Emergency Circle",
         role: "owner",
+        memberCount: 2,
+        isSystem: true,
+        systemKind: "sms",
+      }),
+      circle({
+        id: "joined_sms",
+        name: "Alice's SMS Circle",
+        role: "member",
         isSystem: true,
         systemKind: "sms",
       }),
@@ -141,20 +149,26 @@ describe("the circle row's second line", () => {
 
     const created = screen.getByTestId("one-location-circle-group-created");
     const joined = screen.getByTestId("one-location-circle-group-joined");
-    const builtIn = screen.getByTestId("one-location-circle-group-built-in");
 
     expect(within(created).getByText("Created by you")).toBeTruthy();
     expect(within(created).getByText("Family")).toBeTruthy();
     expect(within(created).getByText("Close Friends")).toBeTruthy();
+    expect(within(created).getByText("Trusted")).toBeTruthy();
+    expect(within(created).getByText("Emergency Circle")).toBeTruthy();
+    expect(within(created).getByText("Save My Soul · 1 person")).toBeTruthy();
     expect(within(created).queryByText("Road Trip")).toBeNull();
+    expect(within(created).queryByText("Alice's SMS Circle")).toBeNull();
 
     expect(within(joined).getByText("Joined circles")).toBeTruthy();
     expect(within(joined).getByText("Road Trip")).toBeTruthy();
+    expect(within(joined).getByText("Alice's SMS Circle")).toBeTruthy();
+    expect(within(joined).getByText("Save My Soul · Only you")).toBeTruthy();
     expect(within(joined).queryByText("Family")).toBeNull();
+    expect(within(joined).queryByText("Trusted")).toBeNull();
 
-    expect(within(builtIn).getByText("Built-in")).toBeTruthy();
-    expect(within(builtIn).getByText("Trusted")).toBeTruthy();
-    expect(within(builtIn).getByText("Emergency Circle")).toBeTruthy();
-    expect(within(builtIn).getByText("Save My Soul · Only you")).toBeTruthy();
+    expect(screen.queryByText("Built-in")).toBeNull();
+    expect(
+      screen.queryByTestId("one-location-circle-group-built-in"),
+    ).toBeNull();
   });
 });

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -177,7 +177,7 @@ function circleListPeopleLabel(memberCount: number | null | undefined): string {
   return `${others} ${others === 1 ? "person" : "people"}`;
 }
 
-type CircleListGroupKey = "created" | "joined" | "built-in";
+type CircleListGroupKey = "created" | "joined";
 
 type CircleListGroup = {
   key: CircleListGroupKey;
@@ -188,7 +188,6 @@ type CircleListGroup = {
 function circleListGroupKey(
   circle: OneLocationCircleSummary,
 ): CircleListGroupKey {
-  if (circle.systemKind || circle.isSystem) return "built-in";
   return circle.role === "owner" ? "created" : "joined";
 }
 
@@ -198,7 +197,6 @@ function groupCirclesForPeopleTab(
   const groups: CircleListGroup[] = [
     { key: "created", title: "Created by you", circles: [] },
     { key: "joined", title: "Joined circles", circles: [] },
-    { key: "built-in", title: "Built-in", circles: [] },
   ];
   const groupByKey = new Map(groups.map((group) => [group.key, group]));
 

--- a/hushh-webapp/e2e/connect-circle-cta.layout.spec.ts
+++ b/hushh-webapp/e2e/connect-circle-cta.layout.spec.ts
@@ -17,6 +17,12 @@ import {
   CONNECT_SEARCH_PLACEHOLDER,
 } from "../app/connect/connect-search-layout";
 import {
+  CONNECT_CONNECTIONS_SUMMARY_CHEVRON_CLASSNAME,
+  CONNECT_CONNECTIONS_SUMMARY_COUNT_CLASSNAME,
+  CONNECT_CONNECTIONS_SUMMARY_TRAILING_CLASSNAME,
+  CONNECT_DIRECTORY_MENU_CLASSNAME,
+} from "../app/connect/connect-surface-layout";
+import {
   CIRCLE_NAME_ACTION_CLASSNAME,
   CIRCLE_NAME_INPUT_CLASSNAME,
   CIRCLE_NAME_ROW_CLASSNAME,
@@ -359,9 +365,7 @@ const SEARCH_CANDIDATES = [
 ];
 
 /** The row exactly as Connect builds it: one full-width search field. */
-const searchRowBody = (
-  empty: boolean,
-) => `<div class="block w-full">
+const searchRowBody = (empty: boolean) => `<div class="block w-full">
   <div class="relative">
     <input data-testid="connect-search" placeholder="${CONNECT_SEARCH_PLACEHOLDER}"
       class="${INPUT_CLASSNAME} ${CONNECT_SEARCH_INPUT_CLASSNAME} ${
@@ -434,7 +438,6 @@ test.describe("Connect search row", () => {
         current.needed,
         `"${CONNECT_SEARCH_PLACEHOLDER}" needs ${current.needed.toFixed(1)}px of ${current.available.toFixed(1)}px`,
       ).toBeLessThanOrEqual(current.available + 0.5);
-
     });
   }
 
@@ -486,9 +489,7 @@ test.describe("Connect search row", () => {
       const field = await boxOf(page, '[data-testid="connect-search"]');
       expect(field.left).toBeGreaterThanOrEqual(0);
       expect(field.right).toBeLessThanOrEqual(width + 0.5);
-      expect(field.width).toBeGreaterThanOrEqual(
-        width - PAGE_PADDING_PX * 2,
-      );
+      expect(field.width).toBeGreaterThanOrEqual(width - PAGE_PADDING_PX * 2);
     });
   }
 });
@@ -637,4 +638,130 @@ test.describe("Connect list rows", () => {
     expect(cancel.width).toBeLessThanOrEqual(connect.width + 0.5);
     expect(cancel.height).toBeLessThanOrEqual(32.5);
   });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The My connections disclosure and directory menu
+// ---------------------------------------------------------------------------
+
+const DISCLOSURE_CARD_CLASSNAME =
+  "relative isolate overflow-hidden rounded-[var(--app-card-radius-standard,24px)] bg-[color:var(--app-card-surface-default-solid)] shadow-[var(--app-card-shadow-standard)] ring-0";
+const DISCLOSURE_ROW_SHELL_CLASSNAME =
+  "group/settings-row relative isolate overflow-hidden bg-transparent [--settings-row-py:10px]";
+const DISCLOSURE_TRIGGER_CLASSNAME =
+  "relative isolate grid w-full appearance-none overflow-hidden border-0 bg-transparent px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-left min-h-[56px] grid-cols-[minmax(0,1fr)_auto] items-center gap-x-[var(--settings-row-gap)]";
+const DISCLOSURE_MAIN_CLASSNAME =
+  "relative z-0 flex min-w-0 items-center gap-[var(--settings-row-gap)]";
+const DISCLOSURE_ICON_CLASSNAME =
+  "inline-flex h-7 w-7 shrink-0 items-center justify-center self-center rounded-[7px]";
+const DISCLOSURE_TITLE_CLASSNAME = "ui-text-row-label min-w-0 flex-1 truncate";
+const DISCLOSURE_TRAILING_WRAPPER_CLASSNAME =
+  "relative z-0 flex max-w-full shrink-0 items-center justify-end self-center gap-2.5 pr-0.5 sm:pr-1";
+
+const DISCLOSURE_CANDIDATES = [
+  "mx-auto w-full max-w-[720px]",
+  DISCLOSURE_CARD_CLASSNAME,
+  DISCLOSURE_ROW_SHELL_CLASSNAME,
+  DISCLOSURE_TRIGGER_CLASSNAME,
+  DISCLOSURE_MAIN_CLASSNAME,
+  DISCLOSURE_ICON_CLASSNAME,
+  DISCLOSURE_TITLE_CLASSNAME,
+  DISCLOSURE_TRAILING_WRAPPER_CLASSNAME,
+  CONNECT_CONNECTIONS_SUMMARY_TRAILING_CLASSNAME,
+  CONNECT_CONNECTIONS_SUMMARY_COUNT_CLASSNAME,
+  CONNECT_CONNECTIONS_SUMMARY_CHEVRON_CLASSNAME,
+].flatMap((className) => className.split(/\s+/));
+
+const disclosureBody = `<section class="mx-auto w-full max-w-[720px]">
+  <div class="${DISCLOSURE_CARD_CLASSNAME}">
+    <div class="${DISCLOSURE_ROW_SHELL_CLASSNAME}">
+      <button type="button" data-testid="connections-trigger" class="${DISCLOSURE_TRIGGER_CLASSNAME}">
+        <span class="${DISCLOSURE_MAIN_CLASSNAME}">
+          <span aria-hidden="true" class="${DISCLOSURE_ICON_CLASSNAME}">
+            <svg width="16" height="16" viewBox="0 0 16 16"><circle cx="8" cy="6" r="3" /></svg>
+          </span>
+          <span data-testid="connections-title" class="${DISCLOSURE_TITLE_CLASSNAME}">My connections</span>
+        </span>
+        <span data-testid="connections-trailing" class="${DISCLOSURE_TRAILING_WRAPPER_CLASSNAME}">
+          <span class="${CONNECT_CONNECTIONS_SUMMARY_TRAILING_CLASSNAME}">
+            <span class="${CONNECT_CONNECTIONS_SUMMARY_COUNT_CLASSNAME}">9,999</span>
+            <svg data-testid="connections-chevron" aria-hidden="true" class="${CONNECT_CONNECTIONS_SUMMARY_CHEVRON_CLASSNAME}" viewBox="0 0 16 16"><path d="m4 6 4 4 4-4" /></svg>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</section>`;
+
+test.describe("Connect disclosure row", () => {
+  for (const width of [320, 768] as const) {
+    test(`stays a full-width single row at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(
+        await buildFixture(
+          "connect-connections-disclosure",
+          disclosureBody,
+          DISCLOSURE_CANDIDATES,
+        ),
+      );
+      await awaitProductFont(page);
+      await fontsReady(page);
+
+      const trigger = await boxOf(page, '[data-testid="connections-trigger"]');
+      const title = await boxOf(page, '[data-testid="connections-title"]');
+      const trailing = await boxOf(
+        page,
+        '[data-testid="connections-trailing"]',
+      );
+      const chevron = await boxOf(page, '[data-testid="connections-chevron"]');
+
+      expect(trigger.height, "touch target").toBeGreaterThanOrEqual(56);
+      expect(trigger.left).toBeGreaterThanOrEqual(PAGE_PADDING_PX - 1);
+      expect(trigger.right).toBeLessThanOrEqual(width - PAGE_PADDING_PX + 1);
+      expect(
+        title.right,
+        "title does not collide with count",
+      ).toBeLessThanOrEqual(trailing.left + 0.5);
+      expect(title.top).toBeLessThan(trailing.bottom);
+      expect(trailing.top).toBeLessThan(title.bottom);
+      expect(chevron.right).toBeLessThanOrEqual(trigger.right);
+
+      const scrollWidth = await page.evaluate(
+        () => document.documentElement.scrollWidth,
+      );
+      expect(scrollWidth).toBeLessThanOrEqual(width);
+    });
+  }
+});
+
+test("Connect directory menu is opaque in light and dark themes", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(
+    await buildFixture(
+      "connect-directory-menu",
+      `<div data-testid="directory-menu" class="${CONNECT_DIRECTORY_MENU_CLASSNAME}">People</div>`,
+      CONNECT_DIRECTORY_MENU_CLASSNAME.split(/\s+/),
+    ),
+  );
+
+  for (const dark of [false, true]) {
+    await page.evaluate((enabled) => {
+      document.documentElement.classList.toggle("dark", enabled);
+    }, dark);
+
+    const alpha = await page.getByTestId("directory-menu").evaluate((el) => {
+      const canvas = document.createElement("canvas");
+      canvas.width = canvas.height = 1;
+      const context = canvas.getContext("2d")!;
+      context.clearRect(0, 0, 1, 1);
+      context.fillStyle = "rgba(0, 0, 0, 0)";
+      context.fillStyle = getComputedStyle(el).backgroundColor;
+      context.fillRect(0, 0, 1, 1);
+      return context.getImageData(0, 0, 1, 1).data[3];
+    });
+
+    expect(alpha, dark ? "dark menu alpha" : "light menu alpha").toBe(255);
+  }
 });


### PR DESCRIPTION
# Description

This PR clarifies both People surfaces covered by the task.

### One Location People

- Circles owned by the viewer render under **Created by you**.
- Circles joined as a member render under **Joined circles**.
- Trusted and SMS/system Circles follow the same canonical owner/member rule.
- The separate **Built-in** category is removed.

### Connect People

- The People directory and search are always visible again; the temporary **Add people** reveal gate is removed.
- **My connections** is a compact, full-row disclosure that starts closed. The RIA audience keeps its own independently closed **My RIAs** disclosure.
- Refresh, connection rows, and pagination are all contained inside the disclosure panel.
- The People / RIAs / Around you menu uses a fully opaque shared surface in light and dark themes.
- Contact sync appears only on People, and hidden directory reads are skipped on Circles and Around you.

No API, schema, cache-key, consent, or persisted-data contract changed.

## Impact Map

- Routes touched:
  - [x] `/one/location?view=people`
  - [x] `/one/connect`
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- Mobile parity impacts:
  - [x] Shared React/Capacitor surfaces receive the same responsive behavior on web, iOS, and Android; no native bridge changed
- Trust boundary touched:
  - [x] None
- Rollback behavior:
  - [x] Revert the two feature commits; no persisted state requires migration
- UI browser proof:
  - [x] Circle grouping was exercised at 320, 390, 834, and 1440px
  - [x] Connect disclosure geometry and menu opacity were exercised by Playwright in Chromium and WebKit, including 320px phone width, 768px layout, and light/dark menu surfaces

## Verification

- [x] `npm run verify:one-location` — 771 tests passed for the Circle change
- [x] `npm run verify:connect-search` — 6 files, 158 tests passed
- [x] `npm run typecheck`
- [x] Targeted ESLint for all changed Connect source/test files
- [x] `npm run verify:design-system`
- [x] `playwright test e2e/connect-circle-cta.layout.spec.ts --project=chromium` — 27 passed
- [x] `playwright test e2e/connect-circle-cta.layout.spec.ts --project=webkit` — 27 passed
- [x] `git diff --check origin/main...HEAD`
- [x] Every PR commit contains a DCO sign-off; remote DCO is authoritative
- [ ] `npm run verify:routes` requires maintainer-only reviewer credentials unavailable in this shell

## Review-Ready Contract

- [x] Current reachable production components are changed directly.
- [x] Focused tests exercise the production components and service-call boundaries.
- [x] Responsive browser contracts cover the compact disclosure and opaque dropdown.
- [x] The branch contains the latest `main` and is DCO-signed.
- [x] No generated files or dependencies changed.
- [x] Not a stacked PR.

## Privacy, Consent, and Licensing

- [x] No new user-data access or consent path is introduced.
- [x] Existing safe loading/empty/error behavior remains intact.
- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependency or third-party notice changed.

## Deployment

Merge is authorized after required checks pass. UAT deployment is intentionally excluded until separately authorized.
