### PR TITLE
fix(uat): route One Live through Vertex fallback

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -563,6 +563,10 @@ jobs:
           # still target hushh-pda-uat via $PROJECT_ID. To revert, delete this
           # line (genai_project_id then falls back to $PROJECT_ID).
           SUBSTITUTIONS="${SUBSTITUTIONS}##_GENAI_PROJECT_ID=hushh-gemini-bridge"
+          # The canonical 3.1 Live preview uses a separate prepaid Developer
+          # API pool. UAT must remain functional when that pool is depleted, so
+          # pin the already-rehearsed GA Vertex rollback until credits recover.
+          SUBSTITUTIONS="${SUBSTITUTIONS}##_AGENT_ONE_ADK_MODEL=gemini-live-2.5-flash-native-audio"
           # Durable Kai analyze-run store ON in UAT: exercises the migration-125
           # persist/replay path against real Cloud SQL before prod flips it on.
           SUBSTITUTIONS="${SUBSTITUTIONS}##_KAI_ANALYZE_DURABLE_RUN_STORE=true"

--- a/consent-protocol/scripts/verify_managed_vertex_runtime.py
+++ b/consent-protocol/scripts/verify_managed_vertex_runtime.py
@@ -74,6 +74,11 @@ def _managed_manifest_models() -> tuple[tuple[str, ...], str]:
 async def main() -> dict[str, object]:
     binding = ManagedGeminiRuntimeBinding.from_environment()
     models, live_model = _managed_manifest_models()
+    # Match the candidate service exactly when an environment activates the
+    # authored rollback lever. Otherwise a UAT revision could run the Vertex
+    # fallback while this gate continued probing the unavailable canonical
+    # Developer API model.
+    live_model = (os.getenv("AGENT_ONE_ADK_MODEL") or live_model).strip()
     live_location = (os.getenv("AGENT_ONE_ADK_LOCATION") or "us-central1").strip()
     # The live model's endpoint follows its declared transport, mirroring
     # agent_tree._build_one_live_model: vertex-transport live models probe the

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -174,6 +174,21 @@ def test_cross_project_vertex_fallback_is_dev_or_exact_uat_bridge_only() -> None
     assert '_GENAI_PROJECT_ID: ""' in backend_build
 
 
+def test_uat_uses_the_rehearsed_vertex_live_fallback_when_developer_credits_are_depleted() -> None:
+    backend_build = _read("deploy/backend.cloudbuild.yaml")
+    uat_workflow = _read(".github/workflows/deploy-uat.yml")
+    production_workflow = _read(".github/workflows/deploy-production.yml")
+    readiness_probe = _read("consent-protocol/scripts/verify_managed_vertex_runtime.py")
+
+    fallback = "gemini-live-2.5-flash-native-audio"
+    assert f"##_AGENT_ONE_ADK_MODEL={fallback}" in uat_workflow
+    assert "_AGENT_ONE_ADK_MODEL" not in production_workflow
+    assert 'add_env "AGENT_ONE_ADK_MODEL" "${_AGENT_ONE_ADK_MODEL}"' in backend_build
+    assert "AGENT_ONE_ADK_MODEL=${_AGENT_ONE_ADK_MODEL}" in backend_build
+    assert '_AGENT_ONE_ADK_MODEL: ""' in backend_build
+    assert 'os.getenv("AGENT_ONE_ADK_MODEL") or live_model' in readiness_probe
+
+
 def test_production_deploy_builds_candidates_without_serving_traffic() -> None:
     production_workflow = _read(".github/workflows/deploy-production.yml")
 

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -299,6 +299,7 @@ steps:
         add_env "ONE_WALLET_CARD_ENABLED" "${_ONE_WALLET_CARD_ENABLED}"
         add_env "WALLET_PASS_PROVIDER" "${_WALLET_PASS_PROVIDER}"
         add_env "APP_REVIEW_MODE" "${_APP_REVIEW_MODE}"
+        add_env "AGENT_ONE_ADK_MODEL" "${_AGENT_ONE_ADK_MODEL}"
         add_env "HUSHH_PROD_PHONE_TEST_ENABLED" "${_HUSHH_PROD_PHONE_TEST_ENABLED}"
         add_env "KAI_ANALYZE_DURABLE_RUN_STORE" "${_KAI_ANALYZE_DURABLE_RUN_STORE}"
         add_env "CONSENT_WEB_FALLBACK_ENABLED" "${_CONSENT_WEB_FALLBACK_ENABLED}"
@@ -386,7 +387,7 @@ steps:
           --service-account="${_RUNTIME_SERVICE_ACCOUNT}" \
           --command="python3" \
           --args="scripts/verify_managed_vertex_runtime.py" \
-          --set-env-vars="^|^HUSHH_GENAI_AUTH_MODE=vertex_adc|GOOGLE_GENAI_USE_VERTEXAI=true|GOOGLE_CLOUD_PROJECT=${genai_project_id}|GOOGLE_CLOUD_LOCATION=global|HUSHH_VERTEX_LOCATIONS=global,us,eu|AGENT_ONE_ADK_LOCATION=us-central1" \
+          --set-env-vars="^|^HUSHH_GENAI_AUTH_MODE=vertex_adc|GOOGLE_GENAI_USE_VERTEXAI=true|GOOGLE_CLOUD_PROJECT=${genai_project_id}|GOOGLE_CLOUD_LOCATION=global|HUSHH_VERTEX_LOCATIONS=global,us,eu|AGENT_ONE_ADK_LOCATION=us-central1|AGENT_ONE_ADK_MODEL=${_AGENT_ONE_ADK_MODEL}" \
           ${live_key_secret_flag} \
           --max-retries=0 \
           --task-timeout=90s \
@@ -507,6 +508,7 @@ substitutions:
   # Defaulted to the canonical secret name so every lane picks it up without
   # workflow changes; add_secret skips gracefully where the secret is absent.
   _HUSHH_MANAGED_GEMINI_LIVE_API_KEY_SECRET: HUSHH_MANAGED_GEMINI_LIVE_API_KEY
+  _AGENT_ONE_ADK_MODEL: ""
   _FINNHUB_API_KEY_SECRET: ""
   _PMP_API_KEY_SECRET: ""
   _NEWSAPI_KEY_SECRET: ""

--- a/docs/reference/one/gemini-runtime-configuration.md
+++ b/docs/reference/one/gemini-runtime-configuration.md
@@ -62,6 +62,11 @@ not published on Vertex, and `gemini-live-2.5-flash-native-audio` (GA, Vertex)
 remains the declared rollback via `AGENT_ONE_ADK_MODEL`. No standalone TTS
 fallback is configured.
 
+UAT currently activates that rehearsed Vertex rollback in the governed deploy
+workflow. This keeps Agent Bar voice available when the separate Gemini
+Developer API prepaid-credit pool is depleted; production retains the authored
+canonical model unless its own release workflow explicitly selects a rollback.
+
 Gemini 3.7 text requests use the global Vertex endpoint and omit legacy
 sampling controls. The runtime retains `thinking_level` for bounded reasoning;
 it does not send `temperature`, `top_p`, `top_k`, `candidate_count`, or


### PR DESCRIPTION
## Summary
- pin UAT Agent Bar voice to the rehearsed `gemini-live-2.5-flash-native-audio` Vertex fallback while the separate Developer API prepaid pool is depleted
- plumb the model override into the candidate Cloud Run service and managed-runtime verifier
- make the pre-traffic verifier exercise the same exact Live model the candidate will run
- leave production unchanged

## Incident evidence
The governed UAT candidate passed every managed Vertex text/ADK probe. Its only failing probe was `gemini-3.1-flash-live-preview` on the Gemini Developer API, which returned `Your prepayment credits are depleted`. The selected fallback is already declared and rehearsed in `GEMINI_LIVE_COMPATIBILITY` with Vertex transport.

## Verification
- 60 focused deploy/readiness/classifier tests passed
- 296/297 One runtime tests passed; the one failure (`TestOpenScreen.test_normalizes_screen_names`) reproduces on current `main` because the test assumes CRM is enabled locally and is unrelated to these files
- voice gateway generation/check passed
- 29 focused frontend voice tests passed
- frontend typecheck passed
- docs verification passed
- YAML parse and `git diff --check` passed
