### PR TITLE
chore(ios): open version 1.3.9 train

### DIFF
--- a/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
@@ -628,7 +628,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.8;
+				MARKETING_VERSION = 1.3.9;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.hushh.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -657,7 +657,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.8;
+				MARKETING_VERSION = 1.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hushh.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary

- bump the iOS App Debug and Release marketing version from 1.3.8 to 1.3.9
- keep build-number resolution and the existing TestFlight workflow unchanged
- unblock the Siri/App Intents P0 upload after App Store Connect closed the 1.3.8 pre-release train

## Evidence

The exact-SHA TestFlight run for 01392b27fa4415b3f23bb645ef112f3ff39b83be passed native project preparation, Swift package resolution, hosted-simulator AppTests, signing, and archive. App Store Connect rejected only the closed 1.3.8 train: https://github.com/hushh-labs/hushh-research/actions/runs/33539455145

Local verification is green: the version resolver reports 1.3.9 and the full pre-PR verification bundle passed, including frontend, backend, Capacitor export, native parity, voice gateway, security, and PKM suites.

After merge, the release will be rerun against the exact landed main SHA.