### PR TITLE
fix(deploy): run Vertex readiness with python3

### DIFF
--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -145,7 +145,10 @@ def test_backend_vertex_preflight_uses_supported_service_usage_command() -> None
 def test_backend_vertex_advisory_probe_parses_pretty_json_verdict() -> None:
     backend_build = _read("deploy/backend.cloudbuild.yaml")
 
-    assert "PROBE_LINE=\"${probe_line}\" python - <<'PY'" in backend_build
+    assert '--command="python3"' in backend_build
+    assert '--command="python"' not in backend_build
+    assert "PROBE_LINE=\"${probe_line}\" python3 - <<'PY'" in backend_build
+    assert "PROBE_LINE=\"${probe_line}\" python - <<'PY'" not in backend_build
     assert 'marker = "managed_vertex_probe_result"' in backend_build
     assert "json.loads(payload)" in backend_build
     assert 'verdict.get("classification")' in backend_build

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -384,7 +384,7 @@ steps:
           --region="${_REGION}" \
           --image="gcr.io/$PROJECT_ID/consent-protocol:${_IMAGE_TAG}" \
           --service-account="${_RUNTIME_SERVICE_ACCOUNT}" \
-          --command="python" \
+          --command="python3" \
           --args="scripts/verify_managed_vertex_runtime.py" \
           --set-env-vars="^|^HUSHH_GENAI_AUTH_MODE=vertex_adc|GOOGLE_GENAI_USE_VERTEXAI=true|GOOGLE_CLOUD_PROJECT=${genai_project_id}|GOOGLE_CLOUD_LOCATION=global|HUSHH_VERTEX_LOCATIONS=global,us,eu|AGENT_ONE_ADK_LOCATION=us-central1" \
           ${live_key_secret_flag} \
@@ -442,7 +442,7 @@ steps:
         fi
         echo "Probe execution: ${execution_name:-unknown}"
         classification="$(
-          PROBE_LINE="${probe_line}" python - <<'PY'
+          PROBE_LINE="${probe_line}" python3 - <<'PY'
         import json
         import os
 


### PR DESCRIPTION
## Summary
- invoke the managed Vertex readiness Cloud Run Job with `python3`, matching the backend runtime image
- parse the readiness result with `python3` in Cloud Build
- lock the interpreter contract with focused deployment tests

## Incident evidence
UAT deploy run 33545957969 built and deployed the candidate backend revision, then failed before traffic promotion because the readiness job exited with `python: command not found`. The governed workflow rolled both services back.

## Verification
- `cd consent-protocol && .venv/bin/pytest -q tests/test_uat_deploy_no_traffic_contract.py` (19 passed)
- Cloud Build YAML parse
- `bash scripts/ci/runtime-contract-check.sh`
- `git diff --check`

Signed-off-by: Kushal Trivedi <kushaltrivedi1711@gmail.com>