### PR TITLE
fix(one): settle Calendar OAuth popup on return and close window

### DIFF
--- a/hushh-webapp/app/profile/google/oauth/return/page.tsx
+++ b/hushh-webapp/app/profile/google/oauth/return/page.tsx
@@ -6,6 +6,10 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { CalendarAgentPage } from "@/components/calendar/calendar-agent-page";
 import { useAuth } from "@/hooks/use-auth";
 import { consumeCalendarSetupOAuthReturn } from "@/lib/calendar/calendar-oauth-journey";
+import {
+  readGoogleOAuthPopupAttempt,
+  settleGoogleOAuthPopup,
+} from "@/lib/google/google-oauth-popup";
 import { ROUTES } from "@/lib/navigation/routes";
 import { GoogleCalendarService } from "@/lib/services/google-calendar-service";
 
@@ -14,21 +18,66 @@ function GoogleOAuthReturnContent() {
   const router = useRouter();
   const search = useSearchParams();
   const started = useRef(false);
+
   useEffect(() => {
     if (loading || started.current) return;
     started.current = true;
-    const code = search.get("code"); const state = search.get("state");
+
+    const code = search.get("code");
+    const state = search.get("state");
+    const oauthError = search.get("error") || search.get("error_description");
     const returnToSetup = consumeCalendarSetupOAuthReturn();
     const destination = returnToSetup ? ROUTES.ONE_SETUP_CALENDAR : ROUTES.CALENDAR;
-    if (!user || !code || !state) { router.replace(destination); return; }
-    void user.getIdToken()
-      .then((idToken) => GoogleCalendarService.completeConnect({ idToken, userId: user.uid, code, state }))
-      .then(() => router.replace(destination))
-      .catch(() => router.replace(`${destination}?calendar=error`));
+    const attempt = readGoogleOAuthPopupAttempt();
+
+    const settle = (
+      outcome: "succeeded" | "cancelled" | "failed",
+      message?: string,
+    ) => {
+      if (attempt) {
+        settleGoogleOAuthPopup(attempt, outcome, message);
+      } else {
+        const query = outcome === "succeeded" ? "" : "?calendar=error";
+        router.replace(`${destination}${query}`);
+      }
+    };
+
+    if (oauthError) {
+      const isDenied = String(oauthError).toLowerCase().includes("access_denied");
+      settle(
+        isDenied ? "cancelled" : "failed",
+        oauthError || "Google authorization was denied.",
+      );
+      return;
+    }
+
+    if (!user || !code || !state) {
+      settle("failed", "Missing authorization parameters. Please try again.");
+      return;
+    }
+
+    void user
+      .getIdToken()
+      .then((idToken) =>
+        GoogleCalendarService.completeConnect({
+          idToken,
+          userId: user.uid,
+          code,
+          state,
+        }),
+      )
+      .then(() => {
+        settle("succeeded");
+      })
+      .catch((err) => {
+        const msg =
+          err instanceof Error && err.message
+            ? err.message
+            : "Google Calendar connection could not be completed.";
+        settle("failed", msg);
+      });
   }, [loading, router, search, user]);
-  // Stay on the Calendar surface while the backend exchanges the code and
-  // stores the encrypted refresh token. This is deliberately not a blank
-  // callback/loading screen between Google and the connected Calendar state.
+
   return <CalendarAgentPage connectionPending />;
 }
 


### PR DESCRIPTION
## Summary
Fixes an issue in the Google Calendar OAuth connection flow on UAT desktop web where completing authorization left the user on a duplicate/stuck page inside a secondary window instead of automatically closing the popup and returning focus to the main application tab.

## Problem & Root Cause
- **Trigger**: `CalendarAgentPage` launches Google OAuth using `openGoogleOAuthPopup()`, which opens a popup window via `window.open()`.
- **Return Page Bug**: After Google redirects to `/profile/google/oauth/return?code=...&state=...`, `GoogleOAuthReturnPage` previously executed `router.replace(destination)` unconditionally. It never invoked `settleGoogleOAuthPopup()` or `window.close()`.
- **Impact**: The popup window was forced to navigate internally to `/one/calendar`, rendering the entire Next.js application inside the popup. Furthermore, the parent opener tab never received the settlement event because `postMessage` / `localStorage` events were never emitted.

## Solution & Approved Scope
1. Updated `hushh-webapp/app/profile/google/oauth/return/page.tsx` to read the popup attempt marker using `readGoogleOAuthPopupAttempt()`.
2. **Popup Settlement**: Upon successful backend code exchange (`GoogleCalendarService.completeConnect()`), calls `settleGoogleOAuthPopup(attempt, "succeeded")`. This dispatches `postMessage` to `window.opener`, updates `localStorage`, and calls `window.close()` to close the popup automatically.
3. **Error & Cancellation Handling**: If Google returns `access_denied` or backend token exchange fails, calls `settleGoogleOAuthPopup(attempt, "cancelled" | "failed", message)`. The popup closes gracefully and the main app window displays a descriptive error toast (`morphyToast.error(...)`).
4. **Fallback Handling**: Preserved the full-page redirect fallback (`router.replace(...)`) for non-popup direct visits (`attempt === null`).

## Scope Control
- **Files Modified**: Exactly 1 file — `hushh-webapp/app/profile/google/oauth/return/page.tsx`.
- No changes to Gmail OAuth flow or `calendar-agent-page.tsx`.

## Verification
- Ran `npm run build` in `hushh-webapp` -> **`0 errors`** (TypeScript compilation and Next.js page generation passed cleanly).
- Verified end-to-end execution against backend server and Cloud SQL proxy.