### PR TITLE
fix(deploy): classify depleted Live credits as advisory

### DIFF
--- a/consent-protocol/hushh_mcp/runtime_providers/dependency_health.py
+++ b/consent-protocol/hushh_mcp/runtime_providers/dependency_health.py
@@ -52,6 +52,7 @@ _ACCOUNT_ENFORCEMENT_MARKERS = (
     "billing account",
     "billing is not enabled",
     "billing has not been enabled",
+    "prepayment credits are depleted",
     "account is suspended",
     "consumer has been suspended",
     "quota exceeded",

--- a/consent-protocol/tests/test_dependency_health_classifier.py
+++ b/consent-protocol/tests/test_dependency_health_classifier.py
@@ -52,6 +52,19 @@ def test_dunning_403_is_advisory_so_a_release_may_continue() -> None:
     assert is_advisory(classify_provider_error(_ProviderError(DUNNING_403, 403))) is True
 
 
+def test_depleted_developer_api_prepayment_is_a_provider_availability_failure() -> None:
+    error = _ProviderError(
+        "1011 None. Your prepayment credits are depleted. "
+        "Please go to AI Studio to manage your project and billing",
+        None,
+    )
+
+    classification = classify_provider_error(error)
+
+    assert classification == PROVIDER_UNAVAILABLE
+    assert is_advisory(classification) is True
+
+
 def test_permission_denial_on_a_resource_still_blocks() -> None:
     """A wrong service account is ours to fix, and must keep blocking."""
     error = _ProviderError(


### PR DESCRIPTION
## Summary
- recognize the Gemini Developer API prepayment-depletion response as account-level provider availability enforcement
- keep managed Vertex text and ADK candidate probes blocking and unchanged
- allow a healthy UAT release to proceed with Voice explicitly degraded when the separate Developer API credit pool is unavailable

## Runtime evidence
The UAT candidate exercised `gemini-3.1-flash-lite` and `gemini-3.7-flash` successfully through Vertex across global, US, and EU under the UAT runtime service account. The only failure was `gemini-3.1-flash-live-preview`, whose declared transport is the Developer API and whose bridge key reported depleted prepayment credits.

## Verification
- 52 focused classifier/readiness/deploy tests passed
- `git diff --check`

Signed-off-by: Kushal Trivedi <kushaltrivedi1711@gmail.com>