### PR TITLE
fix(one-location): expire stale asks and smooth time edits

### DIFF
--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dev_minimum_schema",
-  "expected_migration_version": 190,
+  "expected_migration_version": 191,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_pkm_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 190,
+  "expected_migration_version": 191,
   "migration_version_policy": "exact",
   "required_functions": [
     "remove_domain_summary_key",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 190,
+  "expected_migration_version": 191,
   "migration_version_policy": "exact",
   "required_functions": [
     "remove_domain_summary_key",

--- a/consent-protocol/db/migrations/191_one_location_access_request_expiry.sql
+++ b/consent-protocol/db/migrations/191_one_location_access_request_expiry.sql
@@ -1,0 +1,70 @@
+BEGIN;
+
+-- Direct One Location asks are questions, not standing consent. Keeping one
+-- actionable forever lets an owner approve a request whose context may be days
+-- old, while also preventing the requester from sending a fresh notification.
+-- The deadline is durable and server-owned; clients only present it.
+--
+-- Referral and matched public-link requests intentionally keep NULL here.
+-- Their parent workflow owns a different lifetime and retry contract, and a
+-- public visitor cannot simply resubmit the same phone/invite pair.
+ALTER TABLE one_location_access_requests
+  ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+
+ALTER TABLE one_location_access_requests
+  DROP CONSTRAINT IF EXISTS one_location_access_requests_status_check;
+
+ALTER TABLE one_location_access_requests
+  ADD CONSTRAINT one_location_access_requests_status_check CHECK (
+    status IN ('pending', 'approved', 'denied', 'cancelled', 'expired')
+  ) NOT VALID;
+
+-- Existing direct asks receive the same one-day window from their original
+-- send time. Linked workflows remain NULL rather than being silently severed
+-- from their independently-pending wrapper rows.
+UPDATE one_location_access_requests AS request
+SET expires_at = request.requested_at + INTERVAL '24 hours'
+WHERE request.expires_at IS NULL
+  AND request.referred_by_user_id IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM one_location_referrals AS referral
+    WHERE referral.request_id = request.id
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM one_location_public_invite_submissions AS submission
+    WHERE submission.request_id = request.id
+  );
+
+-- Make rollout truth immediate. The maintenance job will settle future rows,
+-- while read/action paths also enforce the timestamp in case that job lags.
+UPDATE one_location_access_requests
+SET status = 'expired',
+    resolved_at = COALESCE(resolved_at, expires_at)
+WHERE status = 'pending'
+  AND expires_at IS NOT NULL
+  AND expires_at <= NOW();
+
+ALTER TABLE one_location_access_requests
+  DROP CONSTRAINT IF EXISTS chk_one_location_access_request_expiry_after_send;
+
+ALTER TABLE one_location_access_requests
+  ADD CONSTRAINT chk_one_location_access_request_expiry_after_send CHECK (
+    expires_at IS NULL OR expires_at > requested_at
+  ) NOT VALID;
+
+ALTER TABLE one_location_access_requests
+  VALIDATE CONSTRAINT one_location_access_requests_status_check;
+
+ALTER TABLE one_location_access_requests
+  VALIDATE CONSTRAINT chk_one_location_access_request_expiry_after_send;
+
+CREATE INDEX IF NOT EXISTS idx_one_location_access_requests_pending_expiry
+  ON one_location_access_requests (expires_at, owner_user_id, requester_user_id)
+  WHERE status = 'pending' AND expires_at IS NOT NULL;
+
+COMMENT ON COLUMN one_location_access_requests.expires_at IS
+  'Server-owned deadline for a direct/extension location ask. NULL only when a linked referral or public-link workflow owns the lifetime.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/191_one_location_access_request_expiry.rollback.sql
+++ b/consent-protocol/db/migrations/rollback/191_one_location_access_request_expiry.rollback.sql
@@ -1,0 +1,37 @@
+BEGIN;
+
+-- The old schema cannot represent expiry. Preserve terminal safety by mapping
+-- both expired questions and still-pending timed questions to cancelled rather
+-- than dropping their deadline and making them approvable forever. Linked NULL
+-- requests keep their parent-owned pending lifecycle.
+UPDATE one_location_access_requests
+SET status = 'cancelled',
+    resolved_at = COALESCE(resolved_at, NOW()),
+    metadata = COALESCE(metadata, '{}'::jsonb) ||
+      jsonb_build_object(
+        'rollback_from_status', status,
+        'rollback_reason', 'request_expiry_schema_removed'
+      )
+WHERE status = 'expired'
+   OR (status = 'pending' AND expires_at IS NOT NULL);
+
+DROP INDEX IF EXISTS idx_one_location_access_requests_pending_expiry;
+
+ALTER TABLE one_location_access_requests
+  DROP CONSTRAINT IF EXISTS chk_one_location_access_request_expiry_after_send;
+
+ALTER TABLE one_location_access_requests
+  DROP CONSTRAINT IF EXISTS one_location_access_requests_status_check;
+
+ALTER TABLE one_location_access_requests
+  ADD CONSTRAINT one_location_access_requests_status_check CHECK (
+    status IN ('pending', 'approved', 'denied', 'cancelled')
+  ) NOT VALID;
+
+ALTER TABLE one_location_access_requests
+  VALIDATE CONSTRAINT one_location_access_requests_status_check;
+
+ALTER TABLE one_location_access_requests
+  DROP COLUMN IF EXISTS expires_at;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -162,7 +162,8 @@
     "187_one_location_sms_contact_events.sql",
     "188_feed_location_viewed_projection.sql",
     "189_trusted_device_heartbeat.sql",
-    "190_one_location_place_ratings.sql"
+    "190_one_location_place_ratings.sql",
+    "191_one_location_access_request_expiry.sql"
   ],
   "environment_overlays": {
     "uat": [
@@ -278,7 +279,8 @@
       "187_one_location_sms_contact_events.sql",
       "188_feed_location_viewed_projection.sql",
       "189_trusted_device_heartbeat.sql",
-      "190_one_location_place_ratings.sql"
+      "190_one_location_place_ratings.sql",
+      "191_one_location_access_request_expiry.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -105,6 +105,11 @@ COORDINATE_METADATA_KEYS = {
     "reverse_geocode",
 }
 LOCATION_TERMINAL_RETENTION_HOURS = 12
+LOCATION_REQUEST_EXPIRY_HOURS = 24
+# Keep a small outcome tombstone long enough for the reported three-day return
+# visit to explain what happened and offer Ask again. Other terminal work still
+# uses the 12-hour privacy cleanup window.
+LOCATION_EXPIRED_REQUEST_RETENTION_HOURS = 7 * 24
 ATOMIC_LOCATION_SHARE_NAMESPACE = uuid.UUID("ef983dac-5044-49b0-9d35-c523b3437a54")
 
 
@@ -221,6 +226,38 @@ def _parse_datetime(value: datetime | str | None, *, field_name: str) -> datetim
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
+
+
+def _request_effective_expires_at(row: dict[str, Any]) -> Any:
+    """Persisted deadline, or a rolling-deploy projection for an old direct row."""
+
+    expires_at = row.get("expires_at")
+    if expires_at is not None or not bool(row.get("legacy_direct_request")):
+        return expires_at
+    try:
+        requested_at = _parse_datetime(row.get("requested_at"), field_name="requestedAt")
+    except OneLocationAgentError:
+        return None
+    return requested_at + timedelta(hours=LOCATION_REQUEST_EXPIRY_HOURS)
+
+
+def _request_expiry_has_passed(row: dict[str, Any], *, now: datetime | None = None) -> bool:
+    """Whether a direct request crossed its server-owned deadline.
+
+    A NULL deadline is intentional for referral/public-link workflows. A read
+    query can mark an unlinked NULL as an old-revision direct row, in which case
+    its original send time projects the same one-day deadline until repaired.
+    Invalid persisted values fail closed so a read projection cannot 500.
+    """
+
+    expires_at = _request_effective_expires_at(row)
+    if expires_at is None:
+        return False
+    try:
+        parsed = _parse_datetime(expires_at, field_name="expiresAt")
+    except OneLocationAgentError:
+        return False
+    return parsed <= (now or _utcnow())
 
 
 def _validated_envelope_fields(
@@ -2238,7 +2275,27 @@ class OneLocationAgentService:
                 (
                     "one_location_requests",
                     """
-                    SELECT owner_user_id, requester_user_id, referred_by_user_id, status,
+                    SELECT owner_user_id, requester_user_id, referred_by_user_id,
+                           CASE
+                             WHEN status = 'pending' AND (
+                               (expires_at IS NOT NULL AND expires_at <= clock_timestamp())
+                               OR (
+                                 expires_at IS NULL
+                                 AND referred_by_user_id IS NULL
+                                 AND requested_at + INTERVAL '24 hours' <= clock_timestamp()
+                                 AND NOT EXISTS (
+                                   SELECT 1 FROM one_location_referrals referral
+                                   WHERE referral.request_id = one_location_access_requests.id
+                                 )
+                                 AND NOT EXISTS (
+                                   SELECT 1 FROM one_location_public_invite_submissions submission
+                                   WHERE submission.request_id = one_location_access_requests.id
+                                 )
+                               )
+                             )
+                               THEN 'expired'
+                             ELSE status
+                           END AS status,
                            requested_at, resolved_at
                     FROM one_location_access_requests
                     WHERE owner_user_id = :owner_user_id OR requester_user_id = :owner_user_id
@@ -2651,6 +2708,14 @@ class OneLocationAgentService:
             if row.get("requested_duration_hours") is not None
             else None
         )
+        expires_at = _request_effective_expires_at(row)
+        raw_status = str(row.get("status") or "pending")
+        status = (
+            "expired" if raw_status == "pending" and _request_expiry_has_passed(row) else raw_status
+        )
+        resolved_at = row.get("resolved_at")
+        if status == "expired" and resolved_at is None:
+            resolved_at = expires_at
         return {
             "id": str(row.get("id") or ""),
             "ownerUserId": str(row.get("owner_user_id") or ""),
@@ -2672,10 +2737,11 @@ class OneLocationAgentService:
             or None,
             "ownerMaskedPhone": _mask_phone(row.get("owner_phone_number")),
             "referredByUserId": str(row.get("referred_by_user_id") or "") or None,
-            "status": str(row.get("status") or "pending"),
+            "status": status,
             "message": str(row.get("message") or "") or None,
             "requestedAt": _iso(row.get("requested_at")),
-            "resolvedAt": _iso(row.get("resolved_at")),
+            "expiresAt": _iso(expires_at),
+            "resolvedAt": _iso(resolved_at),
             "approvedGrantId": str(row.get("approved_grant_id") or "") or None,
             "requestedDurationHours": requested_duration_hours,
             "requestedDurationMode": str(row.get("requested_duration_mode") or "") or None,
@@ -3278,6 +3344,100 @@ class OneLocationAgentService:
         for notification in notifications:
             self._send_metadata_notification(**notification)
 
+    def _repair_legacy_direct_request_deadlines(self, user_id: str | None) -> None:
+        """Adopt direct asks written by an older revision during rollout.
+
+        Release migrations run before the new backend is fully promoted. An
+        old replica can therefore insert a NULL-expiry direct request after the
+        one-time backfill. Parent rows distinguish the intentional NULLs used
+        by public-link/referral workflows; only unlinked rows are repaired.
+        """
+
+        self._execute_many(
+            """
+            WITH repair_clock AS (
+              SELECT clock_timestamp() AS observed_at
+            )
+            UPDATE one_location_access_requests AS legacy_request
+            SET expires_at = legacy_request.requested_at
+                + (:hours * INTERVAL '1 hour'),
+                status = CASE
+                  WHEN legacy_request.requested_at
+                    + (:hours * INTERVAL '1 hour') <= repair_clock.observed_at
+                    THEN 'expired'
+                  ELSE legacy_request.status
+                END,
+                resolved_at = CASE
+                  WHEN legacy_request.requested_at
+                    + (:hours * INTERVAL '1 hour') <= repair_clock.observed_at
+                    THEN COALESCE(
+                      legacy_request.resolved_at,
+                      legacy_request.requested_at + (:hours * INTERVAL '1 hour')
+                    )
+                  ELSE legacy_request.resolved_at
+                END
+            FROM repair_clock
+            WHERE legacy_request.status = 'pending'
+              AND legacy_request.expires_at IS NULL
+              AND legacy_request.referred_by_user_id IS NULL
+              AND (
+                :user_id IS NULL
+                OR legacy_request.owner_user_id = :user_id
+                OR legacy_request.requester_user_id = :user_id
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM one_location_referrals AS referral
+                WHERE referral.request_id = legacy_request.id
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM one_location_public_invite_submissions AS submission
+                WHERE submission.request_id = legacy_request.id
+              )
+            RETURNING legacy_request.id
+            """,
+            {"hours": LOCATION_REQUEST_EXPIRY_HOURS, "user_id": user_id},
+        )
+
+    def _expire_stale_requests(self, user_id: str | None) -> None:
+        """Settle direct asks whose one-day answer window has ended.
+
+        Reads and action mutations also enforce ``expires_at`` immediately, so
+        scheduler lag can never widen consent. This bounded transition exists
+        to keep persistence and terminal-retention cleanup in step with that
+        effective state. NULL-expiry linked workflows are deliberately outside
+        this policy.
+        """
+
+        self._repair_legacy_direct_request_deadlines(user_id)
+        self._execute_many(
+            """
+            WITH stale AS (
+              SELECT id
+              FROM one_location_access_requests
+              WHERE status = 'pending'
+                AND expires_at IS NOT NULL
+                AND expires_at <= clock_timestamp()
+                AND (
+                  :user_id IS NULL
+                  OR owner_user_id = :user_id
+                  OR requester_user_id = :user_id
+                )
+              ORDER BY expires_at
+              LIMIT 500
+              FOR UPDATE SKIP LOCKED
+            )
+            UPDATE one_location_access_requests AS target_request
+            SET status = 'expired',
+                resolved_at = COALESCE(target_request.resolved_at, target_request.expires_at)
+            FROM stale
+            WHERE target_request.id = stale.id
+            RETURNING target_request.id
+            """,
+            {"user_id": user_id},
+        )
+
     def _purge_terminal_work(
         self,
         *,
@@ -3314,6 +3474,11 @@ class OneLocationAgentService:
                   status IN ('approved', 'denied', 'cancelled')
                   AND COALESCE(resolved_at, requested_at)
                     <= NOW() - (:hours * INTERVAL '1 hour')
+                )
+                OR (
+                  status = 'expired'
+                  AND COALESCE(resolved_at, expires_at, requested_at)
+                    <= NOW() - (:expired_request_hours * INTERVAL '1 hour')
                 )
                 OR approved_grant_id IN (SELECT id FROM stale_grants))
                 AND (
@@ -3571,7 +3736,11 @@ class OneLocationAgentService:
               (SELECT COUNT(*) FROM deleted_public_submissions) AS deleted_public_submissions,
               (SELECT COUNT(*) FROM deleted_events) AS deleted_events
             """,
-                {"user_id": user_id, "hours": hours},
+                {
+                    "user_id": user_id,
+                    "hours": hours,
+                    "expired_request_hours": LOCATION_EXPIRED_REQUEST_RETENTION_HOURS,
+                },
             )
             or {}
         )
@@ -3594,6 +3763,7 @@ class OneLocationAgentService:
     def purge_terminal_work(
         self, *, older_than_hours: float = LOCATION_TERMINAL_RETENTION_HOURS
     ) -> dict[str, Any]:
+        self._expire_stale_requests(None)
         self._expire_stale_grants(None)
         return self._purge_terminal_work(user_id=None, older_than_hours=older_than_hours)
 
@@ -7524,6 +7694,7 @@ class OneLocationAgentService:
                         message=message_value or f"Public request from {display_name}",
                         notify_owner=False,
                         require_requester_key_material=True,
+                        _expires_after_hours=None,
                     )
                     status_value = "matched_request_pending"
                 except OneLocationAgentError as exc:
@@ -7946,6 +8117,14 @@ class OneLocationAgentService:
         ).strip().lower() in {"1", "true", "yes", "on"}
         if not read_only_state:
             try:
+                self._expire_stale_requests(user_id)
+            except Exception as exc:  # noqa: BLE001 - compatibility housekeeping
+                logger.warning(
+                    "one_location.list_state.expire_stale_requests_failed user=%s error=%s",
+                    user_id,
+                    exc,
+                )
+            try:
                 self._expire_stale_grants(user_id)
             except Exception as exc:  # noqa: BLE001 - compatibility housekeeping
                 logger.warning(
@@ -8054,7 +8233,19 @@ class OneLocationAgentService:
                       owner.photo_url AS owner_photo_url,
                       owner.custom_photo_url AS owner_custom_photo_url,
                       owner.phone_number AS owner_phone_number,
-                      extended.expires_at AS extends_grant_expires_at
+                      extended.expires_at AS extends_grant_expires_at,
+                      (
+                        req.expires_at IS NULL
+                        AND req.referred_by_user_id IS NULL
+                        AND NOT EXISTS (
+                          SELECT 1 FROM one_location_referrals referral
+                          WHERE referral.request_id = req.id
+                        )
+                        AND NOT EXISTS (
+                          SELECT 1 FROM one_location_public_invite_submissions submission
+                          WHERE submission.request_id = req.id
+                        )
+                      ) AS legacy_direct_request
                     FROM one_location_access_requests req
                     LEFT JOIN actor_identity_cache requester ON requester.user_id = req.requester_user_id
                     LEFT JOIN actor_identity_cache owner ON owner.user_id = req.owner_user_id
@@ -8376,6 +8567,7 @@ class OneLocationAgentService:
 
     def list_pending_owner_requests(self, *, owner_user_id: str) -> list[dict[str, Any]]:
         """The owner's own pending access requests -- see list_active_owner_grants."""
+        self._expire_stale_requests(owner_user_id)
         rows = self._execute_many(
             """
             SELECT
@@ -8390,6 +8582,7 @@ class OneLocationAgentService:
             LEFT JOIN one_location_share_grants extended ON extended.id = req.extends_grant_id
             WHERE req.owner_user_id = :owner_user_id
               AND req.status = 'pending'
+              AND (req.expires_at IS NULL OR req.expires_at > clock_timestamp())
             ORDER BY req.requested_at DESC
             LIMIT 50
             """,
@@ -8402,6 +8595,7 @@ class OneLocationAgentService:
         outgoing asks still waiting on someone else's approve/decline.
         Joins the owner's identity instead of the requester's, since the
         requester already knows who they are."""
+        self._expire_stale_requests(requester_user_id)
         rows = self._execute_many(
             """
             SELECT
@@ -8416,6 +8610,7 @@ class OneLocationAgentService:
             LEFT JOIN one_location_share_grants extended ON extended.id = req.extends_grant_id
             WHERE req.requester_user_id = :requester_user_id
               AND req.status = 'pending'
+              AND (req.expires_at IS NULL OR req.expires_at > clock_timestamp())
             ORDER BY req.requested_at DESC
             LIMIT 50
             """,
@@ -8916,6 +9111,7 @@ class OneLocationAgentService:
         requested_duration_mode: str | None = None,
         extends_grant_id: str | None = None,
         _notification_outbox: list[_MetadataNotification] | None = None,
+        _expires_after_hours: float | None = LOCATION_REQUEST_EXPIRY_HOURS,
     ) -> dict[str, Any]:
         """Ask an owner for location access -- optionally for a named duration.
 
@@ -8946,6 +9142,7 @@ class OneLocationAgentService:
             duration_hours=requested_duration_hours,
             duration_mode=requested_duration_mode,
         )
+        expires_after_hours = None if _expires_after_hours is None else float(_expires_after_hours)
 
         # Resolve which live share (if any) this ask is about. A client-supplied
         # id is a hint that must be verified -- it is only honoured when the
@@ -8997,14 +9194,20 @@ class OneLocationAgentService:
                     )
                 },
             )
+            self._repair_legacy_direct_request_deadlines(owner_user_id)
             row = self._execute_one(
                 """
-                SELECT *
+                SELECT *,
+                       (expires_at IS NOT NULL AND expires_at <= clock_timestamp()) AS request_expired
                 FROM one_location_access_requests
                 WHERE owner_user_id = :owner_user_id
                   AND requester_user_id = :requester_user_id
                   AND status = 'pending'
                   AND referred_by_user_id IS NOT DISTINCT FROM :referred_by_user_id
+                  AND (
+                    (:has_request_expiry AND expires_at IS NOT NULL)
+                    OR (NOT :has_request_expiry AND expires_at IS NULL)
+                  )
                 ORDER BY requested_at DESC
                 LIMIT 1
                 FOR UPDATE
@@ -9013,20 +9216,46 @@ class OneLocationAgentService:
                     "owner_user_id": owner_user_id,
                     "requester_user_id": requester_user_id,
                     "referred_by_user_id": referred_by_user_id,
+                    "has_request_expiry": expires_after_hours is not None,
                 },
             )
+            if row and bool(row.get("request_expired")):
+                # Retire the old question before inserting the new one. Reusing
+                # it would make an exact "Ask again" a no-op with no event or
+                # notification, which is the failure the expired affordance is
+                # specifically promising to repair.
+                expired = self._execute_one(
+                    """
+                    UPDATE one_location_access_requests
+                    SET status = 'expired',
+                        resolved_at = COALESCE(resolved_at, expires_at)
+                    WHERE id = CAST(:request_id AS UUID)
+                      AND status = 'pending'
+                      AND expires_at IS NOT NULL
+                      AND expires_at <= clock_timestamp()
+                    RETURNING *
+                    """,
+                    {"request_id": str(row.get("id") or "")},
+                )
+                if expired:
+                    row = None
             if not row:
                 row = self._execute_one(
                     """
                     INSERT INTO one_location_access_requests (
                       owner_user_id, requester_user_id, referred_by_user_id, status,
-                      message, requested_at, metadata,
+                      message, requested_at, expires_at, metadata,
                       requested_duration_hours, requested_duration_mode, extends_grant_id,
                       request_revision
                     )
                     VALUES (
                       :owner_user_id, :requester_user_id, :referred_by_user_id, 'pending',
-                      :message, NOW(), '{}'::jsonb,
+                      :message, clock_timestamp(),
+                      CASE
+                        WHEN :expires_after_hours IS NULL THEN NULL
+                        ELSE clock_timestamp() + (:expires_after_hours * INTERVAL '1 hour')
+                      END,
+                      '{}'::jsonb,
                       :requested_duration_hours, :requested_duration_mode,
                       CAST(:extends_grant_id AS UUID), 1
                     )
@@ -9040,6 +9269,7 @@ class OneLocationAgentService:
                         "requested_duration_hours": duration_hours_value,
                         "requested_duration_mode": duration_mode_value,
                         "extends_grant_id": extends_grant_value,
+                        "expires_after_hours": expires_after_hours,
                     },
                 )
                 transitioned = row is not None
@@ -9071,7 +9301,15 @@ class OneLocationAgentService:
                             requested_duration_mode = :requested_duration_mode,
                             extends_grant_id = CAST(:extends_grant_id AS UUID),
                             request_revision = request_revision + CASE WHEN :ask_changed THEN 1 ELSE 0 END,
-                            requested_at = CASE WHEN :ask_changed THEN NOW() ELSE requested_at END
+                            requested_at = CASE
+                              WHEN :ask_changed THEN clock_timestamp()
+                              ELSE requested_at
+                            END,
+                            expires_at = CASE
+                              WHEN :ask_changed AND :expires_after_hours IS NOT NULL
+                                THEN clock_timestamp() + (:expires_after_hours * INTERVAL '1 hour')
+                              ELSE expires_at
+                            END
                         WHERE id = CAST(:request_id AS UUID)
                           AND status = 'pending'
                         RETURNING *
@@ -9083,6 +9321,7 @@ class OneLocationAgentService:
                             "requested_duration_mode": duration_mode_value,
                             "extends_grant_id": extends_grant_value,
                             "ask_changed": ask_changed,
+                            "expires_after_hours": expires_after_hours,
                         },
                     )
                     if refreshed:
@@ -9229,16 +9468,30 @@ class OneLocationAgentService:
             )
         request_identity = self._execute_one(
             """
-            SELECT requester_user_id
+            SELECT requester_user_id, status, expires_at,
+                   (expires_at IS NOT NULL AND expires_at <= clock_timestamp()) AS request_expired
             FROM one_location_access_requests
             WHERE id = CAST(:request_id AS UUID)
               AND owner_user_id = :owner_user_id
-              AND status = 'pending'
             LIMIT 1
             """,
             {"owner_user_id": owner_user_id, "request_id": request_id},
         )
         if not request_identity:
+            raise OneLocationAgentError(
+                "LOCATION_REQUEST_NOT_FOUND",
+                "Pending location access request was not found.",
+                status_code=404,
+            )
+        if str(request_identity.get("status") or "") == "expired" or bool(
+            request_identity.get("request_expired")
+        ):
+            raise OneLocationAgentError(
+                "LOCATION_REQUEST_EXPIRED",
+                "This location request expired. Ask them to send a new one.",
+                status_code=410,
+            )
+        if str(request_identity.get("status") or "") != "pending":
             raise OneLocationAgentError(
                 "LOCATION_REQUEST_NOT_FOUND",
                 "Pending location access request was not found.",
@@ -9250,19 +9503,34 @@ class OneLocationAgentService:
             owner_user_id=owner_user_id,
             recipient_user_id=expected_requester_user_id,
         ):
+            self._repair_legacy_direct_request_deadlines(owner_user_id)
             request_row = self._execute_one(
                 """
-                SELECT *
+                SELECT *,
+                       (expires_at IS NOT NULL AND expires_at <= clock_timestamp()) AS request_expired
                 FROM one_location_access_requests
                 WHERE id = CAST(:request_id AS UUID)
                   AND owner_user_id = :owner_user_id
-                  AND status = 'pending'
                 LIMIT 1
                 FOR UPDATE
                 """,
                 {"owner_user_id": owner_user_id, "request_id": request_id},
             )
             if not request_row:
+                raise OneLocationAgentError(
+                    "LOCATION_REQUEST_NOT_FOUND",
+                    "Pending location access request was not found.",
+                    status_code=404,
+                )
+            if str(request_row.get("status") or "") == "expired" or bool(
+                request_row.get("request_expired")
+            ):
+                raise OneLocationAgentError(
+                    "LOCATION_REQUEST_EXPIRED",
+                    "This location request expired. Ask them to send a new one.",
+                    status_code=410,
+                )
+            if str(request_row.get("status") or "") != "pending":
                 raise OneLocationAgentError(
                     "LOCATION_REQUEST_NOT_FOUND",
                     "Pending location access request was not found.",
@@ -9479,6 +9747,7 @@ class OneLocationAgentService:
                 WHERE id = CAST(:request_id AS UUID)
                   AND owner_user_id = :owner_user_id
                   AND status = 'pending'
+                  AND (expires_at IS NULL OR expires_at > clock_timestamp())
                 RETURNING *
                 """,
                 {
@@ -9488,6 +9757,12 @@ class OneLocationAgentService:
                 },
             )
             if not resolved:
+                if _request_expiry_has_passed(request_row):
+                    raise OneLocationAgentError(
+                        "LOCATION_REQUEST_EXPIRED",
+                        "This location request expired. Ask them to send a new one.",
+                        status_code=410,
+                    )
                 raise OneLocationAgentError(
                     "LOCATION_REQUEST_CHANGED",
                     "This request changed. Review it again.",
@@ -9610,6 +9885,7 @@ class OneLocationAgentService:
 
     def deny_request(self, *, owner_user_id: str, request_id: str) -> dict[str, Any]:
         with self._event_bound_writer():
+            self._repair_legacy_direct_request_deadlines(owner_user_id)
             row = self._execute_one(
                 """
                 UPDATE one_location_access_requests
@@ -9617,11 +9893,32 @@ class OneLocationAgentService:
                 WHERE id = CAST(:request_id AS UUID)
                   AND owner_user_id = :owner_user_id
                   AND status = 'pending'
+                  AND (expires_at IS NULL OR expires_at > clock_timestamp())
                 RETURNING *
                 """,
                 {"owner_user_id": owner_user_id, "request_id": request_id},
             )
             if not row:
+                existing = self._execute_one(
+                    """
+                    SELECT status, expires_at,
+                           (expires_at IS NOT NULL AND expires_at <= clock_timestamp()) AS request_expired
+                    FROM one_location_access_requests
+                    WHERE id = CAST(:request_id AS UUID)
+                      AND owner_user_id = :owner_user_id
+                    LIMIT 1
+                    """,
+                    {"owner_user_id": owner_user_id, "request_id": request_id},
+                )
+                if existing and (
+                    str(existing.get("status") or "") == "expired"
+                    or bool(existing.get("request_expired"))
+                ):
+                    raise OneLocationAgentError(
+                        "LOCATION_REQUEST_EXPIRED",
+                        "This location request has expired.",
+                        status_code=410,
+                    )
                 raise OneLocationAgentError(
                     "LOCATION_REQUEST_NOT_FOUND",
                     "Pending location access request was not found.",
@@ -9693,6 +9990,7 @@ class OneLocationAgentService:
         second call is a 404 rather than a silent success.
         """
         with self._event_bound_writer():
+            self._repair_legacy_direct_request_deadlines(requester_user_id)
             row = self._execute_one(
                 """
                 UPDATE one_location_access_requests
@@ -9700,11 +9998,32 @@ class OneLocationAgentService:
                 WHERE id = CAST(:request_id AS UUID)
                   AND requester_user_id = :requester_user_id
                   AND status = 'pending'
+                  AND (expires_at IS NULL OR expires_at > clock_timestamp())
                 RETURNING *
                 """,
                 {"requester_user_id": requester_user_id, "request_id": request_id},
             )
             if not row:
+                existing = self._execute_one(
+                    """
+                    SELECT status, expires_at,
+                           (expires_at IS NOT NULL AND expires_at <= clock_timestamp()) AS request_expired
+                    FROM one_location_access_requests
+                    WHERE id = CAST(:request_id AS UUID)
+                      AND requester_user_id = :requester_user_id
+                    LIMIT 1
+                    """,
+                    {"requester_user_id": requester_user_id, "request_id": request_id},
+                )
+                if existing and (
+                    str(existing.get("status") or "") == "expired"
+                    or bool(existing.get("request_expired"))
+                ):
+                    raise OneLocationAgentError(
+                        "LOCATION_REQUEST_EXPIRED",
+                        "This location request has expired.",
+                        status_code=410,
+                    )
                 raise OneLocationAgentError(
                     "LOCATION_REQUEST_NOT_FOUND",
                     "Pending location access request was not found.",
@@ -9792,6 +10111,7 @@ class OneLocationAgentService:
                 message=message,
                 referred_by_user_id=referring_user_id,
                 _notification_outbox=notifications,
+                _expires_after_hours=None,
             )
             # Keep the global request -> grant lock order used by approval.
             # If the grant ended after the first eligibility read, this second

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -16,6 +16,7 @@ from hushh_mcp.services.one_location_agent_service import (
     _DIRECTORY_SEPARATOR_FOLD,
     _DIRECTORY_SEPARATOR_SQL,
     _DIRECTORY_SEPARATORS,
+    LOCATION_REQUEST_EXPIRY_HOURS,
     OneLocationAgentError,
     OneLocationAgentService,
     _contains_plaintext_location_key,
@@ -1651,6 +1652,53 @@ class FourUserMemoryService(OneLocationAgentService):
             ]
         if "UPDATE one_location_share_grants" in sql and "expires_at <= NOW()" in sql:
             return []
+        if "UPDATE one_location_access_requests AS legacy_request" in sql:
+            now = datetime.now(timezone.utc)
+            user_id = params.get("user_id")
+            repaired: list[dict] = []
+            linked_request_ids = {
+                str(item.get("request_id") or "") for item in self.referrals.values()
+            } | {str(item.get("request_id") or "") for item in self.public_submissions.values()}
+            for request in self.requests.values():
+                if request.get("status") != "pending" or request.get("expires_at") is not None:
+                    continue
+                if request.get("referred_by_user_id") is not None:
+                    continue
+                if str(request.get("id") or "") in linked_request_ids:
+                    continue
+                if user_id and user_id not in {
+                    request.get("owner_user_id"),
+                    request.get("requester_user_id"),
+                }:
+                    continue
+                deadline = request["requested_at"] + timedelta(hours=float(params["hours"]))
+                request["expires_at"] = deadline
+                if deadline <= now:
+                    request["status"] = "expired"
+                    request["resolved_at"] = request.get("resolved_at") or deadline
+                repaired.append({"id": request["id"]})
+            return repaired
+        if (
+            "UPDATE one_location_access_requests AS target_request" in sql
+            and "SET status = 'expired'" in sql
+        ):
+            now = datetime.now(timezone.utc)
+            user_id = params.get("user_id")
+            expired: list[dict] = []
+            for request in self.requests.values():
+                if request.get("status") != "pending" or request.get("expires_at") is None:
+                    continue
+                if request["expires_at"] > now:
+                    continue
+                if user_id and user_id not in {
+                    request.get("owner_user_id"),
+                    request.get("requester_user_id"),
+                }:
+                    continue
+                request["status"] = "expired"
+                request["resolved_at"] = request.get("resolved_at") or request["expires_at"]
+                expired.append({"id": request["id"]})
+            return expired[:500]
         if "FROM one_location_recipient_keys" in sql and "encrypted_private_key_jwk" in sql:
             # list_state's own-key lookup (myRecipientKey).
             user_id = params.get("user_id")
@@ -1789,12 +1837,79 @@ class FourUserMemoryService(OneLocationAgentService):
                 if grant["owner_user_id"] == owner or grant["recipient_user_id"] == owner
             ][:100]
         if (
+            "FROM one_location_access_requests req" in sql
+            and "LEFT JOIN actor_identity_cache" in sql
+        ):
+            now = datetime.now(timezone.utc)
+            if "req.owner_user_id = :owner_user_id" in sql:
+                rows = [
+                    request
+                    for request in self.requests.values()
+                    if request["owner_user_id"] == params["owner_user_id"]
+                    and request["status"] == "pending"
+                    and (request.get("expires_at") is None or request["expires_at"] > now)
+                ]
+            elif "req.requester_user_id = :requester_user_id" in sql:
+                rows = [
+                    request
+                    for request in self.requests.values()
+                    if request["requester_user_id"] == params["requester_user_id"]
+                    and request["status"] == "pending"
+                    and (request.get("expires_at") is None or request["expires_at"] > now)
+                ]
+            else:
+                user_id = params["user_id"]
+                rows = [
+                    request
+                    for request in self.requests.values()
+                    if user_id in {request["owner_user_id"], request["requester_user_id"]}
+                ]
+            linked_request_ids = {
+                str(item.get("request_id") or "") for item in self.referrals.values()
+            } | {str(item.get("request_id") or "") for item in self.public_submissions.values()}
+            return [
+                {
+                    **request,
+                    "legacy_direct_request": (
+                        request.get("expires_at") is None
+                        and request.get("referred_by_user_id") is None
+                        and str(request.get("id") or "") not in linked_request_ids
+                    ),
+                }
+                for request in sorted(
+                    rows,
+                    key=lambda item: item["requested_at"],
+                    reverse=True,
+                )[:50]
+            ]
+        if (
             "FROM one_location_access_requests" in sql
             and "owner_user_id = :owner_user_id OR requester_user_id = :owner_user_id" in sql
         ):
             owner = params["owner_user_id"]
+            now = datetime.now(timezone.utc)
+            linked_request_ids = {
+                str(item.get("request_id") or "") for item in self.referrals.values()
+            } | {str(item.get("request_id") or "") for item in self.public_submissions.values()}
             return [
-                request
+                {
+                    **request,
+                    "status": (
+                        "expired"
+                        if request["status"] == "pending"
+                        and (
+                            request.get("expires_at") is not None
+                            and request["expires_at"] <= now
+                            or request.get("expires_at") is None
+                            and request.get("referred_by_user_id") is None
+                            and str(request.get("id") or "") not in linked_request_ids
+                            and request["requested_at"]
+                            + timedelta(hours=LOCATION_REQUEST_EXPIRY_HOURS)
+                            <= now
+                        )
+                        else request["status"]
+                    ),
+                }
                 for request in sorted(
                     self.requests.values(),
                     key=lambda item: item["requested_at"],
@@ -2109,8 +2224,12 @@ class FourUserMemoryService(OneLocationAgentService):
             return None
         if "WITH stale_grants AS" in sql and "deleted_grants" in sql:
             hours = float(params.get("hours") or 12)
+            expired_request_hours = float(params.get("expired_request_hours") or 168)
             user_id = params.get("user_id")
             cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
+            expired_request_cutoff = datetime.now(timezone.utc) - timedelta(
+                hours=expired_request_hours
+            )
 
             def in_user_scope(row: dict, fields: tuple[str, ...]) -> bool:
                 if not user_id:
@@ -2150,6 +2269,15 @@ class FourUserMemoryService(OneLocationAgentService):
                     (
                         request["status"] in {"approved", "denied", "cancelled"}
                         and (request.get("resolved_at") or request.get("requested_at")) <= cutoff
+                    )
+                    or (
+                        request["status"] == "expired"
+                        and (
+                            request.get("resolved_at")
+                            or request.get("expires_at")
+                            or request.get("requested_at")
+                        )
+                        <= expired_request_cutoff
                     )
                     or request.get("approved_grant_id") in stale_grant_ids
                 )
@@ -2465,6 +2593,7 @@ class FourUserMemoryService(OneLocationAgentService):
         if (
             "FROM one_location_access_requests" in sql
             and "requester_user_id = :requester_user_id" in sql
+            and "owner_user_id = :owner_user_id" in sql
         ):
             for request in sorted(
                 self.requests.values(),
@@ -2476,11 +2605,34 @@ class FourUserMemoryService(OneLocationAgentService):
                     and request["requester_user_id"] == params["requester_user_id"]
                     and request["status"] == "pending"
                     and request.get("referred_by_user_id") == params.get("referred_by_user_id")
+                    and (
+                        bool(params.get("has_request_expiry"))
+                        == (request.get("expires_at") is not None)
+                    )
                 ):
-                    return request
+                    return {
+                        **request,
+                        "request_expired": bool(
+                            request.get("expires_at")
+                            and request["expires_at"] <= datetime.now(timezone.utc)
+                        ),
+                    }
+            return None
+        if "UPDATE one_location_access_requests" in sql and "SET status = 'expired'" in sql:
+            request = self.requests.get(params["request_id"])
+            if (
+                request
+                and request["status"] == "pending"
+                and request.get("expires_at") is not None
+                and request["expires_at"] <= datetime.now(timezone.utc)
+            ):
+                request["status"] = "expired"
+                request["resolved_at"] = request.get("resolved_at") or request["expires_at"]
+                return request
             return None
         if "INSERT INTO one_location_access_requests" in sql:
             request_id = str(uuid.uuid4())
+            expires_after_hours = params.get("expires_after_hours")
             row = {
                 "id": request_id,
                 "owner_user_id": params["owner_user_id"],
@@ -2489,6 +2641,11 @@ class FourUserMemoryService(OneLocationAgentService):
                 "status": "pending",
                 "message": params.get("message"),
                 "requested_at": datetime.now(timezone.utc),
+                "expires_at": (
+                    datetime.now(timezone.utc) + timedelta(hours=float(expires_after_hours))
+                    if expires_after_hours is not None
+                    else None
+                ),
                 "resolved_at": None,
                 "approved_grant_id": None,
                 "requested_duration_hours": params.get("requested_duration_hours"),
@@ -2511,16 +2668,35 @@ class FourUserMemoryService(OneLocationAgentService):
                 if params.get("ask_changed"):
                     request["request_revision"] = int(request.get("request_revision") or 1) + 1
                     request["requested_at"] = datetime.now(timezone.utc)
+                    if params.get("expires_after_hours") is not None:
+                        request["expires_at"] = datetime.now(timezone.utc) + timedelta(
+                            hours=float(params["expires_after_hours"])
+                        )
                 return request
             return None
         if "FROM one_location_access_requests" in sql:
             request = self.requests.get(params["request_id"])
-            if (
+            actor_matches = bool(
                 request
-                and request["owner_user_id"] == params["owner_user_id"]
-                and request["status"] == "pending"
-            ):
-                return request
+                and (
+                    (
+                        "owner_user_id" in params
+                        and request["owner_user_id"] == params["owner_user_id"]
+                    )
+                    or (
+                        "requester_user_id" in params
+                        and request["requester_user_id"] == params["requester_user_id"]
+                    )
+                )
+            )
+            if actor_matches and request:
+                return {
+                    **request,
+                    "request_expired": bool(
+                        request.get("expires_at")
+                        and request["expires_at"] <= datetime.now(timezone.utc)
+                    ),
+                }
             return None
         if "SET status = 'approved'" in sql:
             request = self.requests[params["request_id"]]
@@ -2538,6 +2714,10 @@ class FourUserMemoryService(OneLocationAgentService):
                 request
                 and request["requester_user_id"] == params["requester_user_id"]
                 and request["status"] == "pending"
+                and (
+                    request.get("expires_at") is None
+                    or request["expires_at"] > datetime.now(timezone.utc)
+                )
             ):
                 request["status"] = "cancelled"
                 request["resolved_at"] = datetime.now(timezone.utc)
@@ -2549,6 +2729,10 @@ class FourUserMemoryService(OneLocationAgentService):
                 request
                 and request["owner_user_id"] == params["owner_user_id"]
                 and request["status"] == "pending"
+                and (
+                    request.get("expires_at") is None
+                    or request["expires_at"] > datetime.now(timezone.utc)
+                )
             ):
                 request["status"] = "denied"
                 request["resolved_at"] = datetime.now(timezone.utc)
@@ -3957,9 +4141,14 @@ def test_event_failure_rolls_back_location_transition_and_suppresses_push(
         def first(self):
             return self.row
 
+        def all(self):
+            return [] if self.row is None else [self.row]
+
     class _Connection:
         def execute(self, statement, params):
             sql = str(statement)
+            if "UPDATE one_location_access_requests AS legacy_request" in sql:
+                return _Result(None)
             if "SET status = 'denied'" in sql:
                 request["status"] = "denied"
                 return _Result(dict(request))

--- a/consent-protocol/tests/test_one_location_request_expiry.py
+++ b/consent-protocol/tests/test_one_location_request_expiry.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import inspect
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from hushh_mcp.services.one_location_agent_service import (
+    LOCATION_EXPIRED_REQUEST_RETENTION_HOURS,
+    LOCATION_REQUEST_EXPIRY_HOURS,
+    OneLocationAgentError,
+    OneLocationAgentService,
+)
+from tests.services.test_one_location_agent_service import FourUserMemoryService
+
+
+def _service() -> FourUserMemoryService:
+    service = FourUserMemoryService()
+    for user_id in ("user_a", "user_b"):
+        service.register_recipient_key(
+            user_id=user_id,
+            key_id=f"key-{user_id}",
+            public_key_jwk={"kty": "EC", "crv": "P-256", "x": user_id, "y": user_id},
+        )
+    return service
+
+
+def _ask(service: FourUserMemoryService) -> dict:
+    return service.request_access(
+        requester_user_id="user_b",
+        owner_user_id="user_a",
+        requested_duration_hours=1,
+        requested_duration_mode="timed",
+    )
+
+
+def _make_stale(service: FourUserMemoryService, request_id: str) -> None:
+    request = service.requests[request_id]
+    request["requested_at"] = datetime.now(timezone.utc) - timedelta(
+        hours=LOCATION_REQUEST_EXPIRY_HOURS,
+        minutes=1,
+    )
+    request["expires_at"] = datetime.now(timezone.utc) - timedelta(minutes=1)
+
+
+def _attach_public_parent(service: FourUserMemoryService, request_id: str) -> None:
+    submission_id = f"linked-submission-{len(service.public_submissions) + 1}"
+    service.public_submissions[submission_id] = {
+        "id": submission_id,
+        "request_id": request_id,
+    }
+
+
+def test_direct_ask_gets_a_server_owned_one_day_deadline() -> None:
+    service = _service()
+    before = datetime.now(timezone.utc)
+
+    request = _ask(service)
+
+    expires_at = datetime.fromisoformat(request["expiresAt"])
+    assert before + timedelta(hours=LOCATION_REQUEST_EXPIRY_HOURS - 0.01) < expires_at
+    assert expires_at < datetime.now(timezone.utc) + timedelta(
+        hours=LOCATION_REQUEST_EXPIRY_HOURS + 0.01
+    )
+
+
+def test_exact_retry_before_expiry_remains_idempotent() -> None:
+    service = _service()
+    first = _ask(service)
+    notifications_before = len(
+        [
+            item
+            for item in service.notifications
+            if item["notification_type"] == "location_access_request"
+        ]
+    )
+
+    again = _ask(service)
+
+    assert again["id"] == first["id"]
+    assert (
+        len(
+            [
+                item
+                for item in service.notifications
+                if item["notification_type"] == "location_access_request"
+            ]
+        )
+        == notifications_before
+    )
+
+
+def test_ask_again_after_expiry_creates_a_new_request_and_notification() -> None:
+    service = _service()
+    first = _ask(service)
+    _make_stale(service, first["id"])
+
+    again = _ask(service)
+
+    assert again["id"] != first["id"]
+    assert service.requests[first["id"]]["status"] == "expired"
+    assert again["status"] == "pending"
+    notifications = [
+        item
+        for item in service.notifications
+        if item["notification_type"] == "location_access_request"
+    ]
+    assert len(notifications) == 2
+    assert notifications[-1]["data"]["request_id"] == again["id"]
+
+
+def test_read_projection_and_pending_lists_drop_a_stale_row_without_waiting_for_cleanup() -> None:
+    service = _service()
+    request = _ask(service)
+    _make_stale(service, request["id"])
+
+    projected = OneLocationAgentService._request_payload(service.requests[request["id"]])
+
+    assert projected is not None
+    assert projected["status"] == "expired"
+    assert projected["resolvedAt"] == projected["expiresAt"]
+    assert service.list_pending_owner_requests(owner_user_id="user_a") == []
+    assert service.list_pending_requester_requests(requester_user_id="user_b") == []
+
+
+@pytest.mark.parametrize("action", ["approve", "deny", "withdraw"])
+def test_stale_request_actions_return_gone(action: str) -> None:
+    service = _service()
+    request = _ask(service)
+    _make_stale(service, request["id"])
+
+    with pytest.raises(OneLocationAgentError) as raised:
+        if action == "approve":
+            service.approve_request(
+                owner_user_id="user_a",
+                request_id=request["id"],
+                approval_mode="manual",
+                duration_hours=None,
+            )
+        elif action == "deny":
+            service.deny_request(owner_user_id="user_a", request_id=request["id"])
+        else:
+            service.withdraw_request(requester_user_id="user_b", request_id=request["id"])
+
+    assert raised.value.code == "LOCATION_REQUEST_EXPIRED"
+    assert raised.value.status_code == 410
+
+
+@pytest.mark.parametrize("action", ["approve", "deny", "withdraw"])
+def test_mixed_version_orphan_is_repaired_before_any_consent_action(action: str) -> None:
+    service = _service()
+    request = service.request_access(
+        requester_user_id="user_b",
+        owner_user_id="user_a",
+        requested_duration_hours=1,
+        requested_duration_mode="timed",
+        _expires_after_hours=None,
+    )
+    request_row = service.requests[request["id"]]
+    request_row["requested_at"] = datetime.now(timezone.utc) - timedelta(hours=25)
+
+    with pytest.raises(OneLocationAgentError) as raised:
+        if action == "approve":
+            service.approve_request(
+                owner_user_id="user_a",
+                request_id=request["id"],
+                approval_mode="manual",
+                duration_hours=None,
+            )
+        elif action == "deny":
+            service.deny_request(owner_user_id="user_a", request_id=request["id"])
+        else:
+            service.withdraw_request(requester_user_id="user_b", request_id=request["id"])
+
+    assert raised.value.code == "LOCATION_REQUEST_EXPIRED"
+    assert request_row["status"] == "expired"
+
+
+def test_linked_workflow_can_explicitly_keep_its_parent_owned_lifetime() -> None:
+    service = _service()
+
+    request = service.request_access(
+        requester_user_id="user_b",
+        owner_user_id="user_a",
+        _expires_after_hours=None,
+    )
+    _attach_public_parent(service, request["id"])
+    service.requests[request["id"]]["requested_at"] = datetime.now(timezone.utc) - timedelta(
+        days=30
+    )
+
+    assert request["expiresAt"] is None
+    assert service.list_pending_owner_requests(owner_user_id="user_a")[0]["id"] == request["id"]
+
+
+@pytest.mark.parametrize("first_policy", ["direct", "parent_owned"])
+def test_direct_and_parent_owned_requests_never_reuse_each_other(first_policy: str) -> None:
+    service = _service()
+
+    def create(policy: str) -> dict:
+        if policy == "direct":
+            return _ask(service)
+        request = service.request_access(
+            requester_user_id="user_b",
+            owner_user_id="user_a",
+            requested_duration_hours=1,
+            requested_duration_mode="timed",
+            _expires_after_hours=None,
+        )
+        _attach_public_parent(service, request["id"])
+        return request
+
+    second_policy = "parent_owned" if first_policy == "direct" else "direct"
+    first = create(first_policy)
+    second = create(second_policy)
+
+    assert first["id"] != second["id"]
+    assert len(service.requests) == 2
+    by_policy = {first_policy: first, second_policy: second}
+    assert by_policy["direct"]["expiresAt"] is not None
+    assert by_policy["parent_owned"]["expiresAt"] is None
+
+
+def test_mixed_version_orphaned_direct_request_is_adopted_and_expires() -> None:
+    service = _service()
+    legacy = service.request_access(
+        requester_user_id="user_b",
+        owner_user_id="user_a",
+        requested_duration_hours=1,
+        requested_duration_mode="timed",
+        _expires_after_hours=None,
+    )
+    legacy_row = service.requests[legacy["id"]]
+    legacy_row["requested_at"] = datetime.now(timezone.utc) - timedelta(hours=25)
+
+    fresh = _ask(service)
+
+    assert fresh["id"] != legacy["id"]
+    assert legacy_row["status"] == "expired"
+    assert legacy_row["expires_at"] == legacy_row["requested_at"] + timedelta(
+        hours=LOCATION_REQUEST_EXPIRY_HOURS
+    )
+
+
+def test_read_only_state_projects_mixed_version_direct_expiry_without_writing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _service()
+    legacy = service.request_access(
+        requester_user_id="user_b",
+        owner_user_id="user_a",
+        _expires_after_hours=None,
+    )
+    legacy_row = service.requests[legacy["id"]]
+    legacy_row["requested_at"] = datetime.now(timezone.utc) - timedelta(days=3)
+    monkeypatch.setenv("ONE_LOCATION_READ_ONLY_STATE_ENABLED", "true")
+
+    state = service.list_state(user_id="user_b")
+    projected = next(item for item in state["requests"] if item["id"] == legacy["id"])
+
+    assert projected["status"] == "expired"
+    assert projected["expiresAt"] is not None
+    assert legacy_row["status"] == "pending"
+    assert legacy_row["expires_at"] is None
+
+
+def test_read_only_state_does_not_invent_expiry_for_linked_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _service()
+    linked = service.request_access(
+        requester_user_id="user_b",
+        owner_user_id="user_a",
+        _expires_after_hours=None,
+    )
+    _attach_public_parent(service, linked["id"])
+    linked_row = service.requests[linked["id"]]
+    linked_row["requested_at"] = datetime.now(timezone.utc) - timedelta(days=30)
+    monkeypatch.setenv("ONE_LOCATION_READ_ONLY_STATE_ENABLED", "true")
+
+    state = service.list_state(user_id="user_b")
+    projected = next(item for item in state["requests"] if item["id"] == linked["id"])
+
+    assert projected["status"] == "pending"
+    assert projected["expiresAt"] is None
+
+
+def test_request_deadline_actions_use_the_database_wall_clock() -> None:
+    # PostgreSQL NOW() is frozen at transaction start. A consent deadline must
+    # keep advancing while a transaction waits on a lock or performs approval.
+    for method in (
+        OneLocationAgentService.request_access,
+        OneLocationAgentService.approve_request,
+        OneLocationAgentService.deny_request,
+        OneLocationAgentService.withdraw_request,
+        OneLocationAgentService._repair_legacy_direct_request_deadlines,
+        OneLocationAgentService._expire_stale_requests,
+    ):
+        assert "clock_timestamp()" in inspect.getsource(method)
+
+
+def test_expired_request_does_not_remain_a_needs_action_recommendation() -> None:
+    service = _service()
+    service._seed_connection("user_a", "user_b")
+    request = _ask(service)
+    _make_stale(service, request["id"])
+
+    recipients = service.list_verified_recipients(owner_user_id="user_a")
+    user_b = next(recipient for recipient in recipients if recipient["userId"] == "user_b")
+
+    assert user_b["recommendationCategory"] != "needs_action"
+    assert all(
+        reason["code"] != "pending_location_request" for reason in user_b["recommendationReasons"]
+    )
+
+
+def test_hourly_maintenance_settles_expired_requests() -> None:
+    service = _service()
+    request = _ask(service)
+    _make_stale(service, request["id"])
+
+    service.purge_terminal_work(older_than_hours=12)
+
+    assert service.requests[request["id"]]["status"] == "expired"
+
+
+def test_three_day_return_keeps_expired_outcome_for_ask_again() -> None:
+    service = _service()
+    request = _ask(service)
+    request_row = service.requests[request["id"]]
+    request_row["requested_at"] = datetime.now(timezone.utc) - timedelta(days=3)
+    request_row["expires_at"] = request_row["requested_at"] + timedelta(
+        hours=LOCATION_REQUEST_EXPIRY_HOURS
+    )
+
+    service.purge_terminal_work(older_than_hours=12)
+
+    assert request["id"] in service.requests
+    assert request_row["status"] == "expired"
+    projected = OneLocationAgentService._request_payload(request_row)
+    assert projected is not None
+    assert projected["status"] == "expired"
+
+
+def test_expired_outcome_is_removed_after_bounded_tombstone_window() -> None:
+    service = _service()
+    request = _ask(service)
+    request_row = service.requests[request["id"]]
+    request_row["requested_at"] = datetime.now(timezone.utc) - timedelta(
+        hours=LOCATION_EXPIRED_REQUEST_RETENTION_HOURS + LOCATION_REQUEST_EXPIRY_HOURS + 1
+    )
+    request_row["expires_at"] = request_row["requested_at"] + timedelta(
+        hours=LOCATION_REQUEST_EXPIRY_HOURS
+    )
+
+    service.purge_terminal_work(older_than_hours=12)
+
+    assert request["id"] not in service.requests
+
+
+def test_migration_scopes_backfill_away_from_linked_workflows() -> None:
+    root = Path(__file__).resolve().parents[1]
+    migration = (root / "db/migrations/191_one_location_access_request_expiry.sql").read_text(
+        encoding="utf-8"
+    )
+    rollback = (
+        root / "db/migrations/rollback/191_one_location_access_request_expiry.rollback.sql"
+    ).read_text(encoding="utf-8")
+
+    assert "'expired'" in migration
+    assert "expires_at" in migration
+    assert "INTERVAL '24 hours'" in migration
+    assert "one_location_referrals" in migration
+    assert "one_location_public_invite_submissions" in migration
+    expiry_constraint = "chk_one_location_access_request_expiry_after_send"
+    assert migration.index(f"DROP CONSTRAINT IF EXISTS {expiry_constraint}") < migration.index(
+        f"ADD CONSTRAINT {expiry_constraint}"
+    )
+    assert "status = 'cancelled'" in rollback
+    assert "status = 'pending' AND expires_at IS NOT NULL" in rollback
+    assert rollback.index("status = 'pending' AND expires_at IS NOT NULL") < rollback.index(
+        "DROP COLUMN IF EXISTS expires_at"
+    )
+
+    manifest = json.loads((root / "db/release_migration_manifest.json").read_text(encoding="utf-8"))
+    migration_name = "191_one_location_access_request_expiry.sql"
+    assert migration_name in manifest["ordered_migrations"]
+    assert manifest["ordered_migrations"].index(migration_name) > manifest[
+        "ordered_migrations"
+    ].index("190_one_location_place_ratings.sql")
+    assert migration_name in manifest["groups"]["iam"]
+    expected_version = int(migration_name.split("_", 1)[0])
+    for contract_name in (
+        "dev_minimum_schema.json",
+        "prod_core_schema.json",
+        "uat_integrated_schema.json",
+    ):
+        contract = json.loads((root / "db/contracts" / contract_name).read_text(encoding="utf-8"))
+        assert contract["expected_migration_version"] >= expected_version

--- a/hushh-webapp/__tests__/components/location-request-take-back.test.tsx
+++ b/hushh-webapp/__tests__/components/location-request-take-back.test.tsx
@@ -122,7 +122,11 @@ describe("the Requests sent list", () => {
     // fixture: re-adding the word here would not change the fixture and would
     // not turn it red. This assertion is what closes that gap, so the two are
     // load-bearing together, not redundant.
-    const pendingBranchStart = source.indexOf('request.status === "pending" ?');
+    // Pending is now deadline-aware: a cached row at or beyond `expiresAt`
+    // must become the compact Expired state rather than retaining this action.
+    const pendingBranchStart = source.indexOf(
+      "isLocationRequestPending(request, vm.nowMs) ?",
+    );
     expect(pendingBranchStart).toBeGreaterThan(-1);
     const pendingBranchEnd = source.indexOf(
       "requestStatusWord(request.status)",
@@ -134,7 +138,7 @@ describe("the Requests sent list", () => {
       // The comment explaining the decision says "Pending" itself.
       .replace(/^\s*\/\/.*$/gm, "");
     expect(pendingBranch.trim().length).toBeGreaterThan(0);
-    expect(pendingBranch).not.toContain("Pending");
+    expect(pendingBranch).not.toMatch(/(["'`])Pending\1/);
     expect(pendingBranch).not.toContain("MUTED_TEXT");
   });
 

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // The rungs themselves, not a copy of their labels: Ask and Share must offer
 // the same ladder, so the test reads the same list the component does.
+import { CONSENT_STATE_CHANGED_EVENT } from "@/lib/consent/consent-events";
 import { ROUTES } from "@/lib/navigation/routes";
 import { INTERNAL_APP_NAVIGATION_REQUEST_EVENT } from "@/lib/utils/browser-navigation";
 
@@ -1434,6 +1435,7 @@ describe("OneLocationAgentPage", () => {
           requesterUserId: "user_b",
           status: "pending",
           requestedAt: "2026-05-20T07:30:00.000Z",
+          expiresAt: "2099-05-20T07:30:00.000Z",
         },
       ],
     });
@@ -1469,6 +1471,7 @@ describe("OneLocationAgentPage", () => {
           status: "pending",
           message: "School pickup",
           requestedAt: "2026-05-20T07:30:00.000Z",
+          expiresAt: "2099-05-20T07:30:00.000Z",
           requestedDurationHours: 1,
           requestedDurationMode: "timed",
         },
@@ -1520,6 +1523,7 @@ describe("OneLocationAgentPage", () => {
       status: "pending" as const,
       message: "Running late",
       requestedAt: "2026-05-20T07:30:00.000Z",
+      expiresAt: "2099-05-20T07:30:00.000Z",
       requestedDurationHours: 4,
       requestedDurationMode: "timed",
     };
@@ -1616,6 +1620,7 @@ describe("OneLocationAgentPage", () => {
           requesterUserId: "user_b",
           status: "pending",
           requestedAt: "2026-05-20T07:30:00.000Z",
+          expiresAt: "2099-05-20T07:30:00.000Z",
         },
       ],
     });
@@ -1913,6 +1918,7 @@ describe("OneLocationAgentPage", () => {
         requesterDisplayName: "Trusted B",
         status: "pending",
         requestedAt: "2026-08-24T09:01:00.000Z",
+        expiresAt: "2099-08-24T09:01:00.000Z",
         requestedDurationHours: 1,
         requestedDurationMode: "timed",
       },
@@ -1923,6 +1929,7 @@ describe("OneLocationAgentPage", () => {
         requesterDisplayName: "Investor D",
         status: "pending",
         requestedAt: "2026-08-24T09:02:00.000Z",
+        expiresAt: "2099-08-24T09:02:00.000Z",
         requestedDurationHours: 1,
         requestedDurationMode: "timed",
       },
@@ -2015,6 +2022,7 @@ describe("OneLocationAgentPage", () => {
       requesterDisplayName: "Trusted B",
       status: "pending",
       requestedAt: "2026-08-24T09:01:00.000Z",
+      expiresAt: "2099-08-24T09:01:00.000Z",
       requestedDurationHours: 1,
       requestedDurationMode: "timed",
     };
@@ -4738,8 +4746,12 @@ describe("OneLocationAgentPage", () => {
     ).toEqual(["15 min", "1 hour", "2 hours", "Custom"]);
 
     // Removed from the face of the ladder, not from the lane.
-    expect(within(ladder).queryByRole("button", { name: "4 hours" })).toBeNull();
-    expect(within(ladder).queryByRole("button", { name: "8 hours" })).toBeNull();
+    expect(
+      within(ladder).queryByRole("button", { name: "4 hours" }),
+    ).toBeNull();
+    expect(
+      within(ladder).queryByRole("button", { name: "8 hours" }),
+    ).toBeNull();
 
     // And Custom still reaches them: one deliberate tap, then the wheel.
     fireEvent.click(within(ladder).getByRole("button", { name: "Custom" }));
@@ -4949,6 +4961,7 @@ describe("OneLocationAgentPage", () => {
           requesterUserId: "user_a",
           status: "pending",
           requestedAt: "2026-05-20T07:30:00.000Z",
+          expiresAt: "2099-05-20T07:30:00.000Z",
         },
       ],
     });
@@ -4964,6 +4977,38 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getAllByText("Trusted B").length).toBeGreaterThan(0);
     expect(screen.queryByText("user_b")).toBeNull();
     expect(screen.queryByText("request_1")).toBeNull();
+  });
+
+  it("does not keep calling a request Pending after its deadline", async () => {
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+      requests: [
+        {
+          id: "request_expired_client_side",
+          ownerUserId: "user_b",
+          requesterUserId: "user_a",
+          status: "pending",
+          requestedAt: new Date(Date.now() - 3_600_000).toISOString(),
+          expiresAt: new Date(Date.now() - 1).toISOString(),
+        },
+      ],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "People" }));
+    await screen.findByRole("heading", { name: "Requests sent" });
+
+    expect(screen.getByText("Request expired")).toBeInTheDocument();
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+    expect(screen.queryByText("Pending")).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: "Take back your request to Trusted B",
+      }),
+    ).toBeNull();
   });
 
   it("lets the requester delete a live (approved) request they sent", async () => {
@@ -6527,6 +6572,103 @@ describe("OneLocationAgentPage", () => {
     }
   }, 15000);
 
+  it("keeps the recipient identity and new duration across an older in-flight refresh", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(DURING_A_LIVE_SHARE));
+    try {
+      const initialState = locationState();
+      const updatedState = {
+        ...initialState,
+        ownerGrants: initialState.ownerGrants.map((grant) => ({
+          ...grant,
+          durationMode: "until_stopped",
+          durationHours: null,
+          expiresAt: null,
+        })),
+      };
+      mockSetGrantDuration.mockResolvedValueOnce({
+        id: "grant_1",
+        status: "active",
+        durationMode: "until_stopped",
+        durationHours: null,
+        expiresAt: null,
+      });
+
+      render(<OneLocationAgentPage />);
+      await skipLocationEntryFlow();
+      await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+
+      const callsBeforeRefresh = mockGetState.mock.calls.length;
+      let resolveOlderRefresh!: (
+        state: ReturnType<typeof locationState>,
+      ) => void;
+      mockGetState
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveOlderRefresh = resolve;
+            }),
+        )
+        .mockResolvedValueOnce(updatedState);
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent(CONSENT_STATE_CHANGED_EVENT, {
+            detail: { source: "one_location_notification" },
+          }),
+        );
+      });
+      await waitFor(() =>
+        expect(mockGetState.mock.calls.length).toBeGreaterThan(
+          callsBeforeRefresh,
+        ),
+      );
+
+      const card = await screen.findByTestId("one-location-live-share");
+      fireEvent.click(
+        within(card).getByTestId("one-location-live-share-change-time"),
+      );
+      const editor = await screen.findByTestId(
+        "one-location-live-share-duration-editor",
+      );
+      fireEvent.click(
+        within(editor).getByRole("button", { name: "Until I stop" }),
+      );
+      fireEvent.click(
+        within(editor).getByTestId("one-location-live-share-duration-save"),
+      );
+
+      await waitFor(() => expect(mockSetGrantDuration).toHaveBeenCalled());
+      const optimisticCard = await screen.findByTestId(
+        "one-location-live-share",
+      );
+      expect(
+        within(optimisticCard).getByText("Sharing with Trusted B"),
+      ).toBeInTheDocument();
+      expect(
+        within(optimisticCard).getByText("Until you stop"),
+      ).toBeInTheDocument();
+
+      await act(async () => {
+        resolveOlderRefresh(initialState);
+        await Promise.resolve();
+      });
+      await waitFor(() =>
+        expect(mockGetState.mock.calls.length).toBeGreaterThanOrEqual(
+          callsBeforeRefresh + 2,
+        ),
+      );
+      const reconciledCard = screen.getByTestId("one-location-live-share");
+      expect(
+        within(reconciledCard).getByText("Sharing with Trusted B"),
+      ).toBeInTheDocument();
+      expect(
+        within(reconciledCard).getByText("Until you stop"),
+      ).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 15000);
+
   it("offers four common lengths and the open-ended row, one tap each", async () => {
     // The report (issue #6228): Change time showed too many near-identical
     // choices -- 15 min / 1 hour / 2 hours / 4 hours / 8 hours / Custom /
@@ -6550,6 +6692,16 @@ describe("OneLocationAgentPage", () => {
         "one-location-live-share-duration-editor",
       );
 
+      const dialog = screen.getByRole("dialog", { name: "Change time" });
+      expect(
+        within(dialog).queryByText("Set a new end time for this share."),
+      ).toBeNull();
+      expect(within(editor).getByText("Share for")).toBeInTheDocument();
+      expect(within(editor).queryByText("New time")).toBeNull();
+      expect(
+        document.querySelector('[data-slot="dialog-overlay"]'),
+      ).toHaveClass("backdrop-blur-[8px]");
+
       for (const label of [
         "15 min",
         "1 hour",
@@ -6572,7 +6724,9 @@ describe("OneLocationAgentPage", () => {
       // One tap on a rung is the whole interaction -- no drag, no confirm
       // step of its own before Save.
       await act(async () => {
-        fireEvent.click(within(editor).getByRole("button", { name: "2 hours" }));
+        fireEvent.click(
+          within(editor).getByRole("button", { name: "2 hours" }),
+        );
       });
       await act(async () => {
         fireEvent.click(
@@ -6595,6 +6749,35 @@ describe("OneLocationAgentPage", () => {
       vi.useRealTimers();
     }
   }, 15000);
+
+  it("restores focus to Change time and describes the modal without visible repetition", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(DURING_A_LIVE_SHARE));
+    try {
+      render(<OneLocationAgentPage />);
+      await skipLocationEntryFlow();
+      await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+
+      const card = await screen.findByTestId("one-location-live-share");
+      const changeTime = within(card).getByTestId(
+        "one-location-live-share-change-time",
+      );
+      fireEvent.click(changeTime);
+
+      const dialog = await screen.findByRole("dialog", { name: "Change time" });
+      const description = within(dialog).getByText(
+        "Choose how long this live location share should continue.",
+      );
+      expect(description).toHaveClass("sr-only");
+      expect(within(dialog).queryByText("Dialog content")).toBeNull();
+
+      fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+      await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+      expect(changeTime).toHaveFocus();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it("remembers the running share on the device, and only ids and times", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });

--- a/hushh-webapp/__tests__/components/request-recipient-status.test.ts
+++ b/hushh-webapp/__tests__/components/request-recipient-status.test.ts
@@ -78,8 +78,14 @@ describe("someone you already asked", () => {
   it("reports the most recent ask when there are several", () => {
     const status = statusFor({
       requestedByMe: [
-        request({ id: "old", requestedAt: new Date(NOW - 5 * 3_600_000).toISOString() }),
-        request({ id: "new", requestedAt: new Date(NOW - 60_000).toISOString() }),
+        request({
+          id: "old",
+          requestedAt: new Date(NOW - 5 * 3_600_000).toISOString(),
+        }),
+        request({
+          id: "new",
+          requestedAt: new Date(NOW - 60_000).toISOString(),
+        }),
       ],
     });
     expect(status.subtitle).toBe("Asked 1m ago, waiting on them");
@@ -103,14 +109,53 @@ describe("someone you already asked", () => {
     expect(status.pendingRequestId).toBe("req_live");
   });
 
+  it("expires after one day and makes ask again the row action", () => {
+    const status = statusFor({
+      requestedByMe: [
+        request({
+          id: "req_expired",
+          requestedAt: new Date(NOW - 24 * 3_600_000).toISOString(),
+          expiresAt: new Date(NOW).toISOString(),
+        }),
+      ],
+    });
+
+    expect(status.subtitle).toBe("Request expired · Ask again");
+    expect(status.statusLabel).toBe("Expired");
+    expect(status.selectable).toBe(true);
+    expect(status.pendingRequestId).toBeUndefined();
+  });
+
+  it("honours a server deadline and leaves linked requests with null expiry pending", () => {
+    const explicit = request({
+      expiresAt: new Date(NOW).toISOString(),
+      requestedAt: new Date(NOW - 60_000).toISOString(),
+    });
+    expect(statusFor({ requestedByMe: [explicit] }).statusLabel).toBe(
+      "Expired",
+    );
+
+    const linked = request({
+      expiresAt: null,
+      requestedAt: new Date(NOW - 3 * 24 * 3_600_000).toISOString(),
+    });
+    expect(statusFor({ requestedByMe: [linked] }).statusLabel).toBe("Asked");
+  });
+
   it("offers the take-back for the ask it is reporting", () => {
     // The subtitle names the newest ask; a take-back wired to the older one
     // would end a request the row is not talking about and leave the visible
     // one standing.
     const status = statusFor({
       requestedByMe: [
-        request({ id: "old", requestedAt: new Date(NOW - 5 * 3_600_000).toISOString() }),
-        request({ id: "new", requestedAt: new Date(NOW - 60_000).toISOString() }),
+        request({
+          id: "old",
+          requestedAt: new Date(NOW - 5 * 3_600_000).toISOString(),
+        }),
+        request({
+          id: "new",
+          requestedAt: new Date(NOW - 60_000).toISOString(),
+        }),
       ],
     });
     expect(status.pendingRequestId).toBe("new");
@@ -122,7 +167,7 @@ describe("someone already sharing with you", () => {
     // Asking somebody to share while they already are is the clearest possible
     // sign the list is not looking at anything.
     const status = statusFor({ receivedGrants: [grant({})] });
-    expect(status.subtitle).toBe("Sharing with you, 55 more min");
+    expect(status.subtitle).toBe("Sharing with you, 55 min left");
     expect(status.statusLabel).toBe("Live");
     expect(status.selectable).toBe(false);
   });
@@ -137,7 +182,7 @@ describe("someone already sharing with you", () => {
       receivedGrants: [grant({})],
     });
     expect(status.subtitle).toBe(
-      "Sharing with you, 55 more min · asked for 4 hours more",
+      "Sharing with you, 55 min left · asked for 4 hours more",
     );
     expect(status.statusLabel).toBe("Asked");
     expect(status.selectable).toBe(false);
@@ -157,7 +202,7 @@ describe("someone already sharing with you", () => {
       receivedGrants: [grant({})],
     });
     expect(status.subtitle).toBe(
-      "Sharing with you, 55 more min · asked for more time",
+      "Sharing with you, 55 min left · asked for more time",
     );
   });
 
@@ -167,14 +212,31 @@ describe("someone already sharing with you", () => {
       receivedGrants: [grant({})],
     });
     expect(status.subtitle).toBe(
-      "Sharing with you, 55 more min · asked for no end time",
+      "Sharing with you, 55 min left · asked for no end time",
     );
   });
 
   it("ignores a grant that is no longer active", () => {
-    const status = statusFor({ receivedGrants: [grant({ status: "revoked" })] });
+    const status = statusFor({
+      receivedGrants: [grant({ status: "revoked" })],
+    });
     expect(status.subtitle).toBe("Ready for private sharing");
     expect(status.selectable).toBe(true);
+  });
+
+  it("stops treating a cached timed grant as live at its exact deadline", () => {
+    const ended = statusFor({
+      receivedGrants: [grant({ expiresAt: new Date(NOW).toISOString() })],
+    });
+    expect(ended.subtitle).toBe("Ready for private sharing");
+    expect(ended.statusLabel).toBeUndefined();
+    expect(ended.selectable).toBe(true);
+
+    const openEnded = statusFor({
+      receivedGrants: [grant({ expiresAt: null })],
+    });
+    expect(openEnded.statusLabel).toBe("Live");
+    expect(openEnded.selectable).toBe(false);
   });
 });
 
@@ -205,16 +267,16 @@ describe("relative labels", () => {
 
   it("never reports remaining time on access that already ended", () => {
     expect(shortRemaining(NOW - 1, NOW)).toBeNull();
-    expect(shortRemaining(NOW + 55 * 60_000, NOW)).toBe("55 more min");
-    expect(shortRemaining(NOW + 60 * 60_000, NOW)).toBe("1 more hour");
-    expect(shortRemaining(NOW + 3 * 3_600_000, NOW)).toBe("3 more hours");
+    expect(shortRemaining(NOW + 55 * 60_000, NOW)).toBe("55 min");
+    expect(shortRemaining(NOW + 60 * 60_000, NOW)).toBe("1 hour");
+    expect(shortRemaining(NOW + 3 * 3_600_000, NOW)).toBe("3 hours");
   });
 
   it("never overstates the time left", () => {
     // 90 minutes used to round to "2 more hours". A countdown that claims more
     // time than exists is worse than none: it is the number people use to
     // decide when to leave, or when to ask for more.
-    expect(shortRemaining(NOW + 90 * 60_000, NOW)).toBe("1h 30m more");
-    expect(shortRemaining(NOW + 119 * 60_000, NOW)).toBe("1h 59m more");
+    expect(shortRemaining(NOW + 90 * 60_000, NOW)).toBe("1h 30m");
+    expect(shortRemaining(NOW + 119 * 60_000, NOW)).toBe("1h 59m");
   });
 });

--- a/hushh-webapp/__tests__/lib/one-location-state-resource.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location-state-resource.test.ts
@@ -86,4 +86,66 @@ describe("OneLocationStateResource", () => {
       OneLocationStateResource.peek(userId)?.data.smsContactUserIds,
     ).toEqual([]);
   });
+
+  it("merges a duration response without losing identity or accepting an older refresh", async () => {
+    const userId = "location-resource-owner";
+    const initial = {
+      recipients: [],
+      ownerGrants: [
+        {
+          id: "grant_1",
+          ownerUserId: userId,
+          recipientUserId: "friend",
+          recipientDisplayName: "Trusted Friend",
+          recipientKeyId: "key_friend",
+          status: "active",
+          consentScope: "cap.location.live.view",
+          capabilityScopes: ["cap.location.live.view"],
+          durationMode: "timed",
+          durationHours: 1,
+          expiresAt: "2026-09-01T09:00:00.000Z",
+        },
+      ],
+    } as unknown as OneLocationState;
+    OneLocationStateResource.write(userId, initial);
+
+    let resolveStale!: (state: OneLocationState) => void;
+    const staleLoad = OneLocationStateResource.load(
+      userId,
+      () =>
+        new Promise<OneLocationState>((resolve) => {
+          resolveStale = resolve;
+        }),
+    );
+
+    expect(
+      OneLocationStateResource.mergeOwnerGrant(userId, {
+        id: "grant_1",
+        status: "active",
+        durationMode: "until_stopped",
+        durationHours: null,
+        expiresAt: null,
+      }),
+    ).toBe(true);
+    expect(
+      OneLocationStateResource.peek(userId)?.data.ownerGrants[0],
+    ).toMatchObject({
+      id: "grant_1",
+      recipientUserId: "friend",
+      recipientDisplayName: "Trusted Friend",
+      recipientKeyId: "key_friend",
+      durationMode: "until_stopped",
+      expiresAt: null,
+    });
+
+    resolveStale(initial);
+    await staleLoad;
+    expect(
+      OneLocationStateResource.peek(userId)?.data.ownerGrants[0],
+    ).toMatchObject({
+      recipientDisplayName: "Trusted Friend",
+      durationMode: "until_stopped",
+      expiresAt: null,
+    });
+  });
 });

--- a/hushh-webapp/__tests__/one-location-extra-time-notifications.test.ts
+++ b/hushh-webapp/__tests__/one-location-extra-time-notifications.test.ts
@@ -31,7 +31,7 @@ describe("the owner's popup", () => {
     // even read -- extra time on a running share is not a fresh ask.
     expect(copy.title).toBe("More location time requested");
     expect(copy.description).toBe(
-      "Ankit Kumar Singh is asking for 3 hours more of your live location. They have 45 more min left.",
+      "Ankit Kumar Singh is asking for 3 hours more of your live location. They have 45 min left.",
     );
   });
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -197,6 +197,7 @@ import {
   locationApproveActionLabel,
   locationAskPromptLine,
 } from "@/lib/one-location/duration-copy";
+import { isLocationRequestPending } from "@/lib/one-location/request-expiry";
 import {
   resolveShareDurationHours,
   shareReplacementsLosingTime,
@@ -678,7 +679,8 @@ export const LOCATION_FLOW_LABELS: Readonly<Record<string, string>> = {
 // cap and lose ties to whichever SUBVIEW_ACTION_BOOST entry matches the
 // current subview) -- this only changes what becomes a CANDIDATE, not how
 // candidates are ranked once the list is bigger.
-export const LOCATION_VOICE_ACTIONS = deriveLocationVoiceActions("one_location");
+export const LOCATION_VOICE_ACTIONS =
+  deriveLocationVoiceActions("one_location");
 
 const LOCATION_VOICE_CONTROLS = [
   {
@@ -3172,8 +3174,8 @@ export function OneLocationAgentPageContent({
   );
   const rankedRecipients = useMemo(() => {
     const ranked = rankRecipientsForRecommendation(
-        contactSignalRecipients,
-        contactMatchedUserIds,
+      contactSignalRecipients,
+      contactMatchedUserIds,
     );
     // Every paged row came through the same vault-authorized recipient route.
     // Retain it by user id so selecting page 2, then changing search, does not
@@ -3184,7 +3186,7 @@ export function OneLocationAgentPageContent({
         [...pagedRecipientsByUserId.values()],
         contactMatchedUserIds,
       ),
-  );
+    );
   }, [contactMatchedUserIds, contactSignalRecipients, pagedRecipientsByUserId]);
   const shareRecipientPool = useMemo(
     () =>
@@ -3243,9 +3245,9 @@ export function OneLocationAgentPageContent({
             contactMatchedUserIds,
           )
         : filterPeopleByQuery(
-        rankedRecipients,
-        shareRecipientSearch,
-        recipientLabel,
+            rankedRecipients,
+            shareRecipientSearch,
+            recipientLabel,
           ).slice(0, 50),
     [
       contactMatchedUserIds,
@@ -3349,9 +3351,10 @@ export function OneLocationAgentPageContent({
     () =>
       (state?.requests ?? []).filter(
         (request) =>
-          request.ownerUserId === auth.userId && request.status === "pending",
+          request.ownerUserId === auth.userId &&
+          isLocationRequestPending(request, nowMs),
       ),
-    [auth.userId, state?.requests],
+    [auth.userId, nowMs, state?.requests],
   );
   // Warm the shared position while the user is still reading the request.
   //
@@ -6557,17 +6560,38 @@ export function OneLocationAgentPageContent({
 
     setLiveShareDurationSaving(true);
     try {
-      await OneLocationService.setGrantDuration({
+      const updatedGrant = await OneLocationService.setGrantDuration({
         vaultOwnerToken,
         grantId,
         durationHours,
         durationMode: untilStopped ? "until_stopped" : "timed",
       });
+      // The PATCH response is authoritative and already contains the new
+      // expiry. Merge it over the enriched row: duration PATCH payloads may
+      // omit display identity and key fields that the state projection added.
+      // Invalidate before publishing so a refresh started before the PATCH can
+      // never overwrite this authoritative result when it eventually lands.
+      if (updatedGrant?.id && auth.userId && state) {
+        const activeUserId = auth.userId;
+        const priorRefresh = refreshInFlightRef.current;
+        const merged = OneLocationStateResource.mergeOwnerGrant(
+          activeUserId,
+          updatedGrant,
+          state,
+        );
+        if (!merged) OneLocationStateResource.invalidate(activeUserId);
+        // If a refresh was already in flight, calling refresh immediately only
+        // joins that stale task. Wait it out, then start (or join) a read that
+        // is guaranteed to have begun after the mutation.
+        void (async () => {
+          if (priorRefresh) await priorRefresh;
+          await refresh({ background: true });
+        })().catch(() => null);
+      } else {
+        void refresh({ background: true }).catch(() => null);
+      }
       toast.success("Time updated.");
       setLiveShareDurationEditing(false);
-      // Held until the list has reconciled, so the card's countdown is already
-      // reading the new expiry when the editor closes.
-      await refresh({ background: true }).catch(() => null);
     } catch (error) {
       toast.error(
         error instanceof Error
@@ -6579,9 +6603,11 @@ export function OneLocationAgentPageContent({
     }
   }, [
     activeOwnerGrants,
+    auth.userId,
     liveShareDurationHours,
     liveShareStatus?.stoppableGrantId,
     refresh,
+    state,
     vaultOwnerToken,
   ]);
 
@@ -7087,25 +7113,25 @@ export function OneLocationAgentPageContent({
                     onClick: () => void handleSyncContactSignalRef.current?.(),
                   },
                 }
-            : outcome.remedy === "invite"
-              ? {
-                  action: {
-                    label: "Invite them",
-                    // The other half of a contact scan. Until now the count of
-                    // people who are NOT on One was computed on every sync and
-                    // read by nothing but an analytics dimension — the product
-                    // learned who was missing, recorded it, and offered the
-                    // person no way to act on it.
-                    //
-                    // Reuses the existing invite share rather than minting a
-                    // second one, and deliberately carries no pre-authorized
-                    // connection: `buildInviteToOneShare` documents why, and
-                    // an invite that consents on the recipient's behalf is not
-                    // an invite.
-                    onClick: () => void handleInviteContactCandidates(),
-                  },
-                }
-              : {}),
+              : outcome.remedy === "invite"
+                ? {
+                    action: {
+                      label: "Invite them",
+                      // The other half of a contact scan. Until now the count of
+                      // people who are NOT on One was computed on every sync and
+                      // read by nothing but an analytics dimension — the product
+                      // learned who was missing, recorded it, and offered the
+                      // person no way to act on it.
+                      //
+                      // Reuses the existing invite share rather than minting a
+                      // second one, and deliberately carries no pre-authorized
+                      // connection: `buildInviteToOneShare` documents why, and
+                      // an invite that consents on the recipient's behalf is not
+                      // an invite.
+                      onClick: () => void handleInviteContactCandidates(),
+                    },
+                  }
+                : {}),
       };
       if (result.matchedUserIds.length > 0) {
         toast.success(outcome.title, outcomeOptions);
@@ -7228,7 +7254,9 @@ export function OneLocationAgentPageContent({
             vaultOwnerToken: activeVaultOwnerToken,
             ownerUserId: owner.userId,
             message: buildOneLocationRequestMessage(reason, requestMessage),
-            requestedDurationHours: Number(durationHoursOverride ?? durationHours),
+            requestedDurationHours: Number(
+              durationHoursOverride ?? durationHours,
+            ),
             requestedDurationMode: "timed",
           });
           successCount += 1;
@@ -12297,9 +12325,9 @@ export function OneLocationAgentPageContent({
       try {
         const preference = await OneLocationService.updateAutoApprovePreference(
           {
-          vaultOwnerToken,
-          enabled,
-          scope: enabled ? (input.scope ?? null) : null,
+            vaultOwnerToken,
+            enabled,
+            scope: enabled ? (input.scope ?? null) : null,
           },
         );
         // The PATCH result is the authority. Keep it visible even when the

--- a/hushh-webapp/components/one-location/redesign/__tests__/live-share-status-card.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/live-share-status-card.test.tsx
@@ -232,6 +232,7 @@ describe("LiveShareStatusCard", () => {
     const change = screen.getByRole("button", { name: "Change time" });
     change.click();
     expect(onChangeDuration).toHaveBeenCalledTimes(1);
+    expect(onChangeDuration).toHaveBeenCalledWith(change);
 
     expect(screen.getByText(/^Ends /)).toBeTruthy();
     const shareMore = screen.getByRole("button", { name: "Share with more" });

--- a/hushh-webapp/components/one-location/redesign/live-share-status-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/live-share-status-card.tsx
@@ -172,7 +172,7 @@ export function LiveShareStatusCard({
    * then wanting 45 meant ending the share and starting it again, which is a
    * different share to the person watching.
    */
-  onChangeDuration?: () => void;
+  onChangeDuration?: (trigger: HTMLButtonElement) => void;
   /** Opens the existing share composer while a share is already live. */
   onShareMore?: () => void;
   /** Fired once when the countdown reaches zero, so the page can reconcile. */
@@ -399,7 +399,10 @@ export function LiveShareStatusCard({
           <Button
             variant="ghost"
             size="sm"
-            onClick={runChildAction(onChangeDuration)}
+            onClick={(event) => {
+              event.stopPropagation();
+              onChangeDuration(event.currentTarget);
+            }}
             className={cn(
               LIVE_SHARE_ACTION_CLASSNAME,
               "mx-auto text-[color:var(--app-accent)]",

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -52,6 +52,10 @@ import {
   shortAgo,
   type RequestRecipientStatus,
 } from "@/lib/one-location/request-recipient-status";
+import {
+  isLocationRequestExpired,
+  isLocationRequestPending,
+} from "@/lib/one-location/request-expiry";
 import { SmsTextIcon } from "@/components/one-location/redesign/sms-text-icon";
 import { isSmsTriggeredGrant } from "@/lib/one-location/notifications";
 import {
@@ -1678,6 +1682,7 @@ function NowHub({
   onOpenNeedsReview: () => void;
   onRequestLocation: () => void;
 }) {
+  const liveShareDurationTriggerRef = useRef<HTMLElement | null>(null);
   const activityRows = [
     {
       leading: <LocationMenuListIcon name="pin" />,
@@ -1738,7 +1743,10 @@ function NowHub({
           // running there is no single one for "change time" to mean.
           onChangeDuration={
             vm.liveShare.stoppableGrantId
-              ? vm.onEditLiveShareDurationStart
+              ? (trigger) => {
+                  liveShareDurationTriggerRef.current = trigger;
+                  vm.onEditLiveShareDurationStart();
+                }
               : undefined
           }
           onShareMore={onStartShare}
@@ -1746,22 +1754,36 @@ function NowHub({
         />
       ) : null}
       <Dialog
+        modal
         open={Boolean(vm.liveShare && vm.liveShareDurationEditing)}
         onOpenChange={(open) => {
-          if (!open) vm.onEditLiveShareDurationCancel();
+          if (!open && !vm.liveShareDurationSaving) {
+            vm.onEditLiveShareDurationCancel();
+          }
         }}
       >
         <DialogContent
           className="max-w-[min(420px,calc(100%-2rem))] gap-4 rounded-[24px] p-4 sm:max-w-[420px]"
           showCloseButton={!vm.liveShareDurationSaving}
+          srDescription="Choose how long this live location share should continue."
+          aria-busy={vm.liveShareDurationSaving}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            const trigger = liveShareDurationTriggerRef.current;
+            liveShareDurationTriggerRef.current = null;
+            if (trigger?.isConnected) trigger.focus();
+          }}
+          onEscapeKeyDown={(event) => {
+            if (vm.liveShareDurationSaving) event.preventDefault();
+          }}
+          onPointerDownOutside={(event) => {
+            if (vm.liveShareDurationSaving) event.preventDefault();
+          }}
         >
           <DialogHeader className="gap-1 text-left">
             <DialogTitle className="text-[20px] font-semibold leading-[25px] text-[color:var(--app-primary-label)]">
               Change time
             </DialogTitle>
-            <DialogDescription className="text-[15px] leading-5 text-[color:var(--app-secondary-label)]">
-              Set a new end time for this share.
-            </DialogDescription>
           </DialogHeader>
           <LiveShareDurationEditor
             value={vm.liveShareDurationHours}
@@ -3354,7 +3376,8 @@ function sentRequestStatusLine(
     ? `Requested ${shortAgo(requestedAt, nowMs)}`
     : "Requested";
   const duration = requestDurationLabel(request);
-  if (request.status === "pending") {
+  if (isLocationRequestExpired(request, nowMs)) return "Request expired";
+  if (isLocationRequestPending(request, nowMs)) {
     return duration ? `${when} · ${duration}` : when;
   }
   return requestStatusWord(request.status);
@@ -3409,19 +3432,27 @@ export function PeopleHub({
   const pendingExtensionByGrantId = useMemo(() => {
     const byGrantId = new globalThis.Map<string, OneLocationAccessRequest>();
     for (const request of vm.requestedByMe) {
-      if (request.status !== "pending" || !request.extendsGrantId) continue;
+      if (
+        !isLocationRequestPending(request, vm.nowMs) ||
+        !request.extendsGrantId
+      )
+        continue;
       if (!byGrantId.has(request.extendsGrantId)) {
         byGrantId.set(request.extendsGrantId, request);
       }
     }
     return byGrantId;
-  }, [vm.requestedByMe]);
+  }, [vm.nowMs, vm.requestedByMe]);
   const requestsSentRows = useMemo(
     () =>
       vm.requestedByMe.filter(
-        (request) => !(request.status === "pending" && request.extendsGrantId),
+        (request) =>
+          !(
+            isLocationRequestPending(request, vm.nowMs) &&
+            request.extendsGrantId
+          ),
       ),
-    [vm.requestedByMe],
+    [vm.nowMs, vm.requestedByMe],
   );
   const { expandedLaneUserIds, toggleLaneExpansion } = useExpandedShareLanes();
   const addPeopleEmptyAction = (
@@ -3760,7 +3791,7 @@ export function PeopleHub({
                           </Button>
                         ) : isLive ? (
                           "Active"
-                        ) : request.status === "pending" ? (
+                        ) : isLocationRequestPending(request, vm.nowMs) ? (
                           // "Pending" as bare text was the whole trailing slot:
                           // the state was reported and there was nothing to do
                           // about it. The button replaces the word rather than
@@ -3782,6 +3813,8 @@ export function PeopleHub({
                           >
                             Take back
                           </Button>
+                        ) : isLocationRequestExpired(request, vm.nowMs) ? (
+                          "Expired"
                         ) : (
                           requestStatusWord(request.status)
                         )
@@ -4845,16 +4878,18 @@ function LiveShareDurationEditor({
       */}
       <DurationSelector
         value={value}
-        onChange={onChange}
+        onChange={(next) => {
+          if (!saving) onChange(next);
+        }}
         presentation="ladder"
         rungs={CHANGE_TIME_DURATION_LADDER}
         untilStopValue="until_stopped"
         allowCustom={false}
         centered
         maxWidthClassName={null}
-        label="New time"
+        label="Share for"
         // Beside the label rather than on its own line under the control --
-        // "New time … Ends 6:50 PM" is one statement, and it is how every
+        // "Share for … Ends 6:50 PM" is one statement, and it is how every
         // other ladder on these screens already reads.
         hint={shareEndsAtLabel(value, nowMs)}
       />
@@ -4863,6 +4898,7 @@ function LiveShareDurationEditor({
           variant="ghost"
           className="h-11 rounded-full"
           onClick={onCancel}
+          disabled={saving}
           data-testid="one-location-live-share-duration-cancel"
         >
           Cancel
@@ -5215,9 +5251,10 @@ function AskFlow({
     () =>
       vm.requestedByMe.filter(
         (request) =>
-          request.status === "pending" && request.extendsGrantId == null,
+          isLocationRequestPending(request, statusNowMs) &&
+          request.extendsGrantId == null,
       ),
-    [vm.requestedByMe],
+    [statusNowMs, vm.requestedByMe],
   );
 
   const recipientById = useMemo(() => {
@@ -5284,7 +5321,7 @@ function AskFlow({
   /**
    * Whether anything on screen is actually measured against the clock.
    *
-   * "Asked 6m ago" and "Sharing with you, 29 more min" go stale; "Ready for
+   * "Asked 6m ago" and "Sharing with you, 29 min left" go stale; "Ready for
    * private sharing" does not. A roster of people you have never asked and who
    * are not sharing has nothing that ages, and re-rendering it every 30 seconds
    * is CPU spent to redraw identical text -- battery, on a phone.
@@ -5316,13 +5353,17 @@ function AskFlow({
   const pendingExtensionByGrantId = useMemo(() => {
     const byGrantId = new globalThis.Map<string, OneLocationAccessRequest>();
     for (const request of vm.requestedByMe) {
-      if (request.status !== "pending" || !request.extendsGrantId) continue;
+      if (
+        !isLocationRequestPending(request, statusNowMs) ||
+        !request.extendsGrantId
+      )
+        continue;
       if (!byGrantId.has(request.extendsGrantId)) {
         byGrantId.set(request.extendsGrantId, request);
       }
     }
     return byGrantId;
-  }, [vm.requestedByMe]);
+  }, [statusNowMs, vm.requestedByMe]);
 
   const isRequestFormValid = vm.selectedRequestOwnerIds.length > 0;
   const sendingRequest = vm.busy === "request";
@@ -5379,7 +5420,7 @@ function AskFlow({
               allowUntilStop={false}
               // Not FULL: the two lanes shared one constant for a moment, and
               // trimming this screen to four cells must not take rungs off the
-              // owner's own "New time" editor, which has a card to itself.
+              // owner's own "Share for" editor, which has a card to itself.
               rungs={REQUEST_DURATION_LADDER}
             />
             <ReasonChips

--- a/hushh-webapp/components/ui/dialog.tsx
+++ b/hushh-webapp/components/ui/dialog.tsx
@@ -55,11 +55,14 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  srDescription = "Dialog content",
   overlayClassName,
   overlayStyle,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
+  /** Accessible context for dialogs whose explanatory copy is intentionally hidden. */
+  srDescription?: React.ReactNode
   overlayClassName?: string
   overlayStyle?: React.CSSProperties
 }) {
@@ -87,7 +90,7 @@ function DialogContent({
         {...props}
       >
         <DialogDescription className="sr-only">
-          Dialog content
+          {srDescription}
         </DialogDescription>
 
         {children}

--- a/hushh-webapp/lib/feed/use-feed-actionables.ts
+++ b/hushh-webapp/lib/feed/use-feed-actionables.ts
@@ -23,6 +23,7 @@ import {
   CacheService,
 } from "@/lib/services/cache-service";
 import { OneLocationStateResource } from "@/lib/one-location/one-location-state-resource";
+import { isLocationRequestPending } from "@/lib/one-location/request-expiry";
 import {
   locationApproveActionLabel,
   locationAskPromptLine,
@@ -177,9 +178,10 @@ function consentSummary(entry: ConsentCenterEntry): string {
 export function isIncomingLocationRequestActionable(
   request: OneLocationAccessRequest,
   userId: string,
+  nowMs = Date.now(),
 ): boolean {
   return (
-    request.status === "pending" &&
+    isLocationRequestPending(request, nowMs) &&
     request.ownerUserId === userId &&
     request.requesterUserId !== userId
   );

--- a/hushh-webapp/lib/one-location/__tests__/auto-approve-requests.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/auto-approve-requests.test.ts
@@ -29,6 +29,7 @@ function request(
     requesterUserId: "user_abdul",
     status: "pending",
     requestedAt: new Date(ENABLED_AT_MS + 60_000).toISOString(),
+    expiresAt: "2099-01-01T00:00:00.000Z",
     ...overrides,
   } as OneLocationAccessRequest;
 }
@@ -163,6 +164,16 @@ describe("requests that are no longer open", () => {
     ).toEqual([]);
     expect(
       select({ pendingRequests: [request({ requestedAt: "whenever" })] }),
+    ).toEqual([]);
+  });
+
+  it("does not schedule a request whose server deadline passed", () => {
+    expect(
+      select({
+        pendingRequests: [
+          request({ expiresAt: "2020-01-01T00:00:00.000Z" }),
+        ],
+      }),
     ).toEqual([]);
   });
 });

--- a/hushh-webapp/lib/one-location/__tests__/duration-copy.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/duration-copy.test.ts
@@ -4,6 +4,7 @@ import {
   describeLocationAsk,
   formatLocationDurationLabel,
   formatLocationRemaining,
+  formatLocationTimeLeft,
   locationApproveActionLabel,
   locationAskFacts,
   locationAskPromptLine,
@@ -74,6 +75,14 @@ describe("formatLocationRemaining", () => {
   });
 });
 
+describe("formatLocationTimeLeft", () => {
+  it("keeps baseline share time separate from extension wording", () => {
+    expect(formatLocationTimeLeft(NOW + 45 * 60_000, NOW)).toBe("45 min");
+    expect(formatLocationTimeLeft(NOW + 60 * 60_000, NOW)).toBe("1 hour");
+    expect(formatLocationTimeLeft(NOW + 90 * 60_000, NOW)).toBe("1h 30m");
+  });
+});
+
 describe("locationAskFacts", () => {
   it("treats a request against a live grant as an extension", () => {
     const facts = locationAskFacts(
@@ -88,7 +97,7 @@ describe("locationAskFacts", () => {
     expect(facts).toEqual({
       isExtension: true,
       amountLabel: "3 hours",
-      remainingLabel: "45 more min",
+      remainingLabel: "45 min",
     });
   });
 
@@ -120,7 +129,7 @@ describe("describeLocationAsk", () => {
       ),
     );
     expect(extension).toBe(
-      "is asking for 3 hours more of your live location. They have 45 more min left.",
+      "is asking for 3 hours more of your live location. They have 45 min left.",
     );
 
     const fresh = describeLocationAsk(
@@ -158,7 +167,7 @@ describe("locationAskPromptLine", () => {
         }),
         NOW,
       ),
-    ).toBe("Asks for 4 hours more · 45 more min left");
+    ).toBe("Asks for 4 hours more · 45 min left");
   });
 
   it("names the amount on a fresh ask too", () => {

--- a/hushh-webapp/lib/one-location/__tests__/request-expiry.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/request-expiry.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isLocationRequestExpired,
+  isLocationRequestPending,
+  locationRequestExpiryMs,
+} from "@/lib/one-location/request-expiry";
+import type { OneLocationAccessRequest } from "@/lib/one-location/types";
+
+const REQUESTED_AT = "2026-09-01T08:00:00.000Z";
+const REQUESTED_AT_MS = Date.parse(REQUESTED_AT);
+
+function request(
+  overrides: Partial<OneLocationAccessRequest> = {},
+): OneLocationAccessRequest {
+  return {
+    id: "request_1",
+    ownerUserId: "owner",
+    requesterUserId: "requester",
+    status: "pending",
+    requestedAt: REQUESTED_AT,
+    ...overrides,
+  };
+}
+
+describe("One Location request expiry", () => {
+  it("does not invent a deadline when an older API omitted one", () => {
+    const omitted = request();
+
+    expect(locationRequestExpiryMs(omitted)).toBeNull();
+    expect(
+      isLocationRequestPending(omitted, REQUESTED_AT_MS + 30 * 24 * 3_600_000),
+    ).toBe(true);
+  });
+
+  it("uses the server deadline when one is present", () => {
+    const serverDeadline = REQUESTED_AT_MS + 3_600_000;
+    const withDeadline = request({
+      expiresAt: new Date(serverDeadline).toISOString(),
+    });
+
+    expect(locationRequestExpiryMs(withDeadline)).toBe(serverDeadline);
+    expect(isLocationRequestExpired(withDeadline, serverDeadline)).toBe(true);
+  });
+
+  it("does not invent a deadline for null or malformed server values", () => {
+    const linked = request({ expiresAt: null });
+    const malformed = request({ expiresAt: "not-a-timestamp" });
+
+    expect(locationRequestExpiryMs(linked)).toBeNull();
+    expect(locationRequestExpiryMs(malformed)).toBeNull();
+    expect(
+      isLocationRequestPending(linked, REQUESTED_AT_MS + 30 * 24 * 3_600_000),
+    ).toBe(true);
+    expect(
+      isLocationRequestPending(
+        malformed,
+        REQUESTED_AT_MS + 30 * 24 * 3_600_000,
+      ),
+    ).toBe(true);
+  });
+
+  it("trusts an explicit terminal status even when no timestamp is available", () => {
+    expect(
+      isLocationRequestExpired(
+        request({ status: "expired", requestedAt: null, expiresAt: null }),
+        REQUESTED_AT_MS,
+      ),
+    ).toBe(true);
+  });
+});

--- a/hushh-webapp/lib/one-location/__tests__/use-unseen-location-share-count.test.tsx
+++ b/hushh-webapp/lib/one-location/__tests__/use-unseen-location-share-count.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseAuth, mockUseStaleResource, mockUseVault } = vi.hoisted(() => ({
+  mockUseAuth: vi.fn(),
+  mockUseStaleResource: vi.fn(),
+  mockUseVault: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({ useAuth: mockUseAuth }));
+vi.mock("@/lib/cache/use-stale-resource", () => ({
+  useStaleResource: mockUseStaleResource,
+}));
+vi.mock("@/lib/vault/vault-context", () => ({ useVault: mockUseVault }));
+
+import { useUnseenLocationShareCount } from "@/lib/one-location/use-unseen-location-share-count";
+
+const NOW = Date.parse("2026-09-01T08:00:00.000Z");
+
+describe("useUnseenLocationShareCount request deadlines", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    mockUseAuth.mockReturnValue({ user: { uid: "owner" } });
+    mockUseVault.mockReturnValue({
+      isVaultUnlocked: true,
+      getVaultOwnerToken: () => "vault-token",
+    });
+    mockUseStaleResource.mockImplementation(
+      ({ refreshKey }: { refreshKey: string }) => {
+        const tick = Number(refreshKey.split(":").at(-1));
+        return {
+          data:
+            tick === 0
+              ? {
+                  receivedGrantIds: [],
+                  pendingIncomingRequests: 1,
+                  nextPendingRequestExpiryAtMs: NOW + 1_000,
+                }
+              : {
+                  receivedGrantIds: [],
+                  pendingIncomingRequests: 0,
+                  nextPendingRequestExpiryAtMs: null,
+                },
+        };
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("re-evaluates the badge as soon as the nearest request expires", () => {
+    const { result } = renderHook(() => useUnseenLocationShareCount());
+    expect(result.current).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(result.current).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(0);
+    expect(mockUseStaleResource.mock.calls.at(-1)?.[0]?.refreshKey).toBe(
+      "owner:unlocked:1",
+    );
+  });
+});

--- a/hushh-webapp/lib/one-location/auto-approve-requests.ts
+++ b/hushh-webapp/lib/one-location/auto-approve-requests.ts
@@ -1,5 +1,6 @@
 import type { OneLocationAccessRequest } from "@/lib/one-location/types";
 import type { AutoApproveScope } from "@/lib/one-location/location-control-state";
+import { isLocationRequestPending } from "@/lib/one-location/request-expiry";
 
 /**
  * Which pending location requests this browser may schedule for server review.
@@ -44,8 +45,9 @@ export function selectAutoApprovableRequests(input: {
   // point: a missing timestamp must not read as "approve everything".
   if (!Number.isFinite(enabledAtMs)) return [];
 
+  const nowMs = Date.now();
   return pendingRequests.filter((request) => {
-    if (request.status !== "pending") return false;
+    if (!isLocationRequestPending(request, nowMs)) return false;
     if (alreadyAttemptedIds.has(request.id)) return false;
     // A standing people rule does not grant an open-ended duration. Requests
     // for ongoing access stay visible for an explicit owner decision.

--- a/hushh-webapp/lib/one-location/duration-copy.ts
+++ b/hushh-webapp/lib/one-location/duration-copy.ts
@@ -50,6 +50,26 @@ export function formatLocationRemaining(
   return hours === 1 ? "1 more hour" : `${hours} more hours`;
 }
 
+/**
+ * "45 min", "1h 30m", "3 hours" -- a neutral amount that callers can
+ * truthfully place before `left`. Unlike `formatLocationRemaining`, this must
+ * never imply an extension: a running first share has time left, not time
+ * "more" than some unstated baseline.
+ */
+export function formatLocationTimeLeft(
+  untilMs: number,
+  nowMs: number,
+): string | null {
+  const remainingMs = untilMs - nowMs;
+  if (!Number.isFinite(remainingMs) || remainingMs <= 0) return null;
+  const totalMinutes = Math.ceil(remainingMs / 60_000);
+  if (totalMinutes < 60) return `${totalMinutes} min`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (minutes) return `${hours}h ${minutes}m`;
+  return hours === 1 ? "1 hour" : `${hours} hours`;
+}
+
 /** Milliseconds for an ISO timestamp, or null when missing/unparseable. */
 export function locationTimestampMs(
   value: string | null | undefined,
@@ -64,7 +84,7 @@ export type LocationAskFacts = {
   isExtension: boolean;
   /** "3 hours", "as long as they need", or "" when no amount was named. */
   amountLabel: string;
-  /** "45 more min" left on the share being extended, when known. */
+  /** "45 min" left on the share being extended, when known. */
   remainingLabel: string;
 };
 
@@ -89,7 +109,7 @@ export function locationAskFacts(
     remainingLabel:
       expiresAtMs === null
         ? ""
-        : (formatLocationRemaining(expiresAtMs, nowMs) ?? ""),
+        : (formatLocationTimeLeft(expiresAtMs, nowMs) ?? ""),
   };
 }
 

--- a/hushh-webapp/lib/one-location/notification-reconciliation.ts
+++ b/hushh-webapp/lib/one-location/notification-reconciliation.ts
@@ -4,6 +4,7 @@ import type {
   OneLocationRecipient,
   OneLocationState,
 } from "@/lib/one-location/types";
+import { isLocationRequestPending } from "@/lib/one-location/request-expiry";
 import {
   buildOneLocationWorkflowHref,
   ONE_LOCATION_SMS_EMERGENCY_CATEGORY,
@@ -169,10 +170,11 @@ export function buildOneLocationNotificationPayloads(
     payloads.push(payload);
   }
 
+  const requestNowMs = Date.now();
   for (const request of state.requests ?? []) {
     if (
       request.ownerUserId === normalizedUserId &&
-      request.status === "pending"
+      isLocationRequestPending(request, requestNowMs)
     ) {
       const payload: OneLocationNotificationPayload = {
         type: "location_access_request",

--- a/hushh-webapp/lib/one-location/one-location-state-resource.ts
+++ b/hushh-webapp/lib/one-location/one-location-state-resource.ts
@@ -1,4 +1,7 @@
-import type { OneLocationState } from "@/lib/one-location/types";
+import type {
+  OneLocationGrant,
+  OneLocationState,
+} from "@/lib/one-location/types";
 import {
   CACHE_KEYS,
   CACHE_TTL,
@@ -53,6 +56,35 @@ export const OneLocationStateResource = {
       ...snapshot.data,
       smsContactUserIds,
     });
+    return true;
+  },
+
+  /**
+   * Publish an authoritative grant mutation without discarding identity fields
+   * added by the state projection.
+   *
+   * Duration endpoints can return only the mutable grant columns at runtime.
+   * Invalidating before the write also fences off a state load that began
+   * before the mutation, so it cannot later restore the old duration.
+   */
+  mergeOwnerGrant(
+    userId: string,
+    grant: Pick<OneLocationGrant, "id"> & Partial<OneLocationGrant>,
+    fallbackState?: OneLocationState,
+  ): boolean {
+    const current = this.peek(userId)?.data ?? fallbackState;
+    if (!current) return false;
+
+    let matched = false;
+    const ownerGrants = current.ownerGrants.map((row) => {
+      if (row.id !== grant.id) return row;
+      matched = true;
+      return { ...row, ...grant };
+    });
+    if (!matched) return false;
+
+    this.invalidate(userId);
+    this.write(userId, { ...current, ownerGrants });
     return true;
   },
 

--- a/hushh-webapp/lib/one-location/request-expiry.ts
+++ b/hushh-webapp/lib/one-location/request-expiry.ts
@@ -1,0 +1,42 @@
+import type { OneLocationAccessRequest } from "@/lib/one-location/types";
+
+function parsedTimestamp(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * The deadline the UI should present for this request.
+ *
+ * Only an explicit, valid server deadline is safe to enforce in the client.
+ * `null` deliberately leaves a linked referral/public-link workflow under its
+ * parent's lifetime. `undefined` or an invalid value is ambiguous during a
+ * rolling deploy, so the UI relies on the server status instead of inventing a
+ * deadline that could expire a linked request early.
+ */
+export function locationRequestExpiryMs(
+  request: Pick<OneLocationAccessRequest, "expiresAt">,
+): number | null {
+  return parsedTimestamp(request.expiresAt);
+}
+
+/** Presentation guard only; the server independently enforces this deadline. */
+export function isLocationRequestExpired(
+  request: Pick<OneLocationAccessRequest, "status" | "expiresAt">,
+  nowMs: number,
+): boolean {
+  if (request.status === "expired") return true;
+  if (request.status !== "pending") return false;
+  const expiresAt = locationRequestExpiryMs(request);
+  return expiresAt !== null && Number.isFinite(nowMs) && nowMs >= expiresAt;
+}
+
+export function isLocationRequestPending(
+  request: Pick<OneLocationAccessRequest, "status" | "expiresAt">,
+  nowMs: number,
+): boolean {
+  return (
+    request.status === "pending" && !isLocationRequestExpired(request, nowMs)
+  );
+}

--- a/hushh-webapp/lib/one-location/request-recipient-status.ts
+++ b/hushh-webapp/lib/one-location/request-recipient-status.ts
@@ -1,7 +1,12 @@
 import {
   formatLocationDurationLabel,
-  formatLocationRemaining,
+  formatLocationTimeLeft,
 } from "@/lib/one-location/duration-copy";
+import {
+  isLocationRequestExpired,
+  isLocationRequestPending,
+  locationRequestExpiryMs,
+} from "@/lib/one-location/request-expiry";
 import type {
   OneLocationAccessRequest,
   OneLocationGrant,
@@ -66,7 +71,7 @@ export function shortAgo(fromMs: number, nowMs: number): string {
 }
 
 /**
- * "55 more min", "1h 30m more", "3 more hours" -- how much access is left.
+ * "55 min", "1h 30m", "3 hours" -- how much access is left.
  *
  * Delegates to the shared formatter so this row, the countdown on the share
  * card, and the notification copy cannot drift apart. The old local rounding
@@ -74,7 +79,7 @@ export function shortAgo(fromMs: number, nowMs: number): string {
  * exact number people use to decide when to leave.
  */
 export function shortRemaining(untilMs: number, nowMs: number): string | null {
-  return formatLocationRemaining(untilMs, nowMs);
+  return formatLocationTimeLeft(untilMs, nowMs);
 }
 
 export function requestRecipientStatus(input: {
@@ -95,23 +100,36 @@ export function requestRecipientStatus(input: {
   const pending = requestedByMe
     .filter(
       (request) =>
-        request.ownerUserId === recipientUserId && request.status === "pending",
+        request.ownerUserId === recipientUserId &&
+        isLocationRequestPending(request, nowMs),
     )
     .sort(
       (left, right) =>
-        (timestamp(right.requestedAt) ?? 0) - (timestamp(left.requestedAt) ?? 0),
+        (timestamp(right.requestedAt) ?? 0) -
+        (timestamp(left.requestedAt) ?? 0),
     )[0];
 
   // Already sharing beats everything else. Asking somebody to share when they
   // already are is the clearest possible sign the list is not looking.
-  const activeGrant = receivedGrants.find(
-    (grant) =>
-      grant.ownerUserId === recipientUserId && grant.status === "active",
-  );
+  const activeGrant = receivedGrants.find((grant) => {
+    if (grant.ownerUserId !== recipientUserId || grant.status !== "active") {
+      return false;
+    }
+    // A timed grant is no longer live at its exact deadline, even when a
+    // cached API row has not yet been settled to `expired`. Only an explicit
+    // null is open-ended; a missing or malformed deadline is not enough to
+    // claim that somebody is still sharing their location.
+    if (grant.expiresAt === null) return true;
+    const expiresAt = timestamp(grant.expiresAt);
+    return expiresAt !== null && expiresAt > nowMs;
+  });
   if (activeGrant) {
     const expiresAt = timestamp(activeGrant.expiresAt);
-    const remaining = expiresAt === null ? null : shortRemaining(expiresAt, nowMs);
-    const live = remaining ? `Sharing with you, ${remaining}` : "Sharing with you now";
+    const remaining =
+      expiresAt === null ? null : shortRemaining(expiresAt, nowMs);
+    const live = remaining
+      ? `Sharing with you, ${remaining} left`
+      : "Sharing with you now";
     if (pending) {
       // Both facts at once, because both are true and each one alone misleads:
       // the share IS live, and more time HAS been asked for and not answered.
@@ -152,7 +170,9 @@ export function requestRecipientStatus(input: {
       pending.requestedDurationMode === "until_stopped"
         ? "no end time"
         : formatLocationDurationLabel(pending.requestedDurationHours);
-    const when = askedAt ? `Asked ${shortAgo(askedAt, nowMs)}` : "Asked already";
+    const when = askedAt
+      ? `Asked ${shortAgo(askedAt, nowMs)}`
+      : "Asked already";
     return {
       subtitle: askedFor
         ? `${when} for ${askedFor}, waiting on them`
@@ -167,22 +187,41 @@ export function requestRecipientStatus(input: {
     };
   }
 
-  // A refusal is not a permanent state, so this row stays askable. It is said
-  // plainly rather than hidden: asking again without knowing they declined is
-  // how somebody ends up nagging without meaning to.
-  const declined = requestedByMe
+  // Expiry, refusal, and withdrawal are all settled requests and therefore
+  // askable again. Choose the newest outcome so an old expiry can never hide a
+  // later decline (or vice versa).
+  const settled = requestedByMe
     .filter(
       (request) =>
         request.ownerUserId === recipientUserId &&
-        (request.status === "denied" || request.status === "cancelled"),
+        (request.status === "denied" ||
+          request.status === "cancelled" ||
+          isLocationRequestExpired(request, nowMs)),
     )
     .sort(
       (left, right) =>
-        (timestamp(right.resolvedAt) ?? 0) - (timestamp(left.resolvedAt) ?? 0),
+        (timestamp(right.resolvedAt) ??
+          locationRequestExpiryMs(right) ??
+          timestamp(right.requestedAt) ??
+          0) -
+        (timestamp(left.resolvedAt) ??
+          locationRequestExpiryMs(left) ??
+          timestamp(left.requestedAt) ??
+          0),
     )[0];
-  if (declined) {
-    const resolvedAt = timestamp(declined.resolvedAt);
-    const wasDenied = declined.status === "denied";
+  if (settled) {
+    if (isLocationRequestExpired(settled, nowMs)) {
+      return {
+        subtitle: "Request expired · Ask again",
+        tone: "neutral",
+        statusLabel: "Expired",
+        selectable: true,
+      };
+    }
+    // A refusal is not a permanent state. Say it plainly so asking again is a
+    // conscious choice instead of accidental nagging.
+    const resolvedAt = timestamp(settled.resolvedAt);
+    const wasDenied = settled.status === "denied";
     return {
       subtitle: resolvedAt
         ? `${wasDenied ? "Declined" : "Cancelled"} ${shortAgo(resolvedAt, nowMs)}`

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -223,9 +223,22 @@ export type OneLocationAccessRequest = {
   ownerPhotoUrl?: string | null;
   ownerMaskedPhone?: string | null;
   referredByUserId?: string | null;
-  status: "pending" | "approved" | "denied" | "cancelled" | string;
+  status:
+    | "pending"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | "expired"
+    | string;
   message?: string | null;
   requestedAt?: string | null;
+  /**
+   * Server-owned deadline for a direct location ask. `null` is deliberate for
+   * linked referral/public-link workflows, whose parent record owns its own
+   * lifetime. `undefined` is kept for rolling-deploy compatibility with older
+   * API payloads.
+   */
+  expiresAt?: string | null;
   resolvedAt?: string | null;
   approvedGrantId?: string | null;
   /**

--- a/hushh-webapp/lib/one-location/use-unseen-location-share-count.ts
+++ b/hushh-webapp/lib/one-location/use-unseen-location-share-count.ts
@@ -8,6 +8,10 @@ import { useStaleResource } from "@/lib/cache/use-stale-resource";
 import { CONSENT_STATE_CHANGED_EVENT } from "@/lib/consent/consent-events";
 import { OneLocationService } from "@/lib/one-location/service";
 import {
+  isLocationRequestPending,
+  locationRequestExpiryMs,
+} from "@/lib/one-location/request-expiry";
+import {
   isOneLocationGrantOpened,
   ONE_LOCATION_GRANT_OPENED_EVENT,
   ONE_LOCATION_GRANT_UNWATCHED_EVENT,
@@ -19,7 +23,11 @@ type LocationNotificationState = {
   receivedGrantIds: string[];
   /** Pending access requests where someone is asking to see MY location. */
   pendingIncomingRequests: number;
+  /** Nearest explicit deadline, used to retire the badge without polling. */
+  nextPendingRequestExpiryAtMs: number | null;
 };
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 /**
  * App-wide count of location notifications needing your attention, powering the
@@ -60,13 +68,43 @@ export function useUnseenLocationShareCount(): number {
       const receivedGrantIds = (state.receivedGrants ?? [])
         .filter((grant) => grant.status === "active")
         .map((grant) => grant.id);
-      const pendingIncomingRequests = (state.requests ?? []).filter(
+      const requestNowMs = Date.now();
+      const pendingIncoming = (state.requests ?? []).filter(
         (request) =>
-          request.ownerUserId === uid && request.status === "pending",
-      ).length;
-      return { receivedGrantIds, pendingIncomingRequests };
+          request.ownerUserId === uid &&
+          isLocationRequestPending(request, requestNowMs),
+      );
+      const nextPendingRequestExpiryAtMs = pendingIncoming.reduce<
+        number | null
+      >((nearest, request) => {
+        const expiresAt = locationRequestExpiryMs(request);
+        if (expiresAt === null || expiresAt <= requestNowMs) return nearest;
+        return nearest === null ? expiresAt : Math.min(nearest, expiresAt);
+      }, null);
+      return {
+        receivedGrantIds,
+        pendingIncomingRequests: pendingIncoming.length,
+        nextPendingRequestExpiryAtMs,
+      };
     },
   });
+
+  const nextPendingRequestExpiryAtMs =
+    resource.data?.nextPendingRequestExpiryAtMs ?? null;
+  useEffect(() => {
+    if (nextPendingRequestExpiryAtMs === null) return;
+    // One millisecond beyond the inclusive deadline avoids a timer callback
+    // racing the same exact clock value that still produced the cached count.
+    const delay = Math.min(
+      MAX_TIMER_DELAY_MS,
+      Math.max(0, nextPendingRequestExpiryAtMs - Date.now() + 1),
+    );
+    const timeoutId = window.setTimeout(
+      () => setTick((value) => value + 1),
+      delay,
+    );
+    return () => window.clearTimeout(timeoutId);
+  }, [nextPendingRequestExpiryAtMs]);
 
   useEffect(() => {
     const bump = () => setTick((value) => value + 1);


### PR DESCRIPTION
# Description

Expire direct One Location asks after 24 hours, preserve parent-owned referral/public-link lifetimes, and let requesters ask again from a clear expired state. The same change removes misleading baseline `more` copy, makes Change time a focused blurred modal without repeated labels, restores trigger focus, and reconciles duration changes immediately without stale-cache rollback.

## Impact Map (Required)

- Routes touched:
  - [x] Listed below: reachable `/one/location` UI; existing One Location backend request/state/action paths through `OneLocationAgentService` (no new route file).
- API / schema / type changes:
  - [x] Listed below: migration 191 adds nullable `expires_at` and terminal `expired`; state payload/type gains `expiresAt`; direct asks default to a 24-hour server deadline.
- Cache keys touched:
  - [x] Listed below: no new key; existing `ONE_LOCATION_STATE` writes are revision-fenced and duration PATCH results merge into the cached owner grant.
- Runtime DB data-plane changes:
  - [x] Listed below: migration + rollback, manifest, and dev/UAT/prod schema contract head 191.
- World-model domain summary effects:
  - [x] None.
- Mobile parity impacts:
  - [x] Listed below: shared Next.js UI used by Capacitor changes; no native plugin API change. Static and native plugin parity checks pass.
- Docs updated (exact files):
  - [x] None; behavior is covered by product tests, migration comments, and this PR contract.
- Top-level / devex / config / generated / ignore files touched:
  - [x] Listed below: existing release migration manifest and schema-contract JSON files only.
- Trust boundary touched:
  - [x] Auth / consent / schema listed below: server wall-clock enforcement prevents approving/denying/withdrawing expired direct asks; referral/public-link wrappers remain parent-owned; rollback cancels timed rows before removing expiry representation.
- Caller / proxy / backend pairing:
  - [x] Listed below with contract proof: existing `OneLocationService` callers consume the enriched backend state/patch payload; no proxy contract changed. Backend and frontend contract tests cover both sides.
- Rollback or safe-failure behavior:
  - [x] Listed below: rollback maps expired and pending timed rows to cancelled, retains linked NULL-lifetime requests, restores the previous status constraint, and drops the expiry column/index safely.
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: Chromium + WebKit layout specs for the duration ladder and live-share card (43/43), plus rendered shipping Dialog/selector/status components verified for blur, focus trap, Escape, focus restoration, expired CTA, and corrected copy.
- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr` (Windows wrapper is not portable; its DCO, secret, governance, web, protocol, package, and integration stages were run directly. GitHub Linux remains authoritative.)
  - [x] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test` (Node 24 full run: 5,854 passed, 1 unrelated full-suite load timeout; that contact-sync file passed 8/8 alone. All 227 affected frontend tests pass.)
  - [x] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit` (no native implementation changed)
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000` (Kai not touched)

## Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: related issue #6256 overlaps copy context but does not implement durable request expiry.
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `/one/location` -> People / Ask for location / live-share Change time; backend `OneLocationAgentService` request/state/action methods.
- [x] New tests import and exercise production code, not only mock components/helpers defined inside the test file.
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [x] Production surface proved: page/component tests, backend service tests, migration authority tests, rendered browser proof, and production Next.js build.
- [ ] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main` (pending GitHub run).
- [x] Maintainer edits are enabled.
- [x] If this is one PR in a stack, the predecessor PR is linked here: not a stack.
- [x] If this responds to requested changes, the new commit or material explanation is described here: initial implementation on this branch.

## Tri-Flow Architecture Check

- [x] **Web**: shared Next.js UI and TypeScript contract updated.
- [x] **iOS**: no Swift plugin contract change; shared web surface is used and parity verification passes.
- [x] **Android**: no Kotlin plugin contract change; shared web surface is used and parity verification passes.

## Testing

- [x] Tested on Web (Chromium/WebKit layout engines).
- [ ] Tested on iOS Simulator/Device (shared web-only change; WebKit layout contract used).
- [ ] Tested on Android Emulator/Device (shared web-only change; Chromium layout contract used).
- [x] Commits are signed off (`git commit -s`).
- [x] Generated schema contract files were updated through the repository's migration-head contract.

Focused evidence: backend expiry/migration 228/228; affected frontend 227/227; take-back contract 9/9; TypeScript; full/targeted ESLint; design-system checks; production build; Chromium/WebKit layout 43/43; integration PKM gate 132/132 across frontend/backend; independent blocker review found no high-severity findings.

## Screenshots / Video

UI-visible behavior was rendered in a local component harness using the shipping Dialog, duration selector, and recipient-status resolver. It verified a soft blurred overlay, non-repeated `Change time` / `Share for` copy, focus trap and restoration, `Request expired · Ask again`, and `Sharing with you, 2h 1m left · asked for 30 min more`. The temporary harness and artifacts were removed; automated browser layout proof is retained in the two Playwright specs listed above.

## Privacy & Consent

- [x] Does this change access user data? It changes lifecycle metadata for existing location-access requests, not coordinates or grant scope.
- [x] If yes, have you implemented `checkConsentToken()`? No new ingress is added; existing vault-owner/consent authorization remains the only caller path.
- [x] Sensitive surface touched: consent and schema.
- [x] Error path, rollback, or safe-failure behavior proved: strict 410 at deadline, rolling-deploy repair/projection, linked-request exclusions, seven-day expired tombstone, and consent-safe rollback tests.

## Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] Third-party notice impact reviewed; no dependency changes.