### PR TITLE
fix(uat): harden runtime recovery and streaming

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -219,6 +219,40 @@ jobs:
             --github-output "$GITHUB_OUTPUT" \
             --json
 
+      - name: Resolve last-known-good rollback targets
+        id: rollback-targets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # This tag intentionally moves after every healthy UAT release. Force
+          # refresh it so a reused checkout cannot resolve a stale local tag.
+          git fetch --force origin \
+            refs/tags/deployed/uat-latest:refs/tags/deployed/uat-latest
+
+          backend_revision=""
+          if [ "${{ steps.scope.outputs.deploy_backend }}" = "true" ]; then
+            backend_revision="$(
+              ROLLBACK_VERIFY_SERVICE="${{ env.BACKEND_SERVICE }}" \
+              ROLLBACK_VERIFY_REGION="${{ env.GCP_REGION }}" \
+              ROLLBACK_VERIFY_PROJECT="${{ env.GCP_PROJECT_ID }}" \
+              bash scripts/ci/resolve-rollback-target.sh uat backend
+            )"
+          fi
+
+          frontend_revision=""
+          if [ "${{ steps.scope.outputs.deploy_frontend }}" = "true" ]; then
+            frontend_revision="$(
+              ROLLBACK_VERIFY_SERVICE="${{ env.FRONTEND_SERVICE }}" \
+              ROLLBACK_VERIFY_REGION="${{ env.GCP_REGION }}" \
+              ROLLBACK_VERIFY_PROJECT="${{ env.GCP_PROJECT_ID }}" \
+              bash scripts/ci/resolve-rollback-target.sh uat frontend
+            )"
+          fi
+
+          echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
+          echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
+
       - name: Resolve UAT verification plan
         id: verification-plan
         shell: bash
@@ -518,7 +552,7 @@ jobs:
         run: |
           set -euo pipefail
           started_at="$(date +%s)"
-          SUBSTITUTIONS="_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }}##_REGION=${{ env.GCP_REGION }}##_CLOUDSQL_INSTANCES=${{ env.UAT_CLOUDSQL_INSTANCE }}##_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID##_PLAID_SECRET_SECRET=PLAID_SECRET##_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY##_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY##_PMP_API_KEY_SECRET=PMP_API_KEY##_NEWSAPI_KEY_SECRET=NEWSAPI_KEY##_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID##_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET##_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI##_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY##_GOOGLE_OAUTH_CLIENT_ID_SECRET=GOOGLE_OAUTH_CLIENT_ID##_GOOGLE_OAUTH_CLIENT_SECRET_SECRET=GOOGLE_OAUTH_CLIENT_SECRET##_GOOGLE_OAUTH_REDIRECT_URI_SECRET=GOOGLE_OAUTH_REDIRECT_URI##_GOOGLE_OAUTH_TOKEN_KEY_SECRET=GOOGLE_OAUTH_TOKEN_KEY##_OPENAI_API_KEY_SECRET=OPENAI_API_KEY##_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY##_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON##_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN##_HUSHH_TECH_LAUNCH_PEPPER_SECRET=HUSSH_TECH_LAUNCH_PEPPER##_RATE_LIMIT_STORAGE_URI_SECRET=RATE_LIMIT_STORAGE_URI##_HUSHH_UAT_PHONE_TEST_NUMBERS_SECRET=HUSHH_UAT_PHONE_TEST_NUMBERS##_HUSHH_UAT_PHONE_TEST_CODE_SECRET=HUSHH_UAT_PHONE_TEST_CODE##_REVIEWER_UID_SECRET=REVIEWER_UID##_REVIEWER_VAULT_PASSPHRASE_SECRET=REVIEWER_VAULT_PASSPHRASE##_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL##_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET=ONE_EMAIL_WATCH_RENEW_TOKEN##_ONE_EMAIL_ADDRESS=one@hushh.ai##_ONE_EMAIL_DELEGATED_USER=one@hushh.ai##_ONE_EMAIL_PUBSUB_TOPIC=projects/hushh-pda/topics/one-email-kyc-uat##_ONE_EMAIL_WEBHOOK_AUDIENCE=https://consent-protocol-f2gsa4kfsq-uc.a.run.app/api/one/email/webhook##_ONE_EMAIL_WEBHOOK_SERVICE_ACCOUNT_EMAIL=one-email-pubsub-push@hushh-pda.iam.gserviceaccount.com##_ONE_EMAIL_WEBHOOK_AUTH_ENABLED=true##_ONE_EMAIL_WATCH_RENEW_AUTH_ENABLED=true##_ONE_EMAIL_KYC_DEFAULT_SCOPE=attr.identity.*##_ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED=true##_ONE_WALLET_CARD_ENABLED=true##_WALLET_PASS_PROVIDER=service##_WALLET_API_KEY_SECRET=WALLET_API_KEY##_APP_REVIEW_MODE=true##_CONSENT_WEB_FALLBACK_ENABLED=false##_CONSENT_SSE_ENABLED=false##_DB_POOL_MIN_SIZE=1##_DB_POOL_MAX_SIZE=4##_DB_SQLALCHEMY_POOL_SIZE=3##_DB_SQLALCHEMY_MAX_OVERFLOW=0##_CLOUD_RUN_MIN_INSTANCES=2##_CLOUD_RUN_MAX_INSTANCES=5##_CLOUD_RUN_NO_TRAFFIC=true##_IMAGE_TAG=uat-${{ steps.resolve-sha.outputs.sha }}##_DEPLOY_ENV=uat##_DEPLOY_SOURCE=deploy-uat##_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }}##_GITHUB_RUN_ID=${{ github.run_id }}"
+          SUBSTITUTIONS="_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }}##_REGION=${{ env.GCP_REGION }}##_CLOUDSQL_INSTANCES=${{ env.UAT_CLOUDSQL_INSTANCE }}##_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID##_PLAID_SECRET_SECRET=PLAID_SECRET##_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY##_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY##_PMP_API_KEY_SECRET=PMP_API_KEY##_NEWSAPI_KEY_SECRET=NEWSAPI_KEY##_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID##_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET##_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI##_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY##_GOOGLE_OAUTH_CLIENT_ID_SECRET=GOOGLE_OAUTH_CLIENT_ID##_GOOGLE_OAUTH_CLIENT_SECRET_SECRET=GOOGLE_OAUTH_CLIENT_SECRET##_GOOGLE_OAUTH_REDIRECT_URI_SECRET=GOOGLE_OAUTH_REDIRECT_URI##_GOOGLE_OAUTH_TOKEN_KEY_SECRET=GOOGLE_OAUTH_TOKEN_KEY##_OPENAI_API_KEY_SECRET=OPENAI_API_KEY##_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY##_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON##_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN##_HUSHH_TECH_LAUNCH_PEPPER_SECRET=HUSSH_TECH_LAUNCH_PEPPER##_RATE_LIMIT_STORAGE_URI_SECRET=RATE_LIMIT_STORAGE_URI##_HUSHH_UAT_PHONE_TEST_NUMBERS_SECRET=HUSHH_UAT_PHONE_TEST_NUMBERS##_HUSHH_UAT_PHONE_TEST_CODE_SECRET=HUSHH_UAT_PHONE_TEST_CODE##_REVIEWER_UID_SECRET=REVIEWER_UID##_REVIEWER_VAULT_PASSPHRASE_SECRET=REVIEWER_VAULT_PASSPHRASE##_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL##_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET=ONE_EMAIL_WATCH_RENEW_TOKEN##_ONE_EMAIL_ADDRESS=one@hushh.ai##_ONE_EMAIL_DELEGATED_USER=one@hushh.ai##_ONE_EMAIL_PUBSUB_TOPIC=projects/hushh-pda/topics/one-email-kyc-uat##_ONE_EMAIL_WEBHOOK_AUDIENCE=https://consent-protocol-f2gsa4kfsq-uc.a.run.app/api/one/email/webhook##_ONE_EMAIL_WEBHOOK_SERVICE_ACCOUNT_EMAIL=one-email-pubsub-push@hushh-pda.iam.gserviceaccount.com##_ONE_EMAIL_WEBHOOK_AUTH_ENABLED=true##_ONE_EMAIL_WATCH_RENEW_AUTH_ENABLED=true##_ONE_EMAIL_KYC_DEFAULT_SCOPE=attr.identity.*##_ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED=true##_ONE_WALLET_CARD_ENABLED=true##_WALLET_PASS_PROVIDER=service##_WALLET_API_KEY_SECRET=WALLET_API_KEY##_APP_REVIEW_MODE=true##_CONSENT_WEB_FALLBACK_ENABLED=false##_CONSENT_SSE_ENABLED=false##_DB_POOL_MIN_SIZE=1##_DB_POOL_MAX_SIZE=4##_DB_SQLALCHEMY_POOL_SIZE=3##_DB_SQLALCHEMY_MAX_OVERFLOW=0##_CLOUD_RUN_MIN_INSTANCES=2##_CLOUD_RUN_MAX_INSTANCES=5##_CLOUD_RUN_CPU=2##_CLOUD_RUN_CONCURRENCY=20##_CLOUD_RUN_NO_TRAFFIC=true##_IMAGE_TAG=uat-${{ steps.resolve-sha.outputs.sha }}##_DEPLOY_ENV=uat##_DEPLOY_SOURCE=deploy-uat##_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }}##_GITHUB_RUN_ID=${{ github.run_id }}"
           SUBSTITUTIONS="${SUBSTITUTIONS}##_RUNTIME_SERVICE_ACCOUNT=${{ env.RUNTIME_SERVICE_ACCOUNT }}"
           SUBSTITUTIONS="${SUBSTITUTIONS}##_CONSENT_API_PUBLIC_ORIGIN=${{ env.CONSENT_API_PUBLIC_ORIGIN }}"
           SUBSTITUTIONS="${SUBSTITUTIONS}##_VPC_CONNECTOR=${{ vars.UAT_VPC_CONNECTOR || '' }}"
@@ -616,7 +650,7 @@ jobs:
           gcloud builds submit \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --config=deploy/frontend.cloudbuild.yaml \
-            "--substitutions=_FRONTEND_SERVICE=${{ env.FRONTEND_SERVICE }},_FRONTEND_RUNTIME_SERVICE_ACCOUNT=${{ env.FRONTEND_RUNTIME_SERVICE_ACCOUNT }},_REGION=${{ env.GCP_REGION }},_ONE_LOCATION_NEARBY_CHECK_IN=${{ 'true' }},_LOCATION_MAP_DEMO=false,_APP_ENV=uat,_ONE_WALLET_CARD_ENABLED=true,_HUSHH_TECH_CLIENT_ENABLED=${{ vars.HUSSH_TECH_CLIENT_ENABLED || 'false' }},_HUSHH_TECH_PROXY_AUDIENCE=${{ env.CONSENT_API_RUNTIME_ORIGIN }},_HUSHH_TECH_FRONTEND_TRUSTED_PROXY_HOPS=${{ vars.HUSSH_TECH_FRONTEND_TRUSTED_PROXY_HOPS || '0' }},_RATE_LIMIT_STORAGE_URI_SECRET=RATE_LIMIT_STORAGE_URI,_VPC_CONNECTOR=${{ vars.UAT_VPC_CONNECTOR || '' }},_CLOUD_RUN_NO_TRAFFIC=true,_IMAGE_TAG=uat-${{ steps.resolve-sha.outputs.sha }},_DEPLOY_ENV=uat,_DEPLOY_SOURCE=deploy-uat,_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }},_GITHUB_RUN_ID=${{ github.run_id }}"
+            "--substitutions=_FRONTEND_SERVICE=${{ env.FRONTEND_SERVICE }},_FRONTEND_RUNTIME_SERVICE_ACCOUNT=${{ env.FRONTEND_RUNTIME_SERVICE_ACCOUNT }},_REGION=${{ env.GCP_REGION }},_ONE_LOCATION_NEARBY_CHECK_IN=${{ 'true' }},_LOCATION_MAP_DEMO=false,_APP_ENV=uat,_ONE_WALLET_CARD_ENABLED=true,_HUSHH_TECH_CLIENT_ENABLED=${{ vars.HUSSH_TECH_CLIENT_ENABLED || 'false' }},_HUSHH_TECH_PROXY_AUDIENCE=${{ env.CONSENT_API_RUNTIME_ORIGIN }},_HUSHH_TECH_FRONTEND_TRUSTED_PROXY_HOPS=${{ vars.HUSSH_TECH_FRONTEND_TRUSTED_PROXY_HOPS || '0' }},_RATE_LIMIT_STORAGE_URI_SECRET=RATE_LIMIT_STORAGE_URI,_VPC_CONNECTOR=${{ vars.UAT_VPC_CONNECTOR || '' }},_CLOUD_RUN_MEMORY=1Gi,_CLOUD_RUN_TIMEOUT_SECONDS=300,_CLOUD_RUN_CONCURRENCY=10,_CLOUD_RUN_MIN_INSTANCES=2,_CLOUD_RUN_MAX_INSTANCES=10,_CLOUD_RUN_NO_TRAFFIC=true,_IMAGE_TAG=uat-${{ steps.resolve-sha.outputs.sha }},_DEPLOY_ENV=uat,_DEPLOY_SOURCE=deploy-uat,_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }},_GITHUB_RUN_ID=${{ github.run_id }}"
           finished_at="$(date +%s)"
           echo "started_at_epoch=${started_at}" >> "$GITHUB_OUTPUT"
           echo "finished_at_epoch=${finished_at}" >> "$GITHUB_OUTPUT"
@@ -1192,19 +1226,19 @@ jobs:
 
       - name: Roll back backend revision
         id: rollback-backend
-        if: always() && steps.classify-uat-release.outputs.release_failed == 'true' && steps.classify-uat-release.outputs.backend_failure == 'true' && steps.scope.outputs.deploy_backend == 'true' && steps.predeploy-state.outputs.backend_revision != ''
+        if: always() && steps.classify-uat-release.outputs.release_failed == 'true' && steps.classify-uat-release.outputs.backend_failure == 'true' && steps.scope.outputs.deploy_backend == 'true' && steps.rollback-targets.outputs.backend_revision != ''
         shell: bash
         run: |
           set -euo pipefail
-          bash scripts/ci/cloudrun-rollback.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ steps.predeploy-state.outputs.backend_revision }}"
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ steps.rollback-targets.outputs.backend_revision }}"
 
       - name: Roll back frontend revision
         id: rollback-frontend
-        if: always() && steps.classify-uat-release.outputs.release_failed == 'true' && steps.classify-uat-release.outputs.frontend_failure == 'true' && steps.scope.outputs.deploy_frontend == 'true' && steps.predeploy-state.outputs.frontend_revision != ''
+        if: always() && steps.classify-uat-release.outputs.release_failed == 'true' && steps.classify-uat-release.outputs.frontend_failure == 'true' && steps.scope.outputs.deploy_frontend == 'true' && steps.rollback-targets.outputs.frontend_revision != ''
         shell: bash
         run: |
           set -euo pipefail
-          bash scripts/ci/cloudrun-rollback.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ steps.predeploy-state.outputs.frontend_revision }}"
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ steps.rollback-targets.outputs.frontend_revision }}"
 
       - name: Resolve final Cloud Run state
         if: always()
@@ -1248,13 +1282,13 @@ jobs:
           if [ "${{ steps.classify-uat-release.outputs.release_failed }}" != "true" ]; then
             STATUS="healthy"
           else
-            if [ "${{ steps.classify-uat-release.outputs.backend_failure }}" = "true" ] && [ "${{ steps.scope.outputs.deploy_backend }}" = "true" ] && [ "${{ steps.predeploy-state.outputs.backend_revision }}" != "" ]; then
+            if [ "${{ steps.classify-uat-release.outputs.backend_failure }}" = "true" ] && [ "${{ steps.scope.outputs.deploy_backend }}" = "true" ] && [ "${{ steps.rollback-targets.outputs.backend_revision }}" != "" ]; then
               BACKEND_ROLLBACK_REQUIRED=true
               if [ "${{ steps.rollback-backend.outcome }}" != "success" ]; then
                 BACKEND_ROLLBACK_DONE=false
               fi
             fi
-            if [ "${{ steps.classify-uat-release.outputs.frontend_failure }}" = "true" ] && [ "${{ steps.scope.outputs.deploy_frontend }}" = "true" ] && [ "${{ steps.predeploy-state.outputs.frontend_revision }}" != "" ]; then
+            if [ "${{ steps.classify-uat-release.outputs.frontend_failure }}" = "true" ] && [ "${{ steps.scope.outputs.deploy_frontend }}" = "true" ] && [ "${{ steps.rollback-targets.outputs.frontend_revision }}" != "" ]; then
               FRONTEND_ROLLBACK_REQUIRED=true
               if [ "${{ steps.rollback-frontend.outcome }}" != "success" ]; then
                 FRONTEND_ROLLBACK_DONE=false
@@ -1319,8 +1353,8 @@ jobs:
                   "blocking_classifications": "${{ steps.classify-uat-release.outputs.blocking_classifications }}",
               },
               "rollback_targets": {
-                  "backend_revision": "${{ steps.predeploy-state.outputs.backend_revision }}",
-                  "frontend_revision": "${{ steps.predeploy-state.outputs.frontend_revision }}",
+                  "backend_revision": "${{ steps.rollback-targets.outputs.backend_revision }}",
+                  "frontend_revision": "${{ steps.rollback-targets.outputs.frontend_revision }}",
               },
               "timing_seconds": {
                   "backend_cloud_build": "${{ steps.deploy-backend.outputs.duration_seconds || '0' }}",

--- a/consent-protocol/hushh_mcp/services/consent_db.py
+++ b/consent-protocol/hushh_mcp/services/consent_db.py
@@ -36,6 +36,7 @@ Usage:
     )
 """
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -472,7 +473,7 @@ class ConsentDBService:
         if limit:
             query = query.limit(limit)
 
-        response = query.execute()
+        response = await asyncio.to_thread(query.execute)
         rows: List[Dict[str, Any]] = []
         for row in response.data or []:
             row_scope = row.get("scope")
@@ -1102,18 +1103,22 @@ class ConsentDBService:
         device-bound owner capabilities must fail closed when revocation state
         cannot be confirmed.
         """
-        rows = (
-            self._get_db()
-            .table("trusted_devices")
-            .select("device_id")
-            .eq("user_id", user_id)
-            .eq("device_id", device_id)
-            .eq("status", "active")
-            .limit(1)
-            .execute()
-            .data
-            or []
-        )
+
+        def query_rows() -> List[Dict[str, Any]]:
+            return (
+                self._get_db()
+                .table("trusted_devices")
+                .select("device_id")
+                .eq("user_id", user_id)
+                .eq("device_id", device_id)
+                .eq("status", "active")
+                .limit(1)
+                .execute()
+                .data
+                or []
+            )
+
+        rows = await asyncio.to_thread(query_rows)
         return bool(rows)
 
     async def is_token_active(
@@ -1155,7 +1160,9 @@ class ConsentDBService:
                 )
                 if normalized_agent_id:
                     query = query.eq("agent_id", normalized_agent_id)
-                rows = query.order("issued_at", desc=True).limit(1).execute().data or []
+                rows = await asyncio.to_thread(
+                    lambda: query.order("issued_at", desc=True).limit(1).execute().data or []
+                )
             except DatabaseExecutionError as exc:
                 if not self._is_missing_internal_access_events_error(exc):
                     raise
@@ -1180,7 +1187,9 @@ class ConsentDBService:
             )
             if normalized_agent_id:
                 query = query.eq("agent_id", normalized_agent_id)
-            rows = query.order("issued_at", desc=True).limit(1).execute().data or []
+            rows = await asyncio.to_thread(
+                lambda: query.order("issued_at", desc=True).limit(1).execute().data or []
+            )
 
         if not rows:
             return False
@@ -1491,7 +1500,7 @@ class ConsentDBService:
         # Remove None values
         data = {k: v for k, v in data.items() if v is not None}
 
-        response = db.table("consent_audit").insert(data).execute()
+        response = await asyncio.to_thread(lambda: db.table("consent_audit").insert(data).execute())
 
         # Extract event ID from response
         if response.data and len(response.data) > 0:
@@ -1537,15 +1546,18 @@ class ConsentDBService:
         }
         data = {k: v for k, v in data.items() if v is not None}
 
-        try:
-            response = db.table("internal_access_events").insert(data).execute()
-        except DatabaseExecutionError as exc:
-            if not self._is_missing_internal_access_events_error(exc):
-                raise
-            logger.warning(
-                "internal_access_events_missing fallback=consent_audit action=insert_internal_event"
-            )
-            response = db.table("consent_audit").insert(data).execute()
+        def insert_event():
+            try:
+                return db.table("internal_access_events").insert(data).execute()
+            except DatabaseExecutionError as exc:
+                if not self._is_missing_internal_access_events_error(exc):
+                    raise
+                logger.warning(
+                    "internal_access_events_missing fallback=consent_audit action=insert_internal_event"
+                )
+                return db.table("consent_audit").insert(data).execute()
+
+        response = await asyncio.to_thread(insert_event)
         if response.data and len(response.data) > 0:
             event_id = response.data[0].get("id")
             logger.info("Inserted internal %s event: %s", action, event_id)

--- a/consent-protocol/hushh_mcp/services/renaissance_service.py
+++ b/consent-protocol/hushh_mcp/services/renaissance_service.py
@@ -8,6 +8,7 @@ Provides:
 - List stocks by tier/sector
 """
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from typing import Optional
@@ -130,7 +131,9 @@ class RenaissanceService:
 
         if normalized == "renaissance_avoid":
             try:
-                response = self.db.table("renaissance_avoid").select("*").order("ticker").execute()
+                response = await asyncio.to_thread(
+                    lambda: self.db.table("renaissance_avoid").select("*").order("ticker").execute()
+                )
                 rows = response.data or []
             except Exception as exc:  # noqa: BLE001
                 logger.error("Error listing Renaissance avoid members: %s", exc)
@@ -177,11 +180,13 @@ class RenaissanceService:
             Tuple of (is_investable, stock_info)
         """
         try:
-            response = (
-                self.db.table("renaissance_universe")
-                .select("*")
-                .eq("ticker", ticker.upper())
-                .execute()
+            response = await asyncio.to_thread(
+                lambda: (
+                    self.db.table("renaissance_universe")
+                    .select("*")
+                    .eq("ticker", ticker.upper())
+                    .execute()
+                )
             )
 
             if response.data and len(response.data) > 0:
@@ -220,8 +225,10 @@ class RenaissanceService:
     async def get_all_investable(self) -> list[RenaissanceStock]:
         """Get all stocks in the Renaissance investable universe."""
         try:
-            response = (
-                self.db.table("renaissance_universe").select("*").order("tier_rank").execute()
+            response = await asyncio.to_thread(
+                lambda: (
+                    self.db.table("renaissance_universe").select("*").order("tier_rank").execute()
+                )
             )
 
             return [
@@ -245,12 +252,14 @@ class RenaissanceService:
     async def get_by_tier(self, tier: str) -> list[RenaissanceStock]:
         """Get all stocks in a specific tier."""
         try:
-            response = (
-                self.db.table("renaissance_universe")
-                .select("*")
-                .eq("tier", tier.upper())
-                .order("tier_rank")
-                .execute()
+            response = await asyncio.to_thread(
+                lambda: (
+                    self.db.table("renaissance_universe")
+                    .select("*")
+                    .eq("tier", tier.upper())
+                    .order("tier_rank")
+                    .execute()
+                )
             )
 
             return [
@@ -274,12 +283,14 @@ class RenaissanceService:
     async def get_by_sector(self, sector: str) -> list[RenaissanceStock]:
         """Get all stocks in a specific sector."""
         try:
-            response = (
-                self.db.table("renaissance_universe")
-                .select("*")
-                .ilike("sector", f"%{sector}%")
-                .order("tier_rank")
-                .execute()
+            response = await asyncio.to_thread(
+                lambda: (
+                    self.db.table("renaissance_universe")
+                    .select("*")
+                    .ilike("sector", f"%{sector}%")
+                    .order("tier_rank")
+                    .execute()
+                )
             )
 
             return [
@@ -311,12 +322,14 @@ class RenaissanceService:
         - source: str | None
         """
         try:
-            response = (
-                self.db.table("renaissance_avoid")
-                .select("*")
-                .eq("ticker", ticker.upper())
-                .limit(1)
-                .execute()
+            response = await asyncio.to_thread(
+                lambda: (
+                    self.db.table("renaissance_avoid")
+                    .select("*")
+                    .eq("ticker", ticker.upper())
+                    .limit(1)
+                    .execute()
+                )
             )
             rows = response.data or []
             if rows:
@@ -347,15 +360,16 @@ class RenaissanceService:
     async def get_screening_criteria(self) -> list[dict]:
         """Return all screening criteria rows (for UI and LLM prompting)."""
         try:
-            result = self.db.execute_raw(
+            result = await asyncio.to_thread(
+                self.db.execute_raw,
                 """
-                SELECT section, rule_index, title, detail, value_text
-                FROM renaissance_screening_criteria
-                ORDER BY
-                    section ASC,
-                    rule_index ASC NULLS LAST,
-                    id ASC
-                """
+                    SELECT section, rule_index, title, detail, value_text
+                    FROM renaissance_screening_criteria
+                    ORDER BY
+                        section ASC,
+                        rule_index ASC NULLS LAST,
+                        id ASC
+                """,
             )
             return result.data or []
         except Exception:
@@ -442,13 +456,15 @@ class RenaissanceService:
         # Get sector peers in same or higher tier
         sector_peers = []
         try:
-            response = (
-                self.db.table("renaissance_universe")
-                .select("ticker")
-                .eq("sector", stock.sector)
-                .neq("ticker", ticker.upper())
-                .limit(5)
-                .execute()
+            response = await asyncio.to_thread(
+                lambda: (
+                    self.db.table("renaissance_universe")
+                    .select("ticker")
+                    .eq("sector", stock.sector)
+                    .neq("ticker", ticker.upper())
+                    .limit(5)
+                    .execute()
+                )
             )
 
             sector_peers = [row["ticker"] for row in response.data]

--- a/consent-protocol/tests/test_internal_vault_owner_token_validation.py
+++ b/consent-protocol/tests/test_internal_vault_owner_token_validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 import time
 
 import pytest
@@ -15,9 +16,15 @@ class _FakeResponse:
 
 
 class _FakeQuery:
-    def __init__(self, table_name: str, response_rows: dict[str, list[dict]]):
+    def __init__(
+        self,
+        table_name: str,
+        response_rows: dict[str, list[dict]],
+        execute_thread_ids: list[int],
+    ):
         self._table_name = table_name
         self._response_rows = response_rows
+        self._execute_thread_ids = execute_thread_ids
 
     def select(self, *_args, **_kwargs):
         return self
@@ -35,6 +42,7 @@ class _FakeQuery:
         return self
 
     def execute(self):
+        self._execute_thread_ids.append(threading.get_ident())
         return _FakeResponse(self._response_rows.get(self._table_name, []))
 
 
@@ -42,10 +50,24 @@ class _FakeDb:
     def __init__(self, response_rows: dict[str, list[dict]]):
         self.response_rows = response_rows
         self.requested_tables: list[str] = []
+        self.execute_thread_ids: list[int] = []
 
     def table(self, table_name: str):
         self.requested_tables.append(table_name)
-        return _FakeQuery(table_name, self.response_rows)
+        return _FakeQuery(table_name, self.response_rows, self.execute_thread_ids)
+
+
+@pytest.mark.asyncio
+async def test_token_validation_does_not_execute_sync_database_io_on_event_loop(monkeypatch):
+    fake_db = _FakeDb({"consent_audit": []})
+    service = ConsentDBService()
+    monkeypatch.setattr(service, "_get_db", lambda: fake_db)
+
+    event_loop_thread = threading.get_ident()
+    await service.is_token_active("user_test", ConsentScope.PKM_READ.value)
+
+    assert fake_db.execute_thread_ids
+    assert all(thread_id != event_loop_thread for thread_id in fake_db.execute_thread_ids)
 
 
 @pytest.mark.asyncio

--- a/consent-protocol/tests/test_renaissance_async_db_offload.py
+++ b/consent-protocol/tests/test_renaissance_async_db_offload.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from hushh_mcp.services.renaissance_service import RenaissanceService
+
+
+class _FakeQuery:
+    def __init__(self, rows: list[dict], execute_thread_ids: list[int]):
+        self._rows = rows
+        self._execute_thread_ids = execute_thread_ids
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, *_args, **_kwargs):
+        return self
+
+    def execute(self):
+        self._execute_thread_ids.append(threading.get_ident())
+        return SimpleNamespace(data=self._rows)
+
+
+class _FakeDb:
+    def __init__(self):
+        self.execute_thread_ids: list[int] = []
+
+    def table(self, _table_name: str):
+        return _FakeQuery(
+            [
+                {
+                    "ticker": "AAPL",
+                    "company_name": "Apple",
+                    "sector": "Technology",
+                    "tier": "ACE",
+                    "fcf_billions": 100.0,
+                    "investment_thesis": "Synthetic test row",
+                    "tier_rank": 1,
+                }
+            ],
+            self.execute_thread_ids,
+        )
+
+
+@pytest.mark.asyncio
+async def test_renaissance_query_does_not_block_event_loop(monkeypatch):
+    fake_db = _FakeDb()
+    service = RenaissanceService()
+    service._db = fake_db
+    monkeypatch.setattr(service, "_is_supported_symbol", lambda _ticker: True)
+
+    event_loop_thread = threading.get_ident()
+    is_investable, stock = await service.is_investable("AAPL")
+
+    assert is_investable is True
+    assert stock is not None
+    assert fake_db.execute_thread_ids
+    assert all(thread_id != event_loop_thread for thread_id in fake_db.execute_thread_ids)

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -41,6 +41,57 @@ def test_uat_deploy_builds_candidates_without_serving_traffic() -> None:
     )
 
 
+def test_uat_runtime_capacity_is_bounded_and_revision_safe() -> None:
+    workflow = _read(".github/workflows/deploy-uat.yml")
+    backend_build = _read("deploy/backend.cloudbuild.yaml")
+    frontend_build = _read("deploy/frontend.cloudbuild.yaml")
+
+    assert '"--cpu=${_CLOUD_RUN_CPU}"' in backend_build
+    assert '"--concurrency=${_CLOUD_RUN_CONCURRENCY}"' in backend_build
+    assert "_CLOUD_RUN_CPU=2" in workflow
+    assert "_CLOUD_RUN_CONCURRENCY=20" in workflow
+
+    assert '"--memory=${_CLOUD_RUN_MEMORY}"' in frontend_build
+    assert '"--concurrency=${_CLOUD_RUN_CONCURRENCY}"' in frontend_build
+    assert '"--max=${_CLOUD_RUN_MAX_INSTANCES}"' in frontend_build
+    assert '"--min=${_CLOUD_RUN_MIN_INSTANCES}"' in frontend_build
+    assert '"--min-instances=0"' in frontend_build
+    assert "_CLOUD_RUN_MEMORY=1Gi" in workflow
+    assert "_CLOUD_RUN_TIMEOUT_SECONDS=300" in workflow
+    assert "_CLOUD_RUN_CONCURRENCY=10" in workflow
+    assert "_CLOUD_RUN_MIN_INSTANCES=2" in workflow
+    assert "_CLOUD_RUN_MAX_INSTANCES=10" in workflow
+
+
+def test_frontend_verifies_server_chunks_before_binding_cloud_run_port() -> None:
+    next_config = _read("hushh-webapp/next.config.ts")
+    dockerfile = _read("hushh-webapp/Dockerfile")
+    verifier = _read("hushh-webapp/scripts/runtime/verify-server-chunks.mjs")
+
+    assert "preloadEntriesOnStart: true" in next_config
+    assert "node scripts/runtime/verify-server-chunks.mjs && exec node server.js" in dockerfile
+    assert "await readFile(chunk)" in verifier
+    assert "No Next.js server chunks found" in verifier
+
+
+def test_uat_automatic_rollback_uses_tagged_last_known_good() -> None:
+    workflow = _read(".github/workflows/deploy-uat.yml")
+    rollback_block = workflow[
+        workflow.index("- name: Resolve last-known-good rollback targets") : workflow.index(
+            "- name: Resolve final Cloud Run state"
+        )
+    ]
+
+    assert "git fetch --force origin" in rollback_block
+    assert "refs/tags/deployed/uat-latest:refs/tags/deployed/uat-latest" in rollback_block
+    assert "scripts/ci/resolve-rollback-target.sh uat backend" in rollback_block
+    assert "scripts/ci/resolve-rollback-target.sh uat frontend" in rollback_block
+    assert "steps.rollback-targets.outputs.backend_revision" in rollback_block
+    assert "steps.rollback-targets.outputs.frontend_revision" in rollback_block
+    assert "steps.predeploy-state.outputs.backend_revision" not in rollback_block
+    assert "steps.predeploy-state.outputs.frontend_revision" not in rollback_block
+
+
 def test_uat_deploy_pins_the_shared_firebase_authority() -> None:
     workflow_source = _read(".github/workflows/deploy-uat.yml")
     workflow = yaml.safe_load(workflow_source)

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -251,6 +251,8 @@ steps:
         require_non_negative_int "_DB_SQLALCHEMY_MAX_OVERFLOW" "${_DB_SQLALCHEMY_MAX_OVERFLOW}"
         require_non_negative_int "_CLOUD_RUN_MIN_INSTANCES" "${_CLOUD_RUN_MIN_INSTANCES}"
         require_positive_int "_CLOUD_RUN_MAX_INSTANCES" "${_CLOUD_RUN_MAX_INSTANCES}"
+        require_positive_int "_CLOUD_RUN_CPU" "${_CLOUD_RUN_CPU}"
+        require_positive_int "_CLOUD_RUN_CONCURRENCY" "${_CLOUD_RUN_CONCURRENCY}"
         if [[ "${_DB_POOL_MAX_SIZE}" -lt "${_DB_POOL_MIN_SIZE}" ]]; then
           echo "_DB_POOL_MAX_SIZE must be greater than or equal to _DB_POOL_MIN_SIZE." >&2
           exit 1
@@ -316,8 +318,9 @@ steps:
           "--allow-unauthenticated"
           "--port=8080"
           "--memory=1Gi"
-          "--cpu=1"
+          "--cpu=${_CLOUD_RUN_CPU}"
           "--timeout=3600"
+          "--concurrency=${_CLOUD_RUN_CONCURRENCY}"
           "--session-affinity"
           "--max=${_CLOUD_RUN_MAX_INSTANCES}"
           "--min=${_CLOUD_RUN_MIN_INSTANCES}"
@@ -593,6 +596,8 @@ substitutions:
   _DB_POOL_ACQUIRE_TIMEOUT_SECONDS: "60"
   _CLOUD_RUN_MIN_INSTANCES: "1"
   _CLOUD_RUN_MAX_INSTANCES: "5"
+  _CLOUD_RUN_CPU: "1"
+  _CLOUD_RUN_CONCURRENCY: "80"
   _RUNTIME_ENVIRONMENT: ""
   # Direct backend builds remain conservative. The UAT workflow explicitly
   # overrides this from its authoritative changed-SHA verification plan.

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -251,8 +251,6 @@ steps:
         require_non_negative_int "_DB_SQLALCHEMY_MAX_OVERFLOW" "${_DB_SQLALCHEMY_MAX_OVERFLOW}"
         require_non_negative_int "_CLOUD_RUN_MIN_INSTANCES" "${_CLOUD_RUN_MIN_INSTANCES}"
         require_positive_int "_CLOUD_RUN_MAX_INSTANCES" "${_CLOUD_RUN_MAX_INSTANCES}"
-        require_positive_int "_CLOUD_RUN_CPU" "${_CLOUD_RUN_CPU}"
-        require_positive_int "_CLOUD_RUN_CONCURRENCY" "${_CLOUD_RUN_CONCURRENCY}"
         if [[ "${_DB_POOL_MAX_SIZE}" -lt "${_DB_POOL_MIN_SIZE}" ]]; then
           echo "_DB_POOL_MAX_SIZE must be greater than or equal to _DB_POOL_MIN_SIZE." >&2
           exit 1

--- a/deploy/frontend.cloudbuild.yaml
+++ b/deploy/frontend.cloudbuild.yaml
@@ -15,6 +15,32 @@ steps:
       - |
         set -euo pipefail
 
+        require_non_negative_int() {
+          local name="$1"
+          local value="$2"
+          if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+            echo "${name} must be a non-negative integer, got '${value}'." >&2
+            exit 1
+          fi
+        }
+        require_positive_int() {
+          local name="$1"
+          local value="$2"
+          require_non_negative_int "${name}" "${value}"
+          if [[ "${value}" -lt 1 ]]; then
+            echo "${name} must be at least 1, got '${value}'." >&2
+            exit 1
+          fi
+        }
+        require_non_negative_int "_CLOUD_RUN_MIN_INSTANCES" "${_CLOUD_RUN_MIN_INSTANCES}"
+        require_positive_int "_CLOUD_RUN_MAX_INSTANCES" "${_CLOUD_RUN_MAX_INSTANCES}"
+        require_positive_int "_CLOUD_RUN_CONCURRENCY" "${_CLOUD_RUN_CONCURRENCY}"
+        require_positive_int "_CLOUD_RUN_TIMEOUT_SECONDS" "${_CLOUD_RUN_TIMEOUT_SECONDS}"
+        if [[ "${_CLOUD_RUN_MAX_INSTANCES}" -lt "${_CLOUD_RUN_MIN_INSTANCES}" ]]; then
+          echo "_CLOUD_RUN_MAX_INSTANCES must be greater than or equal to _CLOUD_RUN_MIN_INSTANCES." >&2
+          exit 1
+        fi
+
         google_contacts_client_id_file="/workspace/.google-contacts-client-id"
         google_contacts_secret_error="$$(mktemp)"
         trap 'rm -f "$${google_contacts_secret_error}"' EXIT
@@ -180,11 +206,14 @@ steps:
           "--platform=managed"
           "--allow-unauthenticated"
           "--port=8080"
-          "--memory=512Mi"
+          "--memory=${_CLOUD_RUN_MEMORY}"
           "--cpu=1"
-          "--timeout=120"
-          "--max-instances=10"
-          "--min-instances=1"
+          "--timeout=${_CLOUD_RUN_TIMEOUT_SECONDS}"
+          "--concurrency=${_CLOUD_RUN_CONCURRENCY}"
+          "--max=${_CLOUD_RUN_MAX_INSTANCES}"
+          "--min=${_CLOUD_RUN_MIN_INSTANCES}"
+          "--max-instances=${_CLOUD_RUN_MAX_INSTANCES}"
+          "--min-instances=0"
           "--labels=managed-by=hushh-github-actions,deploy-env=${_DEPLOY_ENV},deploy-source=${_DEPLOY_SOURCE},deploy-sha=${_DEPLOY_SHA},github-run-id=${_GITHUB_RUN_ID}"
           "--set-env-vars=NEXT_PUBLIC_APP_ENV=${_APP_ENV},HUSHH_DEPLOY_ENV=${_DEPLOY_ENV},HUSHH_DEPLOY_SOURCE=${_DEPLOY_SOURCE},HUSHH_DEPLOY_SHA=${_DEPLOY_SHA},HUSHH_DEPLOY_RUN_ID=${_GITHUB_RUN_ID},HUSSH_TECH_CLIENT_ENABLED=${_HUSHH_TECH_CLIENT_ENABLED},HUSSH_TECH_PROXY_AUDIENCE=${_HUSHH_TECH_PROXY_AUDIENCE},HUSSH_TECH_FRONTEND_TRUSTED_PROXY_HOPS=${_HUSHH_TECH_FRONTEND_TRUSTED_PROXY_HOPS},RIA_ONBOARDING_PROXY_TIMEOUT_MS=90000,MAIL_API_ENDPOINT=${_MAIL_API_ENDPOINT}"
           "--set-secrets=${secrets}"
@@ -244,6 +273,11 @@ substitutions:
   # single endpoint serves UAT and production.
   _MAIL_API_ENDPOINT: "https://hushh-mail-api-646258530541.us-central1.run.app"
   _CLOUD_RUN_NO_TRAFFIC: "false"
+  _CLOUD_RUN_MEMORY: "512Mi"
+  _CLOUD_RUN_TIMEOUT_SECONDS: "120"
+  _CLOUD_RUN_CONCURRENCY: "80"
+  _CLOUD_RUN_MIN_INSTANCES: "1"
+  _CLOUD_RUN_MAX_INSTANCES: "10"
   _IMAGE_TAG: v2.1.2
   _DEPLOY_ENV: manual
   _DEPLOY_SOURCE: manual

--- a/hushh-webapp/Dockerfile
+++ b/hushh-webapp/Dockerfile
@@ -94,6 +94,11 @@ COPY --from=builder /app/public ./public
 # Copy static assets
 COPY --from=builder /app/.next/static ./.next/static
 
+# Read every server chunk before binding the Cloud Run port. This makes an
+# image-layer/filesystem EIO a startup failure instead of an intermittent 500
+# or 120-second timeout on the first request that lazily loads that chunk.
+COPY --from=builder /app/scripts/runtime/verify-server-chunks.mjs ./scripts/runtime/verify-server-chunks.mjs
+
 # Normalize the supported standalone layouts so Cloud Run always has one
 # canonical entrypoint and any nested standalone path still resolves assets.
 RUN set -eux; \
@@ -123,5 +128,5 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
 
-# Start the canonical normalized standalone server.
-CMD ["node", "server.js"]
+# Verify the immutable runtime image, then start the canonical server.
+CMD ["sh", "-c", "node scripts/runtime/verify-server-chunks.mjs && exec node server.js"]

--- a/hushh-webapp/__tests__/app/api/one-proxy-stream.test.ts
+++ b/hushh-webapp/__tests__/app/api/one-proxy-stream.test.ts
@@ -36,6 +36,7 @@ beforeEach(() => {
 
 describe("/api/one proxy", () => {
   it("passes an event-stream through instead of parsing it as JSON", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
     const frames = 'event: results\ndata: {"event":"results","category":"hotels_stays","items":[]}\n\n';
     mocks.fetch.mockResolvedValue(
       new Response(frames, {
@@ -52,11 +53,13 @@ describe("/api/one proxy", () => {
     expect(response.headers.get("content-type")).toContain("text/event-stream");
     expect(response.headers.get("x-accel-buffering")).toBe("no");
     expect(response.headers.get("cache-control")).toContain("no-transform");
+    expect(timeoutSpy).toHaveBeenCalledWith(285_000);
     // The bytes must survive intact — this is what was being dropped.
     await expect(response.text()).resolves.toContain("hotels_stays");
   });
 
   it("still buffers an ordinary JSON route exactly as before", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
     mocks.fetch.mockResolvedValue(
       new Response(JSON.stringify({ items: [1, 2] }), {
         status: 200,
@@ -70,6 +73,7 @@ describe("/api/one proxy", () => {
     );
 
     expect(response.headers.get("content-type")).toContain("application/json");
+    expect(timeoutSpy).toHaveBeenCalledWith(45_000);
     await expect(response.json()).resolves.toMatchObject({ items: [1, 2] });
   });
 });

--- a/hushh-webapp/app/api/one/[...path]/route.ts
+++ b/hushh-webapp/app/api/one/[...path]/route.ts
@@ -14,6 +14,16 @@ const ONE_API_TIMEOUT_MS = resolveSlowRequestTimeoutMs(45_000, {
   developmentFloorMs: 45_000,
   overrideEnvKey: "HUSHH_ONE_API_TIMEOUT_MS",
 });
+const ONE_STREAM_TIMEOUT_MS = resolveSlowRequestTimeoutMs(285_000, {
+  developmentFloorMs: 285_000,
+  overrideEnvKey: "HUSHH_ONE_STREAM_TIMEOUT_MS",
+});
+
+function requestTimeoutMs(path: string, acceptHeader: string | null): number {
+  const acceptsEventStream = acceptHeader?.toLowerCase().includes("text/event-stream") ?? false;
+  const isKnownStreamRoute = path === "agent-chat" || path.endsWith("/stream");
+  return acceptsEventStream || isKnownStreamRoute ? ONE_STREAM_TIMEOUT_MS : ONE_API_TIMEOUT_MS;
+}
 
 function privateResponseHeaders(upstream?: Response): Headers {
   const headers = new Headers({
@@ -69,7 +79,7 @@ async function proxyRequest(request: NextRequest, params: { path: string[] }) {
       method: request.method,
       headers,
       body,
-      signal: AbortSignal.timeout(ONE_API_TIMEOUT_MS),
+      signal: AbortSignal.timeout(requestTimeoutMs(path, acceptHeader)),
     });
 
     // A streamed upstream must be handed through untouched. The JSON path below

--- a/hushh-webapp/next.config.ts
+++ b/hushh-webapp/next.config.ts
@@ -81,7 +81,10 @@ const config: NextConfig = {
     parallelServerCompiles: false,
     parallelServerBuildTraces: false,
     optimizePackageImports: ["@phosphor-icons/react", "lucide-react"],
-    preloadEntriesOnStart: false,
+    // UAT serves from an immutable Cloud Run image. Preload server entries so
+    // unreadable image-layer chunks fail during startup instead of on a user's
+    // first request, and keep cold-route latency out of the request path.
+    preloadEntriesOnStart: true,
     serverSourceMaps: false,
     serverComponentsHmrCache: true,
     webpackMemoryOptimizations: true,

--- a/hushh-webapp/scripts/runtime/verify-server-chunks.mjs
+++ b/hushh-webapp/scripts/runtime/verify-server-chunks.mjs
@@ -1,0 +1,44 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const appRoot = process.env.APP_ROOT || "/app";
+const chunkRoots = [
+  path.join(appRoot, ".next", "server", "chunks"),
+  path.join(appRoot, "app", ".next", "server", "chunks"),
+  path.join(appRoot, "hushh-webapp", ".next", "server", "chunks"),
+];
+
+async function collectServerChunks(directory) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") return [];
+    throw error;
+  }
+  const chunks = [];
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      chunks.push(...(await collectServerChunks(absolutePath)));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".js")) {
+      chunks.push(absolutePath);
+    }
+  }
+
+  return chunks;
+}
+
+const chunks = (await Promise.all(chunkRoots.map(collectServerChunks))).flat();
+if (chunks.length === 0) {
+  throw new Error(`No Next.js server chunks found under ${appRoot}`);
+}
+
+for (const chunk of chunks) {
+  await readFile(chunk);
+}
+
+console.info(`[startup] verified ${chunks.length} readable Next.js server chunks`);

--- a/scripts/ci/runtime-contract-check.sh
+++ b/scripts/ci/runtime-contract-check.sh
@@ -92,8 +92,15 @@ if ! grep -q -- '--set-env-vars=NEXT_PUBLIC_APP_ENV=' "$frontend_cloudbuild"; th
 fi
 
 frontend_timeout_seconds="$(
-  grep -Eo -- '--timeout=[0-9]+' "$frontend_cloudbuild" | head -n 1 | cut -d= -f2
+  grep -Eo -- '--timeout=[0-9]+' "$frontend_cloudbuild" | head -n 1 | cut -d= -f2 || true
 )"
+if [ -z "$frontend_timeout_seconds" ] && grep -q -- '--timeout=${_CLOUD_RUN_TIMEOUT_SECONDS}' "$frontend_cloudbuild"; then
+  frontend_timeout_seconds="$(
+    grep -E '^[[:space:]]*_CLOUD_RUN_TIMEOUT_SECONDS:' "$frontend_cloudbuild" |
+      head -n 1 |
+      sed -E 's/.*"([0-9]+)".*/\1/'
+  )"
+fi
 if [ -z "$frontend_timeout_seconds" ]; then
   echo "❌ frontend Cloud Run deploy must declare an explicit request timeout."
   exit 1


### PR DESCRIPTION
Incident recovery and durable UAT hardening.

What changed:
- fail frontend startup if immutable Next.js server chunks cannot be read, and preload server entries before traffic
- bound UAT frontend concurrency at 10 with 1 GiB, two warm service instances, a 300-second request budget, and revision min-scale zero
- extend One SSE/agent-chat proxy timeouts to 285 seconds while keeping JSON routes at 45 seconds
- offload synchronous consent and Renaissance database calls from the asyncio event loop
- set UAT backend to 2 vCPU and concurrency 20 without increasing Cloud SQL pools or max instances
- resolve automatic rollback from the refreshed deployed/uat-latest tag, preventing rollback loops into an already-bad predeploy revision

Incident evidence:
- bad frontend revision hushh-webapp-00734-9kj emitted thousands of EIO and ChunkLoadError records and repeated startup/read timeouts
- rollback run 33541502149 restored hushh-webapp-00733-gcj; public root, login, and backend health now return 200

Verification:
- ./bin/hushh lint
- 88 focused backend tests
- 4 focused frontend proxy tests
- TypeScript typecheck
- runtime-contract-check.sh
- YAML parse and shell syntax checks
- startup verifier read 97 local Next.js server chunks

No production deployment is included.