### PR TITLE
Fix UAT Vertex probe classifier runtime

### DIFF
--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -145,7 +145,11 @@ def test_backend_vertex_preflight_uses_supported_service_usage_command() -> None
 def test_backend_vertex_advisory_probe_parses_pretty_json_verdict() -> None:
     backend_build = _read("deploy/backend.cloudbuild.yaml")
 
-    assert "PROBE_LINE=\"${probe_line}\" python - <<'PY'" in backend_build
+    # The Cloud SDK builder provides ``python3`` but not the unversioned
+    # ``python`` executable. Keep verdict parsing inside the supported runtime
+    # so a failed candidate probe can still be classified and rolled back.
+    assert "PROBE_LINE=\"${probe_line}\" python3 - <<'PY'" in backend_build
+    assert "PROBE_LINE=\"${probe_line}\" python - <<'PY'" not in backend_build
     assert 'marker = "managed_vertex_probe_result"' in backend_build
     assert "json.loads(payload)" in backend_build
     assert 'verdict.get("classification")' in backend_build

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -442,7 +442,7 @@ steps:
         fi
         echo "Probe execution: ${execution_name:-unknown}"
         classification="$(
-          PROBE_LINE="${probe_line}" python - <<'PY'
+          PROBE_LINE="${probe_line}" python3 - <<'PY'
         import json
         import os
 


### PR DESCRIPTION
## Summary
- use `python3` in the Cloud SDK Vertex probe classifier
- add a regression assertion forbidding the unavailable `python` executable

## Incident evidence
- UAT deploy run 33545957969 built backend revision `consent-protocol-00577-2cz` at 0% traffic
- Cloud Build `b287cac5-61b6-4f56-bb65-44b42c9e8382` failed only while classifying the candidate probe: `python: command not found` (exit 127)
- governed rollback restored the known-good backend; frontend build and traffic promotion never ran

## Verification
- `uv run pytest tests/test_uat_deploy_no_traffic_contract.py tests/test_cloudbuild_step_arg_limit.py -q` (26 passed)
- YAML parse passed
- DCO signoff passed

Signed-off-by: Ankit Kumar Singh <ankit@hushh.ai>