### PR TITLE
fix(native): restore Capacitor static export

### DIFF
--- a/hushh-webapp/__tests__/app/one-layout-cache.contract.test.ts
+++ b/hushh-webapp/__tests__/app/one-layout-cache.contract.test.ts
@@ -6,13 +6,16 @@ import { describe, expect, it } from "vitest";
 const repoRoot = path.resolve(__dirname, "..", "..");
 
 describe("/one layout cache policy", () => {
-  it("keeps signed-in One routes out of static HTML caching", () => {
+  it("requires a live web request without breaking Capacitor static export", () => {
     const source = readFileSync(
       path.join(repoRoot, "app", "one", "layout.tsx"),
       "utf8",
     );
 
-    expect(source).toContain('export const dynamic = "force-dynamic"');
-    expect(source).toContain("export const revalidate = 0");
+    expect(source).toContain('import { connection } from "next/server"');
+    expect(source).toContain('process.env.CAPACITOR_BUILD !== "true"');
+    expect(source).toContain("await connection()");
+    expect(source).not.toContain('dynamic = "force-dynamic"');
+    expect(source).not.toContain("revalidate = 0");
   });
 });

--- a/hushh-webapp/__tests__/lib/connected-systems/crm-product-availability.test.ts
+++ b/hushh-webapp/__tests__/lib/connected-systems/crm-product-availability.test.ts
@@ -1,8 +1,53 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 import { isLocalCrmProductAvailable } from "@/lib/connected-systems/crm-product-availability";
 
 describe("local CRM product availability", () => {
+  it("fails closed before request-header access during Capacitor export", () => {
+    const source = readFileSync(
+      path.resolve(
+        __dirname,
+        "../../../lib/connected-systems/local-crm-route-guard.ts",
+      ),
+      "utf8",
+    );
+    const nativeGuard = source.indexOf(
+      'process.env.CAPACITOR_BUILD === "true"',
+    );
+    const requestHeaders = source.indexOf("await headers()");
+
+    expect(nativeGuard).toBeGreaterThanOrEqual(0);
+    expect(requestHeaders).toBeGreaterThan(nativeGuard);
+  });
+
+  it("keeps request-only profile query parsing out of Capacitor export", () => {
+    const source = readFileSync(
+      path.resolve(__dirname, "../../../app/one/profile/page.tsx"),
+      "utf8",
+    );
+    const nativeGuard = source.indexOf(
+      'process.env.CAPACITOR_BUILD !== "true"',
+    );
+    const requestSearchParams = source.indexOf("await searchParams");
+
+    expect(nativeGuard).toBeGreaterThanOrEqual(0);
+    expect(requestSearchParams).toBeGreaterThan(nativeGuard);
+  });
+
+  it("hides a crafted local-CRM profile route in disabled builds", () => {
+    const source = readFileSync(
+      path.resolve(__dirname, "../../../app/profile/profile-workspace-page.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain("const localCrmEnabled = isLocalCrmBuildEnabled()");
+    expect(source).toContain(
+      'profileRouteState.panel === "connected-systems" && !localCrmEnabled',
+    );
+  });
+
   it.each(["uat", "production"] as const)("fails closed in %s", (environment) => {
     expect(
       isLocalCrmProductAvailable({

--- a/hushh-webapp/app/one/layout.tsx
+++ b/hushh-webapp/app/one/layout.tsx
@@ -1,12 +1,19 @@
 import type { ReactNode } from "react";
+import { connection } from "next/server";
 
 import { OneAuthGate } from "./one-auth-gate";
 import { HushhIntroGate } from "@/components/app-ui/HushhIntroGate";
 
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
+export default async function OneLayout({ children }: { children: ReactNode }) {
+  // Web requests must never reuse authenticated One HTML across people. The
+  // Capacitor app has no Next.js server, so its release build deliberately
+  // skips this request boundary and emits the same client-owned shell as static
+  // files. A route-segment `force-dynamic` export cannot express both modes and
+  // makes every iOS/Android static export fail before native compilation.
+  if (process.env.CAPACITOR_BUILD !== "true") {
+    await connection();
+  }
 
-export default function OneLayout({ children }: { children: ReactNode }) {
   // HushhIntroGate sits one level above OneAuthGate (and therefore above
   // VaultLockGuard and every other auth/vault guard). It does not just
   // overlay them — it withholds `{children}` (OneAuthGate, VaultLockGuard,

--- a/hushh-webapp/app/one/profile/page.tsx
+++ b/hushh-webapp/app/one/profile/page.tsx
@@ -6,12 +6,17 @@ type ProfilePageProps = {
 };
 
 export default async function ProfilePage({ searchParams }: ProfilePageProps) {
-  const query = (await searchParams) ?? {};
-  const requestedPanel = String(query.panel ?? query.tab ?? "")
-    .trim()
-    .toLowerCase();
-  if (requestedPanel === "connected-systems" || requestedPanel === "systems") {
-    await requireLocalCrmRoute();
+  // Search parameters are request state on web but browser state in the
+  // serverless Capacitor bundle. Native availability is enforced again by the
+  // client workspace, so the exporter must not await a request-only value.
+  if (process.env.CAPACITOR_BUILD !== "true") {
+    const query = (await searchParams) ?? {};
+    const requestedPanel = String(query.panel ?? query.tab ?? "")
+      .trim()
+      .toLowerCase();
+    if (requestedPanel === "connected-systems" || requestedPanel === "systems") {
+      await requireLocalCrmRoute();
+    }
   }
   return <ProfileWorkspacePage />;
 }

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -75,6 +75,7 @@ import { VoicePreferencesPanel } from "@/components/profile/voice-preferences-pa
 import { VoiceChangelogPage } from "@/components/profile/voice-changelog-page";
 import { VoiceExamplesPage } from "@/components/profile/voice-examples-page";
 import { ConnectedSystemsPanel } from "@/components/profile/connected-systems-panel";
+import { isLocalCrmBuildEnabled } from "@/lib/connected-systems/crm-product-availability";
 import { ThemeToggleLean } from "@/components/theme-toggle";
 import {
   AlertDialog,
@@ -686,8 +687,12 @@ function ProfilePageContent() {
     () => resolveProfileRouteState(pathname, searchParams),
     [pathname, searchParams],
   );
-  const activePanel = profileRouteState.panel;
-  const activeDetail = profileRouteState.detail;
+  const localCrmEnabled = isLocalCrmBuildEnabled();
+  const activePanel =
+    profileRouteState.panel === "connected-systems" && !localCrmEnabled
+      ? null
+      : profileRouteState.panel;
+  const activeDetail = activePanel ? profileRouteState.detail : null;
   const profileNativeRouteId = useMemo(
     () =>
       pathname === ROUTES.PROFILE || pathname.startsWith(`${ROUTES.PROFILE}/`)

--- a/hushh-webapp/lib/connected-systems/local-crm-route-guard.ts
+++ b/hushh-webapp/lib/connected-systems/local-crm-route-guard.ts
@@ -6,6 +6,11 @@ import { notFound } from "next/navigation";
 import { isLocalCrmProductAvailable } from "@/lib/connected-systems/crm-product-availability";
 
 export async function requireLocalCrmRoute(): Promise<void> {
+  // The native app is a static UAT/production bundle and local CRM is an
+  // explicitly localhost-only development surface. Fail closed before reading
+  // request headers so Capacitor export never acquires a server dependency.
+  if (process.env.CAPACITOR_BUILD === "true") notFound();
+
   const requestHeaders = await headers();
   const host = String(
     requestHeaders.get("x-forwarded-host") || requestHeaders.get("host") || "",


### PR DESCRIPTION
## Summary

- preserve request-bound rendering for the web app while allowing Capacitor static export
- fail closed for the localhost-only CRM surface in native builds
- keep the Siri/App Intent flow on the existing Agent Bar and One Voice runtime
- unblock the TestFlight pipeline after run 33533786427 exposed the static-export regression

## Verification

- complete local pre-PR mirror: passing
- frontend: 715 test files passed, 5,841 tests passed
- backend: 1,861 tests passed
- Next.js production build and Capacitor static export: passing (140 native routes)
- voice gateway, generated route index, native surface map, native static parity, and Capacitor plugin parity: passing
- TypeScript, lint, security, governance, DCO, and PKM compatibility: passing

## Release intent

After exact-head PR validation and exact-SHA post-merge smoke, dispatch the existing TestFlight workflow for the landed main SHA.