### PR TITLE
fix(location): keep Circle counts scoped to Circle members

### DIFF
--- a/hushh-webapp/__tests__/circle-recipient-selection.test.ts
+++ b/hushh-webapp/__tests__/circle-recipient-selection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  countSelectedCircleRecipients,
   isCircleSelectionFullySelected,
   mergeRecipientsByUserId,
   resolveCircleRecipientSelection,
@@ -109,6 +110,38 @@ describe("isCircleSelectionFullySelected", () => {
     expect(
       isCircleSelectionFullySelected({ ...selection(), ready: [] }, []),
     ).toBe(false);
+  });
+});
+
+describe("countSelectedCircleRecipients", () => {
+  it("does not let hand-picked outsiders inflate the Circle row count", () => {
+    const resolved = resolveCircleRecipientSelection({
+      circle: circle(),
+      currentUserId: "owner",
+    });
+    const readyIds = resolved.ready.map((target) => target.recipient.userId);
+
+    expect(readyIds).toEqual(["ready", "no-phone"]);
+    expect(
+      countSelectedCircleRecipients(resolved, [
+        ...readyIds,
+        "outsider-one",
+        "outsider-two",
+      ]),
+    ).toBe(2);
+  });
+
+  it("counts the unique selected intersection for partial or empty state", () => {
+    const resolved = resolveCircleRecipientSelection({
+      circle: circle(),
+      currentUserId: "owner",
+    });
+
+    expect(
+      countSelectedCircleRecipients(resolved, ["ready", "ready", "outsider"]),
+    ).toBe(1);
+    expect(countSelectedCircleRecipients(resolved, [])).toBe(0);
+    expect(countSelectedCircleRecipients(null, ["ready"])).toBe(0);
   });
 });
 

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -2469,6 +2469,128 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
+  it("keeps a selected Circle count scoped to its members when extra people are added", async () => {
+    const readyRecipient = locationState().recipients[0]!;
+    const makeReadyRecipient = (userId: string, displayName: string) => ({
+      ...readyRecipient,
+      userId,
+      displayName,
+      keyId: `${userId}-key`,
+    });
+    const circleMemberOne = makeReadyRecipient(
+      "circle_member_one",
+      "Circle Member One",
+    );
+    const circleMemberTwo = makeReadyRecipient(
+      "circle_member_two",
+      "Circle Member Two",
+    );
+    const outsiderOne = makeReadyRecipient("outside_one", "Outside One");
+    const outsiderTwo = makeReadyRecipient("outside_two", "Outside Two");
+    const circleSummary = {
+      id: "circle_family",
+      name: "Family",
+      kind: "family" as const,
+      role: "owner" as const,
+      // Circle summaries include the viewer; the UI count intentionally does
+      // not. Two shareable people plus the current owner therefore means 3.
+      memberCount: 3,
+      memberLimit: 20,
+    };
+
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      recipients: [
+        circleMemberOne,
+        circleMemberTwo,
+        outsiderOne,
+        outsiderTwo,
+      ],
+      circles: [circleSummary],
+      ownerGrants: [],
+    });
+    mockGetCircle.mockResolvedValue({
+      ...circleSummary,
+      members: [
+        {
+          userId: "user_a",
+          displayName: "Me",
+          role: "owner" as const,
+          phoneVerified: true,
+          secureLocationReady: true,
+          canReceiveLocation: true,
+          keyId: "owner-key",
+          publicKeyJwk: { kty: "EC" },
+        },
+        ...[circleMemberOne, circleMemberTwo].map((recipient) => ({
+          userId: recipient.userId,
+          displayName: recipient.displayName,
+          role: "member" as const,
+          phoneVerified: true,
+          secureLocationReady: true,
+          canReceiveLocation: true,
+          keyId: recipient.keyId,
+          publicKeyJwk: recipient.publicKeyJwk,
+        })),
+      ],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await openSharePersonStep();
+    const shareHeader = screen
+      .getByRole("heading", { name: "Who can see you?" })
+      .closest("header");
+    if (!shareHeader) throw new Error("Share flow header was not rendered.");
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Select the Family Circle, 2 members",
+      }),
+    );
+
+    const selectedCircleRow = await screen.findByRole("button", {
+      name: "Deselect the Family Circle, 2 selected",
+    });
+    expect(within(shareHeader).getByText("2 selected")).toBeTruthy();
+    expect(within(selectedCircleRow).getByText("2 selected")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Select Outside One for private sharing",
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Select Outside Two for private sharing",
+      }),
+    );
+
+    expect(within(shareHeader).getByText("4 selected")).toBeTruthy();
+    expect(
+      within(
+        screen.getByRole("button", {
+          name: "Deselect the Family Circle, 2 selected",
+        }),
+      ).getByText("2 selected"),
+    ).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Deselect Outside Two for private sharing",
+      }),
+    );
+    expect(within(shareHeader).getByText("3 selected")).toBeTruthy();
+    expect(
+      within(
+        screen.getByRole("button", {
+          name: "Deselect the Family Circle, 2 selected",
+        }),
+      ).getByText("2 selected"),
+    ).toBeTruthy();
+  });
+
   it("resets every abandoned share field and ignores a late review preflight", async () => {
     const { rerender } = render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -122,6 +122,7 @@ import type {
 } from "@/lib/one-location/types";
 import { locationStatusLabel } from "@/lib/one-location/location-readiness";
 import {
+  countSelectedCircleRecipients,
   isCircleSelectionFullySelected,
   type CircleRecipientSelection,
 } from "@/lib/one-location/circle-recipient-selection";
@@ -4490,6 +4491,10 @@ function ShareFlow({
     vm.selectedShareCircleSelection,
     vm.selectedRecipientIds,
   );
+  const selectedShareCircleRecipientCount = countSelectedCircleRecipients(
+    vm.selectedShareCircleSelection,
+    vm.selectedRecipientIds,
+  );
 
   // Step 2 of 2 — "Details" and the old separate "Consent check" merged.
   //
@@ -4700,6 +4705,9 @@ function ShareFlow({
               const selected =
                 vm.selectedShareCircleSelection?.circle.id === circle.id &&
                 shareCircleFullySelected;
+              const circleSelectionDescription = selected
+                ? `${selectedShareCircleRecipientCount} selected`
+                : circleMemberCountLabel(circle.memberCount);
               const circleRole = roleClasses("people");
               return (
                 <SettingsRow
@@ -4708,7 +4716,7 @@ function ShareFlow({
                   disabled={vm.busy === "shareCircle"}
                   onClick={() => void vm.onSelectShareCircle(circle.id)}
                   ariaPressed={selected}
-                  ariaLabel={`${selected ? "Deselect" : "Select"} the ${circle.name} Circle`}
+                  ariaLabel={`${selected ? "Deselect" : "Select"} the ${circle.name} Circle, ${circleSelectionDescription}`}
                   leading={
                     <span
                       className={cn(
@@ -4724,9 +4732,7 @@ function ShareFlow({
                   description={
                     vm.busy === "shareCircle"
                       ? "Loading…"
-                      : selected
-                        ? `${selectedReady.length} selected`
-                        : circleMemberCountLabel(circle.memberCount)
+                      : circleSelectionDescription
                   }
                   trailing={<SelectionDot selected={selected} />}
                 />

--- a/hushh-webapp/lib/one-location/circle-recipient-selection.ts
+++ b/hushh-webapp/lib/one-location/circle-recipient-selection.ts
@@ -119,6 +119,30 @@ export function isCircleSelectionFullySelected(
   return ready.every((target) => selected.has(target.recipient.userId));
 }
 
+/**
+ * Count only selected recipients that belong to this resolved Circle snapshot.
+ *
+ * The share composer may contain extra hand-picked people while a whole Circle
+ * remains selected. Those people belong in the composer-wide total, but never
+ * in the Circle row's own count. Use recipient ids rather than the summary's
+ * `memberCount`: the resolved snapshot has already excluded the viewer and
+ * anyone who cannot currently receive this kind of share.
+ */
+export function countSelectedCircleRecipients(
+  selection: CircleRecipientSelection | null | undefined,
+  selectedRecipientIds: readonly string[],
+): number {
+  if (!selection?.ready.length || !selectedRecipientIds.length) return 0;
+
+  const selected = new Set(selectedRecipientIds);
+  const counted = new Set<string>();
+  for (const target of selection.ready) {
+    const userId = target.recipient.userId;
+    if (userId && selected.has(userId)) counted.add(userId);
+  }
+  return counted.size;
+}
+
 export function mergeRecipientsByUserId(
   ...groups: OneLocationRecipient[][]
 ): OneLocationRecipient[] {


### PR DESCRIPTION
# Description

Keep the Share Location Circle row count scoped to that Circle's selected, location-ready members while preserving the page-level total across all recipients.

The regression came from rendering the Circle row with the composer-wide `selectedReady.length`. A two-member Circle therefore changed to `4 selected` when two standalone connections were added. This PR derives the row label from the unique intersection of the selected recipient IDs and the resolved Circle snapshot.

The UX now behaves in real time as intended:

- Select a two-member Circle: page `2 selected`, Circle `2 selected`.
- Add two people outside the Circle: page `4 selected`, Circle stays `2 selected`.
- Remove one outside person: page `3 selected`, Circle stays `2 selected`.

The accessible Circle action now announces the same Circle-local count. Recipient selection, grant creation, and Circle provenance are unchanged.

Tracks #6376

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
  - Reachable production attach point: `/one/location` → Share location → recipient selection in `LocationRedesignHub`.

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below:
  - The shared React/Capacitor experience receives the same corrected label and accessible name; no iOS or Android bridge contract changes.

- Docs updated (exact files):
  - [x] None
  - No durable product/API contract changed; the issue contains the manual UAT test procedure.

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None
  - This is display-only counting over the already-resolved eligible recipient snapshot. Authorization, data-access, location-grant, and public-ingress boundaries remain unchanged.

- Caller / proxy / backend pairing:
  - [x] Not applicable
  - No request, response, proxy, or backend behavior changed.

- Rollback or safe-failure behavior:
  - [x] Listed below:
  - Revert this commit to restore the prior label calculation. Sharing authority and persisted data are unaffected either way.

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below:
  - `/one/location`; `npx playwright test e2e/one-location-agent-browser.spec.ts --project=chromium` passed 4/4.
  - The rendered-page regression test exercises the exact global `2 → 4 → 3` flow while the Circle row stays at `2`.

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr` (Windows shell/Python alias prevented the umbrella wrapper; equivalent owning checks below were run directly.)
  - [x] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test` (the scoped One Location suite was used instead.)
  - [ ] `cd hushh-webapp && npm run build` (GitHub CI is authoritative for the production build.)
  - [ ] `cd hushh-webapp && npm run ios:cold:audit` (no native fixture change.)
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000` (Kai is not touched.)

Additional passing checks:

- `npx vitest run __tests__/circle-recipient-selection.test.ts __tests__/components/one-location-agent-page.test.tsx` — 2 files / 139 tests.
- `npm run verify:one-location` — 39 files / 776 tests.
- Targeted ESLint on all four changed files.
- `npm run verify:docs`.
- `npm run verify:design-system`.
- DCO signoff check for `origin/main..HEAD`.
- Gitleaks commit scan and GitHub secret-alert parity — no leaks and zero open secret-scanning alerts; existing repository Dependabot alerts remain advisory in this lane.

The credential-gated signed-route sweep was not runnable locally because the maintainer-only signed-in test credentials are not present. This PR changes no route or API contract.

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; no open PR targets this branch or duplicates this fix.
- [x] This PR changes a current reachable app surface.
- [x] Reachable production attach point: `/one/location` Share Location recipient step.
- [x] New tests import and exercise production code, including the rendered page.
- [x] The new helper is wired directly into the live `LocationRedesignHub` Circle row.
- [x] Production surface proved by helper tests, rendered-page regression, and the One Location browser smoke.
- [x] Required checks will be evaluated on this exact head; local DCO, freshness, and changed-surface checks pass.
- [x] Maintainer edits are enabled because the branch is in the canonical repository.
- [x] This is not a stacked PR.
- [x] This is a new maintainer-authored fix, not a response to requested changes.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: shared Next.js/React implementation is updated on `/one/location`.
- [x] **iOS**: no native plugin change; Capacitor renders the same shared UI behavior.
- [x] **Android**: no native plugin change; Capacitor renders the same shared UI behavior.

## 🧪 Testing

- [x] Tested on Web with rendered component and Chromium Playwright coverage.
- [ ] Tested on iOS Simulator/Device (no native bridge or platform-specific behavior changed.)
- [ ] Tested on Android Emulator/Device (no native bridge or platform-specific behavior changed.)
- [x] Commits are signed off (`git commit -s`).
- [x] No generated files changed.

## 📸 Screenshots / Video

The exact reproduction and manual UAT steps are captured in #6376. Automated browser and rendered-page proof cover the corrected route behavior; no new visual design is introduced.

## 🛡️ Privacy & Consent

- [ ] Does this change access user data?
- [x] No new data access is introduced.
- [x] Sensitive surface touched: none; the existing location-recipient eligibility snapshot is only read for display counting.
- [x] Error path / rollback: null, empty, duplicate, self, and unready-member cases resolve without inflating the count; reverting the commit restores the old label without data migration.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependencies or third-party notices changed.
