### PR TITLE
fix(connect): improve person profile UI layout

### DIFF
--- a/hushh-webapp/__tests__/components/person-profile-page.test.tsx
+++ b/hushh-webapp/__tests__/components/person-profile-page.test.tsx
@@ -9,6 +9,9 @@ const mocks = vi.hoisted(() => ({
   pathname: "/people/actual-public-ref",
   native: true,
   platform: "ios",
+  user: null as { uid: string; getIdToken: () => Promise<string> } | null,
+  authLoading: false,
+  isVaultUnlocked: true,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -24,14 +27,14 @@ vi.mock("@capacitor/core", () => ({
 }));
 
 vi.mock("@/hooks/use-auth", () => ({
-  useAuth: () => ({ user: null, loading: false }),
+  useAuth: () => ({ user: mocks.user, loading: mocks.authLoading }),
 }));
 
 vi.mock("@/lib/vault/vault-context", () => ({
   useVault: () => ({
     vaultKey: null,
     vaultOwnerToken: null,
-    isVaultUnlocked: true,
+    isVaultUnlocked: mocks.isVaultUnlocked,
   }),
 }));
 
@@ -101,7 +104,13 @@ vi.mock("@/components/ui/textarea", () => ({
 vi.mock("@/lib/morphy-ux/ui/surface-primitives", () => ({
   AvatarBubble: () => <span data-testid="avatar" />,
   SectionCard: ({ children }: { children: ReactNode }) => <section>{children}</section>,
-  StatusPill: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  StatusPill: ({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) => <span className={className}>{children}</span>,
 }));
 
 vi.mock("@/lib/agent/local-onboarding-actions", () => ({
@@ -121,6 +130,42 @@ vi.mock("sonner", () => ({
 
 import { PersonProfilePage } from "@/components/connections/person-profile-page";
 
+function viewerProfile(overrides = {}) {
+  return {
+    personRef: "actual-public-ref",
+    displayName: "Actual Person",
+    photoUrl: "https://cdn.example.test/person.jpg",
+    verifiedRole: null,
+    relationship: {
+      status: "connected",
+      connectionId: "connection-1",
+      connectedAt: null,
+      requestId: null,
+    },
+    requestableScopes: [
+      {
+        scopeRef: "scope-short",
+        label: "Risk profile",
+        description: null,
+        domain: "Financial",
+        sensitivity: "standard",
+        wildcard: false,
+      },
+      {
+        scopeRef: "scope-wrapped",
+        label: "Profile preferences investment horizon selected at",
+        description: null,
+        domain: "Financial",
+        sensitivity: "standard",
+        wildcard: false,
+      },
+    ],
+    grants: [],
+    requestHistory: [],
+    ...overrides,
+  };
+}
+
 describe("PersonProfilePage native profile route", () => {
   beforeEach(() => {
     mocks.getPublic.mockResolvedValue({
@@ -133,6 +178,9 @@ describe("PersonProfilePage native profile route", () => {
     mocks.pathname = "/people/actual-public-ref";
     mocks.native = true;
     mocks.platform = "ios";
+    mocks.user = null;
+    mocks.authLoading = false;
+    mocks.isVaultUnlocked = true;
   });
 
   afterEach(() => {
@@ -172,5 +220,130 @@ describe("PersonProfilePage native profile route", () => {
     await waitFor(() => {
       expect(mocks.getPublic).toHaveBeenCalledWith("server-public-ref");
     });
+  });
+
+  it("uses the shared connection avatar with the verified advisor badge for RIA profiles", async () => {
+    render(
+      <PersonProfilePage
+        personRef="actual-public-ref"
+        initialProfile={{
+          personRef: "actual-public-ref",
+          displayName: "Divya Rajendran",
+          photoUrl: "https://cdn.example.test/divya.jpg",
+          verifiedRole: "Registered investment adviser",
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Divya Rajendran" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Verified advisor")).toBeInTheDocument();
+    expect(document.querySelector('[data-avatar-size="profile"]')).not.toBeNull();
+    expect(
+      document.querySelector('[data-photo-url="https://cdn.example.test/divya.jpg"]'),
+    ).not.toBeNull();
+  });
+
+  it("does not show a verified advisor badge for non-RIA profiles", async () => {
+    render(
+      <PersonProfilePage
+        personRef="actual-public-ref"
+        initialProfile={{
+          personRef: "actual-public-ref",
+          displayName: "Plain Person",
+          photoUrl: null,
+          verifiedRole: null,
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Plain Person" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Verified advisor")).not.toBeInTheDocument();
+  });
+
+  it("keeps the share profile icon and label separated inside the existing action", async () => {
+    render(
+      <PersonProfilePage
+        personRef="actual-public-ref"
+        initialProfile={{
+          personRef: "actual-public-ref",
+          displayName: "Actual Person",
+          photoUrl: null,
+          verifiedRole: null,
+        }}
+      />,
+    );
+
+    const shareButton = await screen.findByRole("button", {
+      name: "Share profile",
+    });
+    expect(shareButton.querySelector(".inline-flex.items-center.gap-2")).not.toBeNull();
+  });
+
+  it("aligns requestable scope pills in a stable trailing column", async () => {
+    mocks.user = {
+      uid: "viewer",
+      getIdToken: vi.fn().mockResolvedValue("viewer-token"),
+    };
+    mocks.getViewer.mockResolvedValue(viewerProfile());
+
+    render(
+      <PersonProfilePage
+        personRef="actual-public-ref"
+        initialProfile={{
+          personRef: "actual-public-ref",
+          displayName: "Actual Person",
+          photoUrl: null,
+          verifiedRole: null,
+        }}
+      />,
+    );
+
+    await screen.findByRole("heading", { name: "Available to request" });
+    const scopeRows = document.querySelectorAll('button[aria-pressed="false"]');
+    expect(scopeRows).toHaveLength(2);
+    for (const row of scopeRows) {
+      expect(row).toHaveClass("grid");
+      expect(row).toHaveClass("items-center");
+      expect(row).toHaveClass("grid-cols-[minmax(0,1fr)_auto]");
+      expect(row).not.toHaveClass("items-start");
+      expect(row.querySelector(".justify-self-end")).not.toBeNull();
+    }
+  });
+
+  it("renders Review request after Financial rows without sticky viewport positioning", async () => {
+    mocks.user = {
+      uid: "viewer",
+      getIdToken: vi.fn().mockResolvedValue("viewer-token"),
+    };
+    mocks.getViewer.mockResolvedValue(viewerProfile());
+
+    render(
+      <PersonProfilePage
+        personRef="actual-public-ref"
+        initialProfile={{
+          personRef: "actual-public-ref",
+          displayName: "Actual Person",
+          photoUrl: null,
+          verifiedRole: null,
+        }}
+      />,
+    );
+
+    const reviewButton = await screen.findByRole("button", {
+      name: "Review request",
+    });
+    const historyHeading = screen.getByRole("heading", { name: "Request history" });
+    expect(reviewButton.parentElement).toHaveClass("flex");
+    expect(reviewButton.parentElement).toHaveClass("justify-end");
+    expect(reviewButton.parentElement).not.toHaveClass("sticky");
+    expect(reviewButton.parentElement).not.toHaveClass("bottom-4");
+    expect(
+      reviewButton.compareDocumentPosition(historyHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/hushh-webapp/components/connections/connection-person-avatar.tsx
+++ b/hushh-webapp/components/connections/connection-person-avatar.tsx
@@ -37,24 +37,33 @@ export function connectionAvatarInitials(label: string): string {
  *
  * Reported as "circle and Connections dono ka thoda alag alag feel ho rha hai".
  */
-export type ConnectionPersonAvatarSize = "compact" | "comfortable";
+export type ConnectionPersonAvatarSize = "compact" | "comfortable" | "profile";
 
 const AVATAR_SIZE_CLASSNAME: Record<ConnectionPersonAvatarSize, string> = {
   compact: "h-7 w-7",
   comfortable: "h-[34px] w-[34px]",
+  profile: "h-16 w-16",
 };
 
 /** The verified badge scales with the face, or it swallows a 28px one. */
 const AVATAR_BADGE_CLASSNAME: Record<ConnectionPersonAvatarSize, string> = {
   compact: "size-[13px]",
   comfortable: "size-[15px]",
+  profile: "size-[19px]",
 };
 
 const AVATAR_BADGE_GLYPH_CLASSNAME: Record<ConnectionPersonAvatarSize, string> =
   {
     compact: "size-[11px]",
     comfortable: "size-[13px]",
+    profile: "size-[17px]",
   };
+
+const AVATAR_FALLBACK_CLASSNAME: Record<ConnectionPersonAvatarSize, string> = {
+  compact: "text-xs",
+  comfortable: "text-xs",
+  profile: "text-3xl",
+};
 
 export function ConnectionPersonAvatar({
   photoUrl,
@@ -84,7 +93,7 @@ export function ConnectionPersonAvatar({
       data-avatar-size={size}
     >
       {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
-      <AvatarFallback className="text-xs">
+      <AvatarFallback className={AVATAR_FALLBACK_CLASSNAME[size]}>
         {connectionAvatarInitials(label)}
       </AvatarFallback>
       {verified ? (

--- a/hushh-webapp/components/connections/person-profile-page.tsx
+++ b/hushh-webapp/components/connections/person-profile-page.tsx
@@ -23,10 +23,10 @@ import {
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import {
-  AvatarBubble,
   SectionCard,
   StatusPill,
 } from "@/lib/morphy-ux/ui/surface-primitives";
+import { ConnectionPersonAvatar } from "@/components/connections/connection-person-avatar";
 import {
   PersonProfileService,
   type PublicPersonProfile,
@@ -43,12 +43,6 @@ type Props = { personRef: string; initialProfile: PublicPersonProfile | null };
 
 function scopeTitle(scope: ViewerPersonProfile["requestableScopes"][number]) {
   return scope.label || scope.domain || "Information";
-}
-
-function initials(name: string): string {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  return (parts.length > 1 ? `${parts[0]?.[0]}${parts.at(-1)?.[0]}` : parts[0]?.slice(0, 2))
-    ?.toUpperCase() || "H";
 }
 
 export function PersonProfilePage({ personRef, initialProfile }: Props) {
@@ -421,10 +415,11 @@ export function PersonProfilePage({ personRef, initialProfile }: Props) {
       <div className="space-y-6 pb-12" data-native-route="native-route-person-profile">
         <section className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 items-center gap-4">
-            <AvatarBubble
-              initials={initials(profile.displayName)}
-              size={64}
-              imageUrl={profile.photoUrl}
+            <ConnectionPersonAvatar
+              photoUrl={profile.photoUrl}
+              label={profile.displayName}
+              verified={Boolean(profile.verifiedRole)}
+              size="profile"
             />
             <div className="min-w-0">
               <h1 className="truncate text-3xl font-semibold tracking-tight">
@@ -458,8 +453,10 @@ export function PersonProfilePage({ personRef, initialProfile }: Props) {
               toast.success("Profile link copied");
             }}
           >
-            <Copy className="h-4 w-4" />
-            Share profile
+            <span className="inline-flex items-center gap-2">
+              <Copy className="h-4 w-4" />
+              <span>Share profile</span>
+            </span>
           </Button>
         </section>
 
@@ -609,7 +606,7 @@ export function PersonProfilePage({ personRef, initialProfile }: Props) {
                           <button
                             type="button"
                             key={scope.scopeRef}
-                            className="flex w-full items-start justify-between gap-4 rounded-xl py-3 text-left outline-none transition-colors first:pt-0 last:pb-0 focus-visible:ring-2 focus-visible:ring-[var(--app-accent)]"
+                            className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-4 rounded-xl py-3 text-left outline-none transition-colors first:pt-0 last:pb-0 focus-visible:ring-2 focus-visible:ring-[var(--app-accent)]"
                             aria-pressed={selectedScopeRefs.has(scope.scopeRef)}
                             onClick={() => setSelectedScopeRefs((current) => {
                               const next = new Set(current);
@@ -618,13 +615,16 @@ export function PersonProfilePage({ personRef, initialProfile }: Props) {
                               return next;
                             })}
                           >
-                            <div>
+                            <div className="min-w-0">
                               <p className="text-sm font-semibold">{scopeTitle(scope)}</p>
                               {scope.description ? (
                                 <p className="mt-1 text-sm text-muted-foreground">{scope.description}</p>
                               ) : null}
                             </div>
-                            <StatusPill tone={selectedScopeRefs.has(scope.scopeRef) ? "ready" : "neutral"}>
+                            <StatusPill
+                              tone={selectedScopeRefs.has(scope.scopeRef) ? "ready" : "neutral"}
+                              className="shrink-0 justify-self-end"
+                            >
                               {selectedScopeRefs.has(scope.scopeRef) ? "Selected" : "Ask first"}
                             </StatusPill>
                           </button>
@@ -641,7 +641,7 @@ export function PersonProfilePage({ personRef, initialProfile }: Props) {
                 </SectionCard>
               )}
               {groupedScopes.length ? (
-                <div className="sticky bottom-4 flex justify-end">
+                <div className="flex justify-end pt-1">
                   <Button
                     type="button"
                     variant="blue-gradient"


### PR DESCRIPTION
## Summary

- Polish the Connect → Profile page layout and spacing.
- Align the "Ask first" controls consistently across profile fields.
- Keep the "Review request" action in the correct position after the Financial content and before Request history.
- Add/update regression coverage for the Profile UI behavior.

## Verification

- `npm run test -- __tests__/components/person-profile-page.test.tsx` — passed
- `npm run verify:connect-search` — passed
- `npm run typecheck` — passed
- targeted ESLint for affected Profile files — passed
- `npm run lint` — passed
- `npm run verify:design-system` — passed
- `git diff --check` — passed
