### PR TITLE
feat(ios): expose Location actions to Siri

### DIFF
--- a/docs/reference/one/one-voice-runtime-architecture.md
+++ b/docs/reference/one/one-voice-runtime-architecture.md
@@ -43,24 +43,95 @@ flowchart TD
 
 ### Siri/App Shortcut entry adapter
 
-On iOS 16 and later, `TalkToHusshOneIntent` is an entry adapter into this
-runtime, not a second voice runtime. Siri or App Shortcuts foregrounds the
-UIKit/Capacitor app and enqueues one five-minute metadata-only invocation:
-`{id, kind, source, createdAt, expiresAt}`. The native bridge retains that
-request through ordinary cold launch and Hussh sign-in, then the app-level
-handoff waits for foreground visibility, restored authentication, resolved
-route context, the redacted runtime snapshot, and the persistent Agent Bar
-owner. The Agent Bar alone acquires the existing voice lease, microphone,
-Gemini Live transport, relay ticket, WebSocket, context, consent, capture, and
-playback paths.
+On iOS 16 and later, Siri is a structured entry adapter into the existing One
+runtime, not a second voice runtime or action engine. There are two modes:
 
-The adapter does not forward Siri's utterance, force a route, require vault
-unlock, or create an action id. A signed-in but locked account begins in the
-existing `signed_locked` tier, where sensitive tools continue to fail closed.
-Invocation ids are coalesced and claimed exactly once; a transport failure
-reveals the existing Talk to One control as a tap fallback but fails the
-automatic-start release gate. Android and web deliberately report this Apple
-system surface as unsupported/no pending invocation.
+1. `TalkToHusshOneIntent` foregrounds the UIKit/Capacitor app and enqueues the
+   existing five-minute, metadata-only voice invocation. The Agent Bar remains
+   the only owner of the microphone, Gemini Live transport, relay, context,
+   consent, capture, and playback.
+2. Location App Intents resolve typed Apple parameters, enqueue one bounded
+   `execute_one_action` request, and hand the exact generated `action_id` and
+   slots to the same Agent Bar action executor used by One Voice. The adapter
+   never implements Location behavior in Swift and never accepts a free-form
+   prompt.
+
+Both native envelopes use latest-request-wins and exact claim/completion. They
+survive ordinary cold launch and HUSSH sign-in for five minutes and clear on
+completion, failure, expiry, replacement, cancellation, or sign-out. The
+action envelope is stored in this-device-only Keychain storage and is closed
+to sixteen allowlisted generated action identifiers and per-action slot names.
+The App Entity index is owner-bound and contains only existing HUSSH ids and
+display names; it contains no phone numbers, credentials, coordinates, routes,
+tokens, speech, or contact-book records.
+
+The direct adapter waits for foreground visibility, restored authentication,
+the active route/runtime, vault access when the action mutates protected
+information, and the sole Agent Bar executor. Native confirmation is required
+before every generated `confirm_required` mutation. The browser then applies
+the generated guard inventory and reports the browser-observed settlement.
+Signed-locked users may open read-only Location destinations, but mutations
+wait for normal vault restoration. A missing account routes through Login and
+returns to the preserved route without asking the person to repeat the Siri
+request.
+
+All currently exposed Location intents foreground HUSSH. This is deliberate:
+the canonical executor, current vault authority, encrypted location publish,
+and browser settlement are owned by the existing Capacitor/WebView runtime.
+Running a second native service merely to claim background execution would
+duplicate authority-bearing logic. A future background intent is acceptable
+only after that same executor is available behind a shared non-UI port with
+identical guards and settlement.
+
+The authoritative Location contract currently contains 50 generated actions.
+The Siri surface exposes the following useful, bounded subset:
+
+| App Intent behavior | Generated action id | System confirmation | Vault |
+| --- | --- | --- | --- |
+| Open Location | `location.open_now` | No | No |
+| Open map | `location.open_map` | No | No |
+| View active shares | `location.open_active_shares` | No | No |
+| View locations shared with me | `location.open_shared_with_me` | No | No |
+| Review requests | `location.open_needs_review` | No | No |
+| Open privacy settings | `location.open_settings` | No | No |
+| Open temporary-link composer | `location.open_temporary_link` | No | No |
+| Open Check-In composer | `location.open_check_in` | No | No |
+| Open SOS review | `location.open_sos` | No; does not send | No |
+| Share with a resolved contact | `location.share_selected` | Yes | Yes |
+| Ask a resolved contact for location | `location.send_request` | Yes | Yes |
+| Stop sharing with a resolved contact | `location.stop_share` | Yes | Yes |
+| Pause this device's updates | `location.pause_updates` | No | Yes |
+| Resume this device's updates | `location.resume_updates` | Yes | Yes |
+| Create a named Circle | `location.create_circle` | Yes | Yes |
+| Rename a resolved Circle | `location.rename_circle` | Yes | Yes |
+
+The other 34 contract actions remain available through the existing One Voice
+and visible Location experience, but are not direct Siri intents in this
+release:
+
+- Ten redundant composer/deep-link actions (`open_people`, `open_links`,
+  `open_share`, `open_ask`, `open_invite`, `open_create_circle`,
+  `open_join_circle`, `open_sms_contacts`, `find_contacts`, and
+  `add_connections`) are covered by the narrower destination intents or the
+  existing conversational fallback.
+- Three UI-internal selection/refresh steps (`select_ask_recipient`,
+  `select_share_recipient`, and `refresh`) are implementation steps, not useful
+  standalone system commands.
+- Nineteen request, grant, emergency-contact, Circle-membership/invite, saved
+  place, and active Check-In mutations require a typed current-state entity or
+  an already prepared in-app composer. Exposing them by spoken name alone would
+  guess at authority-bearing records or change the meaning of the contract.
+- `trigger_sos` and `sos_default` are intentionally excluded from direct Siri
+  execution because the current generated contract can send an alert without
+  a confirmation gate. Siri may open the existing SOS review surface, but it
+  cannot send the alert in this release.
+
+Apple limits an app to ten zero-setup App Shortcuts, so the provider publishes
+the highest-value phrases: share, ask, stop, location on/off, create Circle,
+Check-In, open Location, open map, review requests, and Talk to One. The other
+App Intents remain discoverable in the Shortcuts app. Android and web
+deliberately report this Apple system surface as unsupported/no pending
+invocation.
 
 ### Route orchestration index
 

--- a/hushh-webapp/__tests__/agent/one-system-action-executor.test.ts
+++ b/hushh-webapp/__tests__/agent/one-system-action-executor.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  executeOneSystemActionInvocation,
+  isOneSystemActionExecutorReady,
+  registerOneSystemActionExecutor,
+} from "@/lib/agent/one-system-action-executor";
+import type { PendingOneSystemActionInvocation } from "@/lib/capacitor/one-system-action-invocation";
+
+const invocation: PendingOneSystemActionInvocation = {
+  id: "request-1",
+  kind: "execute_one_action",
+  source: "siri_app_intent",
+  actionId: "location.share_selected",
+  slots: {
+    person: "Kushal",
+    resolvedRecipientId: "contact-1",
+    duration_hours: "2",
+  },
+  requiresVault: true,
+  confirmedBySystem: true,
+  createdAt: 1_000,
+  expiresAt: 301_000,
+};
+
+let cleanup: (() => void) | null = null;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = null;
+});
+
+describe("One system action executor seam", () => {
+  it("fails closed until the sole Agent Bar owner registers", async () => {
+    const result = await executeOneSystemActionInvocation(invocation);
+    expect(result.status).toBe("blocked");
+    expect(result.reason).toBe("system_action_executor_not_ready");
+  });
+
+  it("hands the unchanged canonical action id and slots to the owner", async () => {
+    const executor = vi.fn(async (received) => ({
+      status: "succeeded" as const,
+      actionId: received.actionId,
+      label: "Share with the people I picked",
+      routeBefore: "/one/location",
+      resultSummary: "Location shared with 1 person for 2 hours.",
+    }));
+    cleanup = registerOneSystemActionExecutor(executor);
+
+    expect(isOneSystemActionExecutorReady()).toBe(true);
+    const result = await executeOneSystemActionInvocation(invocation);
+
+    expect(executor).toHaveBeenCalledOnce();
+    expect(executor).toHaveBeenCalledWith(invocation);
+    expect(result.actionId).toBe("location.share_selected");
+  });
+
+  it("unregisters only the owner that installed the active executor", () => {
+    const firstCleanup = registerOneSystemActionExecutor(vi.fn());
+    cleanup = registerOneSystemActionExecutor(vi.fn());
+    firstCleanup();
+    expect(isOneSystemActionExecutorReady()).toBe(true);
+    cleanup();
+    cleanup = null;
+    expect(isOneSystemActionExecutorReady()).toBe(false);
+  });
+});

--- a/hushh-webapp/__tests__/agent/one-system-action-gateway-adapter.test.ts
+++ b/hushh-webapp/__tests__/agent/one-system-action-gateway-adapter.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { executeOneSystemActionThroughGateway } from "@/lib/agent/one-system-action-gateway-adapter";
+import type { PendingOneSystemActionInvocation } from "@/lib/capacitor/one-system-action-invocation";
+
+function invocation(
+  overrides: Partial<PendingOneSystemActionInvocation> = {},
+): PendingOneSystemActionInvocation {
+  return {
+    id: "action-request-1",
+    kind: "execute_one_action",
+    source: "siri_app_intent",
+    actionId: "location.share_selected",
+    slots: { resolvedRecipientId: "contact-1", duration_hours: "2" },
+    requiresVault: true,
+    confirmedBySystem: true,
+    createdAt: 1_000,
+    expiresAt: 301_000,
+    ...overrides,
+  };
+}
+
+function succeeded(actionId: string) {
+  return {
+    status: "succeeded" as const,
+    actionId,
+    label: actionId,
+    routeBefore: "/one/location",
+    resultSummary: `${actionId} succeeded`,
+  };
+}
+
+describe("Apple system action → generated gateway adapter", () => {
+  it("uses the same canonical executor for navigation, exact selection, and the final action", async () => {
+    const execute = vi.fn(async (actionId: string) => succeeded(actionId));
+    const afterSelection = vi.fn(async () => undefined);
+
+    const result = await executeOneSystemActionThroughGateway({
+      invocation: invocation(),
+      execute,
+      getCurrentRoute: () => ({ pathname: "/one", screen: "one_agents" }),
+      waitForScreen: vi.fn(async () => true),
+      afterSelection,
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(execute).toHaveBeenNthCalledWith(1, "location.open_share", {});
+    expect(execute).toHaveBeenNthCalledWith(
+      2,
+      "location.select_share_recipient",
+      { resolvedRecipientId: "contact-1" },
+      {
+        goalId: "goal.location.select_share_recipient",
+        expectedScreen: "one_location",
+      },
+    );
+    expect(execute).toHaveBeenNthCalledWith(
+      3,
+      "location.share_selected",
+      { duration_hours: "2" },
+      null,
+    );
+    expect(afterSelection).toHaveBeenCalledOnce();
+  });
+
+  it("passes a UI destination straight to the canonical executor", async () => {
+    const execute = vi.fn(async (actionId: string) => succeeded(actionId));
+    const request = invocation({
+      actionId: "location.open_map",
+      slots: {},
+      requiresVault: false,
+      confirmedBySystem: false,
+    });
+
+    await executeOneSystemActionThroughGateway({
+      invocation: request,
+      execute,
+      getCurrentRoute: () => ({ pathname: "/one", screen: "one_agents" }),
+      waitForScreen: vi.fn(),
+      afterSelection: vi.fn(),
+    });
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledWith("location.open_map", {}, null);
+  });
+
+  it("fails closed before the gateway when system confirmation is absent", async () => {
+    const execute = vi.fn();
+    const result = await executeOneSystemActionThroughGateway({
+      invocation: invocation({ confirmedBySystem: false }),
+      execute,
+      getCurrentRoute: () => ({
+        pathname: "/one/location",
+        screen: "one_location",
+      }),
+      waitForScreen: vi.fn(),
+      afterSelection: vi.fn(),
+    });
+
+    expect(result.reason).toBe("system_confirmation_missing");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("never guesses a recipient when the structured entity is missing", async () => {
+    const execute = vi.fn();
+    const result = await executeOneSystemActionThroughGateway({
+      invocation: invocation({ slots: { duration_hours: "2" } }),
+      execute,
+      getCurrentRoute: () => ({
+        pathname: "/one/location",
+        screen: "one_location",
+      }),
+      waitForScreen: vi.fn(),
+      afterSelection: vi.fn(),
+    });
+
+    expect(result.reason).toBe("system_action_recipient_missing");
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/__tests__/agent/siri-one-action-handoff-component.test.tsx
+++ b/hushh-webapp/__tests__/agent/siri-one-action-handoff-component.test.tsx
@@ -1,0 +1,240 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: { user: { uid: "user-1" } as { uid: string } | null, loading: false },
+  runtime: {
+    appRuntimeState: { route: { pathname: "/one/location" } } as object | null,
+    tier: "signed_unlocked" as "signed_locked" | "signed_unlocked" | null,
+  },
+  pathname: "/one/location",
+  search: "view=people",
+  visible: true,
+  push: vi.fn(),
+  getPendingInvocation: vi.fn(),
+  claimInvocation: vi.fn(),
+  completeInvocation: vi.fn(),
+  addAvailabilityListener: vi.fn(),
+  removeAvailabilityListener: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mocks.pathname,
+  useRouter: () => ({ push: mocks.push }),
+  useSearchParams: () => new URLSearchParams(mocks.search),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => mocks.auth,
+}));
+
+vi.mock("@/lib/agent/agent-runtime-context", () => ({
+  useAgentRuntimeStateOptional: () => mocks.runtime,
+}));
+
+vi.mock("@/lib/capacitor/one-system-action-invocation", async (importOriginal) => {
+  const original =
+    await importOriginal<
+      typeof import("@/lib/capacitor/one-system-action-invocation")
+    >();
+  return {
+    ...original,
+    OneSystemActionInvocationBridge: {
+      isSupported: () => true,
+      getPendingInvocation: mocks.getPendingInvocation,
+      claimInvocation: mocks.claimInvocation,
+      completeInvocation: mocks.completeInvocation,
+      addAvailabilityListener: mocks.addAvailabilityListener,
+    },
+  };
+});
+
+import { SiriOneActionHandoff } from "@/components/agent/siri-one-action-handoff";
+import { registerOneSystemActionExecutor } from "@/lib/agent/one-system-action-executor";
+import type { PendingOneSystemActionInvocation } from "@/lib/capacitor/one-system-action-invocation";
+
+function invocation(
+  overrides: Partial<PendingOneSystemActionInvocation> = {},
+): PendingOneSystemActionInvocation {
+  const now = Date.now();
+  return {
+    id: "action-request-1",
+    kind: "execute_one_action",
+    source: "siri_app_intent",
+    actionId: "location.share_selected",
+    slots: { resolvedRecipientId: "contact-1", duration_hours: "2" },
+    requiresVault: true,
+    confirmedBySystem: true,
+    createdAt: now,
+    expiresAt: now + 300_000,
+    ...overrides,
+  };
+}
+
+describe("SiriOneActionHandoff lifecycle", () => {
+  let unregisterExecutor: (() => void) | null = null;
+  let executor: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mocks.auth = { user: { uid: "user-1" }, loading: false };
+    mocks.runtime = {
+      appRuntimeState: { route: { pathname: "/one/location" } },
+      tier: "signed_unlocked",
+    };
+    mocks.pathname = "/one/location";
+    mocks.search = "view=people";
+    mocks.visible = true;
+    mocks.push.mockReset();
+    mocks.getPendingInvocation.mockReset();
+    mocks.claimInvocation.mockReset();
+    mocks.completeInvocation.mockReset();
+    mocks.addAvailabilityListener.mockReset();
+    mocks.removeAvailabilityListener.mockReset();
+    mocks.claimInvocation.mockResolvedValue({ claimed: true });
+    mocks.completeInvocation.mockResolvedValue(undefined);
+    mocks.addAvailabilityListener.mockResolvedValue({
+      remove: mocks.removeAvailabilityListener,
+    });
+    executor = vi.fn(async (received: PendingOneSystemActionInvocation) => ({
+      status: "succeeded" as const,
+      actionId: received.actionId,
+      label: "Share my location",
+      routeBefore: "/one/location",
+      resultSummary: "Location shared for 2 hours.",
+    }));
+    unregisterExecutor = registerOneSystemActionExecutor(executor);
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => (mocks.visible ? "visible" : "hidden"),
+    });
+  });
+
+  afterEach(() => {
+    unregisterExecutor?.();
+    unregisterExecutor = null;
+  });
+
+  it("claims, executes, and completes an authenticated action exactly once", async () => {
+    const pending = invocation();
+    mocks.getPendingInvocation.mockResolvedValue(pending);
+
+    render(<SiriOneActionHandoff />);
+
+    await waitFor(() => expect(executor).toHaveBeenCalledWith(pending));
+    await waitFor(() =>
+      expect(mocks.completeInvocation).toHaveBeenCalledWith({
+        id: pending.id,
+        outcome: "succeeded",
+        summary: "Location shared for 2 hours.",
+      }),
+    );
+    expect(mocks.claimInvocation).toHaveBeenCalledTimes(1);
+    expect(executor).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits in the background and dispatches after the app becomes active", async () => {
+    const pending = invocation({ id: "background-action" });
+    mocks.visible = false;
+    mocks.getPendingInvocation.mockResolvedValue(pending);
+
+    render(<SiriOneActionHandoff />);
+    await waitFor(() => expect(mocks.getPendingInvocation).toHaveBeenCalled());
+    expect(mocks.claimInvocation).not.toHaveBeenCalled();
+
+    act(() => {
+      mocks.visible = true;
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() =>
+      expect(mocks.claimInvocation).toHaveBeenCalledWith({ id: pending.id }),
+    );
+  });
+
+  it("retains the action through sign-in and restores the original route", async () => {
+    const pending = invocation({ id: "auth-restore-action" });
+    mocks.auth = { user: null, loading: false };
+    mocks.getPendingInvocation.mockResolvedValue(pending);
+
+    const view = render(<SiriOneActionHandoff />);
+    await waitFor(() =>
+      expect(mocks.push).toHaveBeenCalledWith(
+        "/login?redirect=%2Fone%2Flocation%3Fview%3Dpeople",
+      ),
+    );
+    expect(mocks.claimInvocation).not.toHaveBeenCalled();
+
+    mocks.auth = { user: { uid: "user-1" }, loading: false };
+    view.rerender(<SiriOneActionHandoff />);
+
+    await waitFor(() => expect(executor).toHaveBeenCalledWith(pending));
+  });
+
+  it("waits for vault restoration for mutations but permits UI-only actions", async () => {
+    const mutation = invocation({ id: "locked-mutation" });
+    mocks.runtime.tier = "signed_locked";
+    mocks.getPendingInvocation.mockResolvedValue(mutation);
+
+    const view = render(<SiriOneActionHandoff />);
+    await waitFor(() => expect(mocks.getPendingInvocation).toHaveBeenCalled());
+    expect(mocks.claimInvocation).not.toHaveBeenCalled();
+
+    mocks.runtime.tier = "signed_unlocked";
+    view.rerender(<SiriOneActionHandoff />);
+    await waitFor(() => expect(executor).toHaveBeenCalledWith(mutation));
+    view.unmount();
+
+    executor.mockClear();
+    mocks.claimInvocation.mockClear();
+    const navigation = invocation({
+      id: "locked-navigation",
+      actionId: "location.open_map",
+      slots: {},
+      requiresVault: false,
+      confirmedBySystem: false,
+    });
+    mocks.runtime.tier = "signed_locked";
+    mocks.getPendingInvocation.mockResolvedValue(navigation);
+    render(<SiriOneActionHandoff />);
+    await waitFor(() => expect(executor).toHaveBeenCalledWith(navigation));
+  });
+
+  it("expires a cold-launch request without claiming or executing it", async () => {
+    const pending = invocation({
+      id: "expired-action",
+      createdAt: Date.now() - 301_000,
+      expiresAt: Date.now() - 1,
+    });
+    mocks.getPendingInvocation.mockResolvedValue(pending);
+
+    render(<SiriOneActionHandoff />);
+
+    await waitFor(() =>
+      expect(mocks.completeInvocation).toHaveBeenCalledWith({
+        id: pending.id,
+        outcome: "expired",
+        summary: "That HUSSH request expired. Try again.",
+      }),
+    );
+    expect(mocks.claimInvocation).not.toHaveBeenCalled();
+    expect(executor).not.toHaveBeenCalled();
+  });
+
+  it("does not execute twice when native availability repeats", async () => {
+    const pending = invocation({ id: "duplicate-action" });
+    mocks.getPendingInvocation.mockResolvedValue(pending);
+    mocks.claimInvocation
+      .mockResolvedValueOnce({ claimed: true })
+      .mockResolvedValue({ claimed: false });
+
+    render(<SiriOneActionHandoff />);
+    await waitFor(() => expect(executor).toHaveBeenCalledTimes(1));
+
+    const listener = mocks.addAvailabilityListener.mock.calls[0]?.[0] as
+      | ((value: PendingOneSystemActionInvocation) => void)
+      | undefined;
+    act(() => listener?.(pending));
+    await waitFor(() => expect(mocks.claimInvocation).toHaveBeenCalledTimes(2));
+    expect(executor).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hushh-webapp/__tests__/agent/siri-one-action-handoff.test.ts
+++ b/hushh-webapp/__tests__/agent/siri-one-action-handoff.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSiriOneActionHandoffState } from "@/lib/agent/siri-one-action-handoff-policy";
+
+const readyInput = {
+  now: 1_000,
+  expiresAt: 301_000,
+  visible: true,
+  authLoading: false,
+  signedIn: true,
+  pathname: "/one",
+  loginPath: "/login",
+  runtimeReady: true,
+  tier: "signed_unlocked" as const,
+  requiresVault: true,
+  executorReady: true,
+};
+
+describe("Siri One action handoff policy", () => {
+  it("waits through foreground, auth, route, runtime, vault, and executor restoration", () => {
+    expect(
+      resolveSiriOneActionHandoffState({ ...readyInput, visible: false }),
+    ).toBe("waiting_for_foreground");
+    expect(
+      resolveSiriOneActionHandoffState({ ...readyInput, authLoading: true }),
+    ).toBe("waiting_for_auth_restoration");
+    expect(
+      resolveSiriOneActionHandoffState({ ...readyInput, signedIn: false }),
+    ).toBe("waiting_for_auth");
+    expect(
+      resolveSiriOneActionHandoffState({ ...readyInput, pathname: "/login" }),
+    ).toBe("waiting_for_route");
+    expect(
+      resolveSiriOneActionHandoffState({ ...readyInput, runtimeReady: false }),
+    ).toBe("waiting_for_runtime");
+    expect(
+      resolveSiriOneActionHandoffState({
+        ...readyInput,
+        tier: "signed_locked",
+      }),
+    ).toBe("waiting_for_vault");
+    expect(
+      resolveSiriOneActionHandoffState({
+        ...readyInput,
+        executorReady: false,
+      }),
+    ).toBe("waiting_for_executor");
+  });
+
+  it("allows UI-only navigation in the signed-locked tier", () => {
+    expect(
+      resolveSiriOneActionHandoffState({
+        ...readyInput,
+        tier: "signed_locked",
+        requiresVault: false,
+      }),
+    ).toBe("dispatch");
+  });
+
+  it("dispatches only when every lifecycle gate is ready", () => {
+    expect(resolveSiriOneActionHandoffState(readyInput)).toBe("dispatch");
+  });
+
+  it("expires before attempting any restoration", () => {
+    expect(
+      resolveSiriOneActionHandoffState({
+        ...readyInput,
+        expiresAt: readyInput.now,
+        visible: false,
+      }),
+    ).toBe("expired");
+  });
+});

--- a/hushh-webapp/__tests__/agent/siri-one-entity-index-publisher.test.tsx
+++ b/hushh-webapp/__tests__/agent/siri-one-entity-index-publisher.test.tsx
@@ -1,0 +1,86 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: { user: { uid: "owner-1" } as { uid: string } | null, loading: false },
+  vaultOwnerToken: "vault-owner-token" as string | null,
+  updateEntityIndex: vi.fn(),
+  clear: vi.fn(),
+  listRecipients: vi.fn(),
+  listCircles: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({ useAuth: () => mocks.auth }));
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({ vaultOwnerToken: mocks.vaultOwnerToken }),
+}));
+vi.mock("@/lib/capacitor/one-system-action-invocation", () => ({
+  OneSystemActionInvocationBridge: {
+    isSupported: () => true,
+    updateEntityIndex: mocks.updateEntityIndex,
+    clear: mocks.clear,
+  },
+}));
+vi.mock("@/lib/one-location/service", () => ({
+  OneLocationService: {
+    listRecipients: mocks.listRecipients,
+    listCircles: mocks.listCircles,
+  },
+}));
+
+import { SiriOneEntityIndexPublisher } from "@/components/agent/siri-one-entity-index-publisher";
+
+describe("SiriOneEntityIndexPublisher", () => {
+  beforeEach(() => {
+    mocks.auth = { user: { uid: "owner-1" }, loading: false };
+    mocks.vaultOwnerToken = "vault-owner-token";
+    mocks.updateEntityIndex.mockReset().mockResolvedValue(true);
+    mocks.clear.mockReset().mockResolvedValue(undefined);
+    mocks.listRecipients.mockReset().mockResolvedValue([
+      {
+        userId: "contact-1",
+        displayName: "Kushal",
+        phoneNumber: "+15550000000",
+        latitude: 47.61,
+        longitude: -122.33,
+      },
+    ]);
+    mocks.listCircles.mockReset().mockResolvedValue([
+      {
+        id: "circle-1",
+        name: "Family",
+        inviteCode: "private-code",
+        memberIds: ["contact-1"],
+      },
+    ]);
+  });
+
+  it("publishes only stable ids and display names from existing Location models", async () => {
+    render(<SiriOneEntityIndexPublisher />);
+
+    await waitFor(() =>
+      expect(mocks.updateEntityIndex).toHaveBeenCalledWith({
+        ownerId: "owner-1",
+        contacts: [{ id: "contact-1", name: "Kushal" }],
+        circles: [{ id: "circle-1", name: "Family" }],
+      }),
+    );
+    expect(mocks.listRecipients).toHaveBeenCalledWith("vault-owner-token");
+    expect(mocks.listCircles).toHaveBeenCalledWith("vault-owner-token");
+  });
+
+  it("clears the owner-bound index after sign-out", async () => {
+    mocks.auth = { user: null, loading: false };
+    mocks.vaultOwnerToken = null;
+
+    render(<SiriOneEntityIndexPublisher />);
+
+    await waitFor(() =>
+      expect(mocks.clear).toHaveBeenCalledWith({
+        outcome: "sign_out",
+        clearEntityIndex: true,
+      }),
+    );
+    expect(mocks.updateEntityIndex).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/__tests__/capacitor/one-system-action-invocation.test.ts
+++ b/hushh-webapp/__tests__/capacitor/one-system-action-invocation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ONE_SYSTEM_ACTION_IDS,
+  isPendingOneSystemActionInvocation,
+} from "@/lib/capacitor/one-system-action-invocation";
+import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
+
+const valid = {
+  id: "request-1",
+  kind: "execute_one_action" as const,
+  source: "siri_app_intent" as const,
+  actionId: "location.share_selected" as const,
+  slots: {
+    person: "Kushal",
+    resolvedRecipientId: "contact-1",
+    duration_hours: "2",
+  },
+  requiresVault: true,
+  confirmedBySystem: true,
+  createdAt: 1_000,
+  expiresAt: 301_000,
+};
+
+describe("One system action invocation bridge contract", () => {
+  it("accepts the bounded structured envelope", () => {
+    expect(isPendingOneSystemActionInvocation(valid)).toBe(true);
+  });
+
+  it("rejects arbitrary action ids and non-string slot payloads", () => {
+    expect(
+      isPendingOneSystemActionInvocation({
+        ...valid,
+        actionId: "location.run_anything" as never,
+      }),
+    ).toBe(false);
+    expect(
+      isPendingOneSystemActionInvocation({
+        ...valid,
+        slots: { prompt: { arbitrary: true } } as never,
+      }),
+    ).toBe(false);
+  });
+
+  it("contains only generated Location action identifiers", () => {
+    expect(ONE_SYSTEM_ACTION_IDS).toHaveLength(16);
+    expect(
+      ONE_SYSTEM_ACTION_IDS.every((actionId) =>
+        actionId.startsWith("location."),
+      ),
+    ).toBe(true);
+    expect(
+      ONE_SYSTEM_ACTION_IDS.every((actionId) => getKaiActionById(actionId)),
+    ).toBe(true);
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -10517,7 +10517,10 @@ export function OneLocationAgentPageContent({
 
   useLocalOnboardingActionHandler("location.stop_share", async (slots) => {
     const spoken = String(slots?.person ?? "").trim();
-    if (!spoken) {
+    const resolvedRecipientId = String(
+      slots?.resolvedRecipientId ?? "",
+    ).trim();
+    if (!spoken && !resolvedRecipientId) {
       return {
         status: "blocked" as const,
         summary: "Say whose access you want to stop.",
@@ -10529,11 +10532,18 @@ export function OneLocationAgentPageContent({
         summary: "Unlock One before stopping a share.",
       };
     }
-    const resolved = resolveBySpokenName(
-      activeOwnerGrants,
-      spoken,
-      (grant) => grant.recipientDisplayName,
-    );
+    const exactGrant = resolvedRecipientId
+      ? activeOwnerGrants.find(
+          (candidate) => candidate.recipientUserId === resolvedRecipientId,
+        ) ?? null
+      : null;
+    const resolved = exactGrant
+      ? ({ kind: "one", match: exactGrant } as const)
+      : resolveBySpokenName(
+          activeOwnerGrants,
+          spoken,
+          (grant) => grant.recipientDisplayName,
+        );
     if (resolved.kind === "none") {
       return {
         status: "blocked" as const,
@@ -11880,7 +11890,14 @@ export function OneLocationAgentPageContent({
           "Unlock One first -- I cannot see your circles while the vault is locked.",
       };
     }
-    const resolved = resolveVoiceCircle(String(slots?.circle ?? "").trim());
+    const resolvedCircleId = String(slots?.resolvedCircleId ?? "").trim();
+    const exactCircle = resolvedCircleId
+      ? namedCircles.find((candidate) => candidate.id === resolvedCircleId) ??
+        null
+      : null;
+    const resolved = exactCircle
+      ? ({ circle: exactCircle } as const)
+      : resolveVoiceCircle(String(slots?.circle ?? "").trim());
     if ("blocked" in resolved) {
       return { status: "blocked" as const, summary: resolved.blocked };
     }

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -28,6 +28,8 @@ import { TopShellRouteSwipe } from "@/components/app-ui/top-shell-route-swipe";
 import { AgentPopoverProvider } from "@/components/agent/agent-popover-provider";
 import { AgentRuntimeStateProvider } from "@/lib/agent/agent-runtime-context";
 import { SiriOneVoiceHandoff } from "@/components/agent/siri-one-voice-handoff";
+import { SiriOneActionHandoff } from "@/components/agent/siri-one-action-handoff";
+import { SiriOneEntityIndexPublisher } from "@/components/agent/siri-one-entity-index-publisher";
 import { AgentVoiceEdgeGlow } from "@/components/agent/agent-voice-edge-glow";
 import { FoundationPublicAmbient } from "@/components/app-ui/foundation-public-ambient";
 import { AppBottomShell } from "@/components/app-ui/app-bottom-shell";
@@ -476,6 +478,8 @@ function AppShellFrame({ children }: ProvidersProps) {
           <AgentRuntimeStateProvider>
             <AgentPopoverProvider>
               <SiriOneVoiceHandoff />
+              <SiriOneActionHandoff />
+              <SiriOneEntityIndexPublisher />
               <NativeTestRouter />
               <NativeTestBootstrap />
               <NativeTestRouteStatus />

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -35,6 +35,8 @@ import {
 } from "@/lib/agent/agent-action-runtime";
 import { settleAgentGatewayAction } from "@/lib/agent/agent-gateway-action-settlement";
 import { useAgentRuntimeStateOptional } from "@/lib/agent/agent-runtime-context";
+import { registerOneSystemActionExecutor } from "@/lib/agent/one-system-action-executor";
+import { executeOneSystemActionThroughGateway } from "@/lib/agent/one-system-action-gateway-adapter";
 import { requiresHardTapConfirmation } from "@/lib/agent/confirmation-tap-policy";
 import {
   readVoicePreferences,
@@ -371,6 +373,10 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   const latestVoiceContextRef = useRef<OneVoiceContextSnapshot | null>(
     runtime?.oneVoiceContextSnapshot ?? null,
   );
+  const latestSystemActionRuntimeRef = useRef(runtime);
+  useEffect(() => {
+    latestSystemActionRuntimeRef.current = runtime;
+  }, [runtime]);
   // UI state updates after async credential resolution. This lease reserves
   // microphone/transport ownership synchronously at the actual tap boundary.
   const voiceLeaseRef = useRef<VoiceSessionLease | null>(null);
@@ -453,6 +459,90 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       }
     };
   }, [runtime, user?.uid, router, busyOperations, setAnalysisParams, switchPersona]);
+
+  // Siri/App Intents are a structured invocation surface, not another action
+  // engine. Register the existing Agent Bar owner as the only executor and
+  // feed it the exact generated action id and slots after native auth settles.
+  useEffect(() => {
+    const execute = async (
+      actionId: string,
+      slots: Record<string, unknown>,
+      goalAuthorization?: { goalId: string; expectedScreen: string } | null,
+    ): Promise<AgentActionRuntimeResult> => {
+      const currentRuntime = latestSystemActionRuntimeRef.current;
+      const runtimeState = currentRuntime?.appRuntimeState;
+      if (!runtimeState) {
+        return {
+          status: "blocked",
+          actionId,
+          label: null,
+          routeBefore: null,
+          resultSummary: "HUSSH is still restoring the action runtime.",
+          reason: "missing_runtime_state",
+        };
+      }
+      const result = await executeAgentGatewayAction({
+        actionId,
+        slots,
+        userId: user?.uid ?? "",
+        router,
+        appRuntimeState: runtimeState,
+        surfaceMetadata: getVoiceSurfaceMetadata(),
+        allowedActionIds:
+          currentRuntime?.oneVoiceContextSnapshot.available_action_ids ?? null,
+        hasPortfolioData:
+          runtimeState.portfolio.has_portfolio_data ||
+          currentRuntime?.oneVoiceContextSnapshot.cache.portfolio_ready === true,
+        busyOperations,
+        setAnalysisParams,
+        switchPersona,
+        goalAuthorization,
+      });
+      return settleAgentGatewayAction(result, {
+        getCurrentRoute: () =>
+          latestSystemActionRuntimeRef.current?.appRuntimeState.route ??
+          runtimeState.route,
+        getCurrentSurfaceMetadata: getVoiceSurfaceMetadata,
+      });
+    };
+
+    const waitForScreen = async (screen: string): Promise<boolean> => {
+      const deadline = Date.now() + 8_000;
+      while (Date.now() < deadline) {
+        if (
+          latestSystemActionRuntimeRef.current?.appRuntimeState.route.screen ===
+          screen
+        ) {
+          return true;
+        }
+        await new Promise((resolve) => window.setTimeout(resolve, 25));
+      }
+      return false;
+    };
+
+    const executor = (invocation: Parameters<typeof executeOneSystemActionThroughGateway>[0]["invocation"]) =>
+      executeOneSystemActionThroughGateway({
+        invocation,
+        execute,
+        getCurrentRoute: () => ({
+          pathname:
+            latestSystemActionRuntimeRef.current?.appRuntimeState.route
+              .pathname ?? null,
+          screen:
+            latestSystemActionRuntimeRef.current?.appRuntimeState.route.screen ??
+            null,
+        }),
+        waitForScreen,
+        afterSelection: () =>
+          new Promise<void>((resolve) =>
+            window.requestAnimationFrame(() =>
+              window.requestAnimationFrame(() => resolve()),
+            ),
+          ),
+      });
+
+    return registerOneSystemActionExecutor(executor);
+  }, [busyOperations, router, setAnalysisParams, switchPersona, user?.uid]);
   const relayMintInFlightRef = useRef(false);
   const relayMintCooldownUntilRef = useRef(0);
   const relayMintBackoffMsRef = useRef(5_000);

--- a/hushh-webapp/components/agent/siri-one-action-handoff.tsx
+++ b/hushh-webapp/components/agent/siri-one-action-handoff.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { useAuth } from "@/hooks/use-auth";
+import { useAgentRuntimeStateOptional } from "@/lib/agent/agent-runtime-context";
+import {
+  executeOneSystemActionInvocation,
+  isOneSystemActionExecutorReady,
+  subscribeOneSystemActionExecutor,
+} from "@/lib/agent/one-system-action-executor";
+import {
+  OneSystemActionInvocationBridge,
+  type OneSystemActionOutcome,
+  type PendingOneSystemActionInvocation,
+} from "@/lib/capacitor/one-system-action-invocation";
+import { ROUTES } from "@/lib/navigation/routes";
+import { buildSiriOneVoiceLoginRoute } from "@/lib/agent/siri-one-voice-handoff-policy";
+import { resolveSiriOneActionHandoffState } from "@/lib/agent/siri-one-action-handoff-policy";
+
+function logLifecycle(
+  state: string,
+  invocation: PendingOneSystemActionInvocation,
+  outcome?: string,
+): void {
+  console.info(
+    `[SIRI_ONE_ACTION] state=${state} request_id=${invocation.id} source=${invocation.source} action_id=${invocation.actionId} outcome=${outcome ?? "none"} duration_ms=${Math.max(0, Date.now() - invocation.createdAt)}`,
+  );
+}
+
+function normalizeOutcome(
+  status: "succeeded" | "started" | "blocked" | "invalid" | "failed" | "noop",
+): OneSystemActionOutcome {
+  if (status === "succeeded" || status === "started" || status === "blocked") {
+    return status;
+  }
+  return "failed";
+}
+
+/**
+ * Restores auth/runtime and hands the structured Siri request to the sole
+ * Agent Bar action owner. It owns no action implementation and no model.
+ */
+export function SiriOneActionHandoff(): null {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { user, loading: authLoading } = useAuth();
+  const runtime = useAgentRuntimeStateOptional();
+  const [pending, setPending] =
+    useState<PendingOneSystemActionInvocation | null>(null);
+  const [executorRevision, setExecutorRevision] = useState(0);
+  const [visibilityRevision, setVisibilityRevision] = useState(0);
+  const claimedRef = useRef<string | null>(null);
+  const waitingStateRef = useRef<string | null>(null);
+
+  const refreshPending = useCallback(async () => {
+    const invocation =
+      await OneSystemActionInvocationBridge.getPendingInvocation().catch(
+        () => null,
+      );
+    if (invocation) logLifecycle("bridge_ready", invocation);
+    setPending(invocation);
+  }, []);
+
+  const complete = useCallback(
+    async (
+      invocation: PendingOneSystemActionInvocation,
+      outcome: OneSystemActionOutcome,
+      summary: string,
+    ) => {
+      await OneSystemActionInvocationBridge.completeInvocation({
+        id: invocation.id,
+        outcome,
+        summary,
+      }).catch(() => undefined);
+      logLifecycle(outcome, invocation, outcome);
+      if (claimedRef.current === invocation.id) claimedRef.current = null;
+      setPending((current) =>
+        current?.id === invocation.id ? null : current,
+      );
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!OneSystemActionInvocationBridge.isSupported()) return undefined;
+    let cancelled = false;
+    let removeListener: (() => Promise<void>) | null = null;
+    void refreshPending();
+    void OneSystemActionInvocationBridge.addAvailabilityListener(
+      (invocation) => {
+        if (cancelled) return;
+        logLifecycle("foregrounded", invocation);
+        setPending(invocation);
+      },
+    ).then((handle) => {
+      if (cancelled) void handle.remove();
+      else removeListener = () => handle.remove();
+    });
+    return () => {
+      cancelled = true;
+      void removeListener?.();
+    };
+  }, [refreshPending]);
+
+  useEffect(
+    () =>
+      subscribeOneSystemActionExecutor(() =>
+        setExecutorRevision((value) => value + 1),
+      ),
+    [],
+  );
+
+  useEffect(() => {
+    const onVisibility = () => setVisibilityRevision((value) => value + 1);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, []);
+
+  useEffect(() => {
+    if (!pending || claimedRef.current) return;
+    const state = resolveSiriOneActionHandoffState({
+      now: Date.now(),
+      expiresAt: pending.expiresAt,
+      visible: document.visibilityState === "visible",
+      authLoading,
+      signedIn: Boolean(user),
+      pathname,
+      loginPath: ROUTES.LOGIN,
+      runtimeReady: Boolean(runtime?.appRuntimeState),
+      tier: runtime?.tier ?? null,
+      requiresVault: pending.requiresVault,
+      executorReady: isOneSystemActionExecutorReady(),
+    });
+    if (state === "expired") {
+      void complete(pending, "expired", "That HUSSH request expired. Try again.");
+      return;
+    }
+    if (
+      state === "waiting_for_auth" ||
+      state === "waiting_for_auth_restoration" ||
+      state === "waiting_for_vault"
+    ) {
+      const key = `${pending.id}:${state}`;
+      if (waitingStateRef.current !== key) {
+        waitingStateRef.current = key;
+        logLifecycle(state, pending);
+      }
+      if (state === "waiting_for_auth" && pathname !== ROUTES.LOGIN) {
+        const search = searchParams?.toString() ?? "";
+        const currentRoute = pathname
+          ? `${pathname}${search ? `?${search}` : ""}`
+          : null;
+        router.push(
+          buildSiriOneVoiceLoginRoute({
+            currentRoute,
+            loginPath: ROUTES.LOGIN,
+            publicHomePath: ROUTES.HOME,
+          }),
+        );
+      }
+      return;
+    }
+    if (state !== "dispatch") return;
+
+    let cancelled = false;
+    void OneSystemActionInvocationBridge.claimInvocation({ id: pending.id })
+      .then(async ({ claimed }) => {
+        if (cancelled) return;
+        if (!claimed) {
+          void refreshPending();
+          return;
+        }
+        claimedRef.current = pending.id;
+        logLifecycle("dispatched", pending);
+        const result = await executeOneSystemActionInvocation(pending);
+        await complete(
+          pending,
+          normalizeOutcome(result.status),
+          result.resultSummary,
+        );
+      })
+      .catch(() => {
+        if (claimedRef.current === pending.id) {
+          void complete(pending, "failed", "HUSSH could not run that action.");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    authLoading,
+    complete,
+    executorRevision,
+    pathname,
+    pending,
+    refreshPending,
+    router,
+    runtime?.appRuntimeState,
+    runtime?.tier,
+    searchParams,
+    user,
+    visibilityRevision,
+  ]);
+
+  return null;
+}

--- a/hushh-webapp/components/agent/siri-one-entity-index-publisher.tsx
+++ b/hushh-webapp/components/agent/siri-one-entity-index-publisher.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+import { useAuth } from "@/hooks/use-auth";
+import { OneSystemActionInvocationBridge } from "@/lib/capacitor/one-system-action-invocation";
+import { FEED_STATE_CHANGED_EVENT } from "@/lib/feed/feed-events";
+import { OneLocationService } from "@/lib/one-location/service";
+import { useVault } from "@/lib/vault/vault-context";
+
+/**
+ * Publishes a bounded, this-device-only AppEntity search index from the
+ * existing Location models. It contains only stable ids and display names;
+ * no phone numbers, tokens, coordinates, routes, or contact-book records.
+ */
+export function SiriOneEntityIndexPublisher(): null {
+  const { user, loading: authLoading } = useAuth();
+  const { vaultOwnerToken } = useVault();
+  const refreshInFlightRef = useRef<Promise<void> | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (
+      !OneSystemActionInvocationBridge.isSupported() ||
+      !user?.uid ||
+      !vaultOwnerToken
+    ) {
+      return;
+    }
+    if (refreshInFlightRef.current) return refreshInFlightRef.current;
+    const task = (async () => {
+      try {
+        const [contacts, circles] = await Promise.all([
+          OneLocationService.listRecipients(vaultOwnerToken),
+          OneLocationService.listCircles(vaultOwnerToken),
+        ]);
+        await OneSystemActionInvocationBridge.updateEntityIndex({
+          ownerId: user.uid,
+          contacts: contacts.map((contact) => ({
+            id: contact.userId,
+            name: contact.displayName,
+          })),
+          circles: circles.map((circle) => ({
+            id: circle.id,
+            name: circle.name,
+          })),
+        });
+      } catch (error) {
+        console.info(
+          `[SIRI_ONE_ACTION] state=entity_index_failed outcome=failed reason=${
+            error instanceof Error ? error.name : "unknown"
+          }`,
+        );
+      } finally {
+        refreshInFlightRef.current = null;
+      }
+    })();
+    refreshInFlightRef.current = task;
+    return task;
+  }, [user?.uid, vaultOwnerToken]);
+
+  useEffect(() => {
+    if (!OneSystemActionInvocationBridge.isSupported()) return;
+    if (!authLoading && !user) {
+      void OneSystemActionInvocationBridge.clear({
+        outcome: "sign_out",
+        clearEntityIndex: true,
+      });
+      return;
+    }
+    void refresh();
+  }, [authLoading, refresh, user]);
+
+  useEffect(() => {
+    if (!OneSystemActionInvocationBridge.isSupported()) return undefined;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleRefresh = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => void refresh(), 500);
+    };
+    window.addEventListener(FEED_STATE_CHANGED_EVENT, scheduleRefresh);
+    return () => {
+      if (timer) clearTimeout(timer);
+      window.removeEventListener(FEED_STATE_CHANGED_EVENT, scheduleRefresh);
+    };
+  }, [refresh]);
+
+  return null;
+}

--- a/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
@@ -32,7 +32,9 @@
 		A11C0A730000000000000011 /* OneVoiceAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A740000000000000001 /* OneVoiceAppIntent.swift */; };
 		A11C0A730000000000000012 /* OneVoiceInvocationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A730000000000000002 /* OneVoiceInvocationCoordinator.swift */; };
 		A11C0A730000000000000013 /* HushhVoiceInvocationPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A730000000000000003 /* HushhVoiceInvocationPlugin.swift */; };
+		A11C0A730000000000000014 /* OneSystemActionInvocationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A730000000000000004 /* OneSystemActionInvocationCoordinator.swift */; };
 		A11C0A730000000000000022 /* OneVoiceInvocationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A730000000000000021 /* OneVoiceInvocationCoordinatorTests.swift */; };
+		A11C0A730000000000000023 /* OneSystemActionInvocationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0A730000000000000024 /* OneSystemActionInvocationCoordinatorTests.swift */; };
 		A1B2C3D42F0E966A009FC3FD /* PersonalKnowledgeModelPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D52F0E966A009FC3FD /* PersonalKnowledgeModelPlugin.swift */; };
 		A2774DC0614D2A490F85042E /* HushhConsentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D0CE383269D3D6B23A9A02 /* HushhConsentPlugin.swift */; };
 		ABCDEF000000000000000002 /* HusshIMessageSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF000000000000000001 /* HusshIMessageSessionStore.swift */; };
@@ -100,7 +102,9 @@
 		A11C0A740000000000000001 /* OneVoiceAppIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OneVoiceAppIntent.swift; sourceTree = "<group>"; };
 		A11C0A730000000000000002 /* OneVoiceInvocationCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OneVoiceInvocationCoordinator.swift; sourceTree = "<group>"; };
 		A11C0A730000000000000003 /* HushhVoiceInvocationPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HushhVoiceInvocationPlugin.swift; path = Plugins/HushhVoiceInvocationPlugin.swift; sourceTree = "<group>"; };
+		A11C0A730000000000000004 /* OneSystemActionInvocationCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OneSystemActionInvocationCoordinator.swift; sourceTree = "<group>"; };
 		A11C0A730000000000000021 /* OneVoiceInvocationCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OneVoiceInvocationCoordinatorTests.swift; sourceTree = "<group>"; };
+		A11C0A730000000000000024 /* OneSystemActionInvocationCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OneSystemActionInvocationCoordinatorTests.swift; sourceTree = "<group>"; };
 		A1B2C3D52F0E966A009FC3FD /* PersonalKnowledgeModelPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PersonalKnowledgeModelPlugin.swift; path = Plugins/PersonalKnowledgeModelPlugin.swift; sourceTree = "<group>"; };
 		A280438C2F21B1FC005B42F3 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		ABCDEF000000000000000001 /* HusshIMessageSessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HusshIMessageSessionStore.swift; path = Plugins/HusshIMessageSessionStore.swift; sourceTree = "<group>"; };
@@ -183,6 +187,7 @@
 				504EC3071FED79650016851F /* AppDelegate.swift */,
 				A11C0A740000000000000001 /* OneVoiceAppIntent.swift */,
 				A11C0A730000000000000002 /* OneVoiceInvocationCoordinator.swift */,
+				A11C0A730000000000000004 /* OneSystemActionInvocationCoordinator.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -213,6 +218,7 @@
 				844A95957616D891DBC4D212 /* NativeSupportTests.swift */,
 				A11C0A710000000000000091 /* LocationEnvelopeCryptoTests.swift */,
 				A11C0A730000000000000021 /* OneVoiceInvocationCoordinatorTests.swift */,
+				A11C0A730000000000000024 /* OneSystemActionInvocationCoordinatorTests.swift */,
 			);
 			path = AppTests;
 			sourceTree = "<group>";
@@ -420,6 +426,7 @@
 				FEBC1F9C14F1FB5C3D876D51 /* NativeSupportTests.swift in Sources */,
 				A11C0A710000000000000092 /* LocationEnvelopeCryptoTests.swift in Sources */,
 				A11C0A730000000000000022 /* OneVoiceInvocationCoordinatorTests.swift in Sources */,
+				A11C0A730000000000000023 /* OneSystemActionInvocationCoordinatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -431,6 +438,7 @@
 				A11C0A730000000000000011 /* OneVoiceAppIntent.swift in Sources */,
 				A11C0A730000000000000012 /* OneVoiceInvocationCoordinator.swift in Sources */,
 				A11C0A730000000000000013 /* HushhVoiceInvocationPlugin.swift in Sources */,
+				A11C0A730000000000000014 /* OneSystemActionInvocationCoordinator.swift in Sources */,
 				ABCDEF000000000000000002 /* HusshIMessageSessionStore.swift in Sources */,
 				D1F9F9122F0E966A009FC3FB /* KaiPlugin.swift in Sources */,
 				4DDFEE23E895EA15BE093A8C /* MyViewController.swift in Sources */,

--- a/hushh-webapp/ios/App/App/AppDelegate.swift
+++ b/hushh-webapp/ios/App/App/AppDelegate.swift
@@ -108,6 +108,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
         logNotificationSettings(context: "applicationDidBecomeActive")
         OneVoiceInvocationCoordinator.shared.publishAvailability(state: "foregrounded")
+        OneSystemActionInvocationCoordinator.shared.publishAvailability(state: "foregrounded")
     }
 
     func applicationWillTerminate(_ application: UIApplication) {

--- a/hushh-webapp/ios/App/App/MyViewController.swift
+++ b/hushh-webapp/ios/App/App/MyViewController.swift
@@ -157,7 +157,7 @@ class MyViewController: CAPBridgeViewController, WKScriptMessageHandler {
         print("   - HushhNotifications (Push Token Registration)")
         print("   - HushhLocation (Foreground Location)")
         print("   - HushhContacts (Contact Matching)")
-        print("   - HushhVoiceInvocation (Siri/App Shortcut handoff)")
+        print("   - HushhVoiceInvocation (Siri voice + generated action handoff)")
         
         // Verify plugins are actually accessible by the bridge
         verifyPluginRegistration()

--- a/hushh-webapp/ios/App/App/OneSystemActionInvocationCoordinator.swift
+++ b/hushh-webapp/ios/App/App/OneSystemActionInvocationCoordinator.swift
@@ -1,0 +1,524 @@
+import Foundation
+import OSLog
+import Security
+
+enum OneSystemActionID: String, Codable, CaseIterable, Sendable {
+    case openLocation = "location.open_now"
+    case openLocationMap = "location.open_map"
+    case openActiveShares = "location.open_active_shares"
+    case openSharedWithMe = "location.open_shared_with_me"
+    case openRequestsToReview = "location.open_needs_review"
+    case openLocationSettings = "location.open_settings"
+    case openTemporaryLink = "location.open_temporary_link"
+    case openCheckIn = "location.open_check_in"
+    case openEmergencySOS = "location.open_sos"
+    case shareLocation = "location.share_selected"
+    case askForLocation = "location.send_request"
+    case stopShare = "location.stop_share"
+    case pauseLocation = "location.pause_updates"
+    case resumeLocation = "location.resume_updates"
+    case createCircle = "location.create_circle"
+    case renameCircle = "location.rename_circle"
+
+    var requiresVault: Bool {
+        switch self {
+        case .shareLocation, .askForLocation, .stopShare, .pauseLocation,
+             .resumeLocation, .createCircle, .renameCircle:
+            return true
+        case .openLocation, .openLocationMap, .openActiveShares,
+             .openSharedWithMe, .openRequestsToReview, .openLocationSettings,
+             .openTemporaryLink, .openCheckIn, .openEmergencySOS:
+            return false
+        }
+    }
+
+    var allowedSlotNames: Set<String> {
+        switch self {
+        case .shareLocation, .askForLocation:
+            return ["person", "resolvedRecipientId", "duration_hours"]
+        case .stopShare:
+            return ["person", "resolvedRecipientId"]
+        case .createCircle:
+            return ["name", "kind"]
+        case .renameCircle:
+            return ["circle", "resolvedCircleId", "name"]
+        case .pauseLocation, .resumeLocation, .openLocation, .openLocationMap,
+             .openActiveShares, .openSharedWithMe, .openRequestsToReview,
+             .openLocationSettings, .openTemporaryLink, .openCheckIn,
+             .openEmergencySOS:
+            return []
+        }
+    }
+}
+
+struct PendingOneSystemActionInvocation: Codable, Equatable, Sendable {
+    static let supportedKind = "execute_one_action"
+    static let supportedSource = "siri_app_intent"
+
+    let id: String
+    let kind: String
+    let source: String
+    let actionID: OneSystemActionID
+    let slots: [String: String]
+    let requiresVault: Bool
+    let confirmedBySystem: Bool
+    let createdAt: Date
+    let expiresAt: Date
+
+    init(
+        id: String = UUID().uuidString,
+        actionID: OneSystemActionID,
+        slots: [String: String],
+        confirmedBySystem: Bool,
+        createdAt: Date,
+        expiresAt: Date
+    ) {
+        self.id = id
+        self.kind = Self.supportedKind
+        self.source = Self.supportedSource
+        self.actionID = actionID
+        self.slots = slots
+        self.requiresVault = actionID.requiresVault
+        self.confirmedBySystem = confirmedBySystem
+        self.createdAt = createdAt
+        self.expiresAt = expiresAt
+    }
+
+    var bridgePayload: [String: Any] {
+        [
+            "id": id,
+            "kind": kind,
+            "source": source,
+            "actionId": actionID.rawValue,
+            "slots": slots,
+            "requiresVault": requiresVault,
+            "confirmedBySystem": confirmedBySystem,
+            "createdAt": Int64(createdAt.timeIntervalSince1970 * 1_000),
+            "expiresAt": Int64(expiresAt.timeIntervalSince1970 * 1_000)
+        ]
+    }
+}
+
+struct OneSystemActionCompletion: Codable, Equatable, Sendable {
+    let id: String
+    let outcome: String
+    let summary: String
+    let finishedAt: Date
+}
+
+struct OneSystemEntityIndexEntry: Codable, Equatable, Sendable {
+    let id: String
+    let name: String
+}
+
+struct OneSystemEntityIndex: Codable, Equatable, Sendable {
+    let ownerID: String
+    let contacts: [OneSystemEntityIndexEntry]
+    let circles: [OneSystemEntityIndexEntry]
+    let updatedAt: Date
+}
+
+extension Notification.Name {
+    static let oneSystemActionInvocationAvailable = Notification.Name(
+        "ai.hushh.one.system-action-invocation-available"
+    )
+}
+
+protocol OneSystemSecureStoring: AnyObject {
+    func data(for key: String) -> Data?
+    func set(_ data: Data, for key: String) -> Bool
+    func remove(_ key: String)
+}
+
+final class OneSystemKeychainStore: OneSystemSecureStoring {
+    private let service: String
+
+    init(service: String = "com.hushh.app.system-actions") {
+        self.service = service
+    }
+
+    func data(for key: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess else {
+            return nil
+        }
+        return item as? Data
+    }
+
+    @discardableResult
+    func set(_ data: Data, for key: String) -> Bool {
+        let identity: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+        let update: [String: Any] = [kSecValueData as String: data]
+        let status = SecItemUpdate(identity as CFDictionary, update as CFDictionary)
+        if status == errSecSuccess { return true }
+        guard status == errSecItemNotFound else { return false }
+        var insert = identity
+        insert[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        insert[kSecValueData as String] = data
+        return SecItemAdd(insert as CFDictionary, nil) == errSecSuccess
+    }
+
+    func remove(_ key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}
+
+/// Secure, latest-wins handoff between App Intents and the existing web action
+/// runtime. This object stores no credentials, coordinates, routes, or speech.
+/// Parameter values are bounded and live in this-device-only Keychain records.
+final class OneSystemActionInvocationCoordinator: @unchecked Sendable {
+    static let shared = OneSystemActionInvocationCoordinator()
+    static let ttl: TimeInterval = 5 * 60
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "ai.hushh.one",
+        category: "SiriOneAction"
+    )
+    private static let allowedOutcomes: Set<String> = [
+        "succeeded", "started", "blocked", "failed", "expired", "cancelled"
+    ]
+    private static let maxSlotLength = 160
+    private static let maxEntityCount = 500
+
+    private let store: OneSystemSecureStoring
+    private let pendingKey: String
+    private let claimedKey: String
+    private let completionKey: String
+    private let entityIndexKey: String
+    private let now: () -> Date
+    private let currentUserID: () -> String?
+    private let lock = NSLock()
+
+    init(
+        store: OneSystemSecureStoring = OneSystemKeychainStore(),
+        keyPrefix: String = "one.system-action.v1",
+        now: @escaping () -> Date = Date.init,
+        currentUserID: @escaping () -> String? = OneSystemActionInvocationCoordinator.persistedAuthUserID
+    ) {
+        self.store = store
+        self.pendingKey = "\(keyPrefix).pending"
+        self.claimedKey = "\(keyPrefix).claimed"
+        self.completionKey = "\(keyPrefix).completion"
+        self.entityIndexKey = "\(keyPrefix).entities"
+        self.now = now
+        self.currentUserID = currentUserID
+    }
+
+    @discardableResult
+    func enqueue(
+        actionID: OneSystemActionID,
+        slots: [String: String] = [:],
+        confirmedBySystem: Bool = false
+    ) -> PendingOneSystemActionInvocation? {
+        guard let safeSlots = sanitizedSlots(slots, for: actionID) else {
+            return nil
+        }
+        let createdAt = now()
+        let invocation = PendingOneSystemActionInvocation(
+            actionID: actionID,
+            slots: safeSlots,
+            confirmedBySystem: confirmedBySystem,
+            createdAt: createdAt,
+            expiresAt: createdAt.addingTimeInterval(Self.ttl)
+        )
+
+        lock.lock()
+        let replaced = read(PendingOneSystemActionInvocation.self, key: pendingKey)
+        store.remove(claimedKey)
+        store.remove(completionKey)
+        let stored = write(invocation, key: pendingKey)
+        lock.unlock()
+        guard stored else { return nil }
+
+        if let replaced {
+            Self.log(state: "cancelled", invocation: replaced, outcome: "replaced")
+        }
+        publishAvailability(state: "requested")
+        return invocation
+    }
+
+    func pending() -> PendingOneSystemActionInvocation? {
+        lock.lock()
+        guard let invocation = readValidatedPending(key: pendingKey) else {
+            lock.unlock()
+            return nil
+        }
+        if invocation.expiresAt <= now() {
+            store.remove(pendingKey)
+            lock.unlock()
+            Self.log(state: "expired", invocation: invocation, outcome: "expired")
+            return nil
+        }
+        lock.unlock()
+        return invocation
+    }
+
+    func claim(id: String) -> Bool {
+        lock.lock()
+        guard let invocation = readValidatedPending(key: pendingKey), invocation.id == id else {
+            lock.unlock()
+            return false
+        }
+        if invocation.expiresAt <= now() {
+            store.remove(pendingKey)
+            lock.unlock()
+            Self.log(state: "expired", invocation: invocation, outcome: "expired")
+            return false
+        }
+        guard write(invocation, key: claimedKey) else {
+            lock.unlock()
+            return false
+        }
+        store.remove(pendingKey)
+        lock.unlock()
+        Self.log(state: "dispatched", invocation: invocation, outcome: "claimed")
+        return true
+    }
+
+    func complete(id: String, outcome: String, summary: String) {
+        let safeOutcome = Self.allowedOutcomes.contains(outcome) ? outcome : "failed"
+        let safeSummary = Self.sanitizeDisplayText(summary, maxLength: 240)
+        lock.lock()
+        let claimed = readValidatedPending(key: claimedKey)
+        let pending = readValidatedPending(key: pendingKey)
+        guard let invocation = claimed?.id == id ? claimed : (pending?.id == id ? pending : nil) else {
+            lock.unlock()
+            return
+        }
+        store.remove(pendingKey)
+        store.remove(claimedKey)
+        _ = write(
+            OneSystemActionCompletion(
+                id: id,
+                outcome: safeOutcome,
+                summary: safeSummary.isEmpty ? "HUSSH could not finish that action." : safeSummary,
+                finishedAt: now()
+            ),
+            key: completionKey
+        )
+        lock.unlock()
+        Self.log(state: safeOutcome, invocation: invocation, outcome: safeOutcome)
+    }
+
+    func completion(id: String) -> OneSystemActionCompletion? {
+        lock.lock()
+        let value = read(OneSystemActionCompletion.self, key: completionKey)
+        lock.unlock()
+        return value?.id == id ? value : nil
+    }
+
+    func waitForCompletion(id: String, timeout: TimeInterval = 25) async -> OneSystemActionCompletion? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let completion = completion(id: id) { return completion }
+            try? await Task.sleep(nanoseconds: 200_000_000)
+        }
+        return completion(id: id)
+    }
+
+    func cancelAll(outcome: String = "cancelled", clearEntityIndex: Bool = false) {
+        lock.lock()
+        let pending = readValidatedPending(key: pendingKey)
+        let claimed = readValidatedPending(key: claimedKey)
+        store.remove(pendingKey)
+        store.remove(claimedKey)
+        store.remove(completionKey)
+        if clearEntityIndex { store.remove(entityIndexKey) }
+        lock.unlock()
+        if let pending { Self.log(state: "cancelled", invocation: pending, outcome: outcome) }
+        if let claimed { Self.log(state: "cancelled", invocation: claimed, outcome: outcome) }
+    }
+
+    func publishAvailability(state: String) {
+        guard let invocation = pending() else { return }
+        Self.log(state: state, invocation: invocation)
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: .oneSystemActionInvocationAvailable,
+                object: self
+            )
+        }
+    }
+
+    @discardableResult
+    func updateEntityIndex(
+        ownerID: String,
+        contacts: [OneSystemEntityIndexEntry],
+        circles: [OneSystemEntityIndexEntry]
+    ) -> Bool {
+        let safeOwnerID = Self.sanitizeIdentifier(ownerID)
+        guard !safeOwnerID.isEmpty else { return false }
+        let index = OneSystemEntityIndex(
+            ownerID: safeOwnerID,
+            contacts: Self.sanitizeEntities(contacts),
+            circles: Self.sanitizeEntities(circles),
+            updatedAt: now()
+        )
+        lock.lock()
+        let result = write(index, key: entityIndexKey)
+        lock.unlock()
+        #if canImport(AppIntents)
+        if result, #available(iOS 16.0, *) {
+            Task { @MainActor in
+                HusshOneAppShortcuts.updateAppShortcutParameters()
+            }
+        }
+        #endif
+        return result
+    }
+
+    func contacts(matching query: String? = nil) -> [OneSystemEntityIndexEntry] {
+        filteredEntities(keyPath: \OneSystemEntityIndex.contacts, matching: query)
+    }
+
+    func circles(matching query: String? = nil) -> [OneSystemEntityIndexEntry] {
+        filteredEntities(keyPath: \OneSystemEntityIndex.circles, matching: query)
+    }
+
+    private func filteredEntities(
+        keyPath: KeyPath<OneSystemEntityIndex, [OneSystemEntityIndexEntry]>,
+        matching query: String?
+    ) -> [OneSystemEntityIndexEntry] {
+        lock.lock()
+        let index = read(OneSystemEntityIndex.self, key: entityIndexKey)
+        lock.unlock()
+        guard let index, index.ownerID == currentUserID() else { return [] }
+        let entities = index[keyPath: keyPath]
+        let target = Self.normalizedName(query ?? "")
+        guard !target.isEmpty else { return entities }
+        return entities
+            .map { ($0, Self.normalizedName($0.name)) }
+            .filter { $0.1 == target || $0.1.hasPrefix(target) || $0.1.contains(target) }
+            .sorted { left, right in
+                let leftExact = left.1 == target
+                let rightExact = right.1 == target
+                if leftExact != rightExact { return leftExact }
+                return left.0.name.localizedCaseInsensitiveCompare(right.0.name) == .orderedAscending
+            }
+            .map(\.0)
+    }
+
+    private func sanitizedSlots(
+        _ slots: [String: String],
+        for actionID: OneSystemActionID
+    ) -> [String: String]? {
+        guard Set(slots.keys).isSubset(of: actionID.allowedSlotNames) else { return nil }
+        var result: [String: String] = [:]
+        for (key, value) in slots {
+            guard value.count <= Self.maxSlotLength else { return nil }
+            let safe = Self.sanitizeDisplayText(value, maxLength: Self.maxSlotLength)
+            guard !safe.isEmpty else { continue }
+            result[key] = safe
+        }
+        return result
+    }
+
+    private func readValidatedPending(key: String) -> PendingOneSystemActionInvocation? {
+        guard let value = read(PendingOneSystemActionInvocation.self, key: key) else { return nil }
+        guard
+            value.kind == PendingOneSystemActionInvocation.supportedKind,
+            value.source == PendingOneSystemActionInvocation.supportedSource,
+            value.requiresVault == value.actionID.requiresVault,
+            sanitizedSlots(value.slots, for: value.actionID) == value.slots
+        else {
+            store.remove(key)
+            return nil
+        }
+        return value
+    }
+
+    private func read<T: Decodable>(_ type: T.Type, key: String) -> T? {
+        guard let data = store.data(for: key) else { return nil }
+        guard let value = try? JSONDecoder().decode(type, from: data) else {
+            store.remove(key)
+            return nil
+        }
+        return value
+    }
+
+    @discardableResult
+    private func write<T: Encodable>(_ value: T, key: String) -> Bool {
+        guard let data = try? JSONEncoder().encode(value) else { return false }
+        return store.set(data, for: key)
+    }
+
+    private static func sanitizeEntities(
+        _ entries: [OneSystemEntityIndexEntry]
+    ) -> [OneSystemEntityIndexEntry] {
+        var seen = Set<String>()
+        return entries.prefix(maxEntityCount).compactMap { entry in
+            let id = sanitizeIdentifier(entry.id)
+            let name = sanitizeDisplayText(entry.name, maxLength: 96)
+            guard !id.isEmpty, !name.isEmpty, seen.insert(id).inserted else { return nil }
+            return OneSystemEntityIndexEntry(id: id, name: name)
+        }
+    }
+
+    private static func sanitizeIdentifier(_ value: String) -> String {
+        let safe = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard safe.count <= 160 else { return "" }
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_:.") )
+        return safe.unicodeScalars.allSatisfy { allowed.contains($0) } ? safe : ""
+    }
+
+    private static func sanitizeDisplayText(_ value: String, maxLength: Int) -> String {
+        let collapsed = value
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return String(collapsed.prefix(maxLength))
+    }
+
+    private static func normalizedName(_ value: String) -> String {
+        sanitizeDisplayText(
+            value.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current),
+            maxLength: 160
+        ).lowercased()
+    }
+
+    private static func persistedAuthUserID() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.hushh.pda.auth",
+            kSecAttrAccount as String: "hushh_user_id",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        guard
+            SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+            let data = item as? Data,
+            let value = String(data: data, encoding: .utf8),
+            !value.isEmpty
+        else { return nil }
+        return value
+    }
+
+    private static func log(
+        state: String,
+        invocation: PendingOneSystemActionInvocation,
+        outcome: String? = nil
+    ) {
+        let durationMs = max(0, Int(Date().timeIntervalSince(invocation.createdAt) * 1_000))
+        let safeOutcome = outcome ?? "none"
+        logger.info(
+            "state=\(state, privacy: .public) request_id=\(invocation.id, privacy: .public) source=\(invocation.source, privacy: .public) action_id=\(invocation.actionID.rawValue, privacy: .public) outcome=\(safeOutcome, privacy: .public) duration_ms=\(durationMs, privacy: .public)"
+        )
+    }
+}

--- a/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
+++ b/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
@@ -1,16 +1,232 @@
 #if canImport(AppIntents)
 import AppIntents
+import Foundation
+
+// MARK: - Thin entities backed by the current One Location index
+
+@available(iOS 16.0, *)
+struct OneContactEntity: AppEntity, Identifiable, Hashable {
+    let id: String
+    let name: String
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "HUSSH Contact"
+    static let defaultQuery = OneContactEntityQuery()
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(name)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct OneContactEntityQuery: EntityStringQuery {
+    func entities(for identifiers: [OneContactEntity.ID]) async throws -> [OneContactEntity] {
+        let requested = Set(identifiers)
+        return OneSystemActionInvocationCoordinator.shared
+            .contacts()
+            .filter { requested.contains($0.id) }
+            .map { OneContactEntity(id: $0.id, name: $0.name) }
+    }
+
+    func entities(matching string: String) async throws -> [OneContactEntity] {
+        OneSystemActionInvocationCoordinator.shared
+            .contacts(matching: string)
+            .map { OneContactEntity(id: $0.id, name: $0.name) }
+    }
+
+    func suggestedEntities() async throws -> [OneContactEntity] {
+        OneSystemActionInvocationCoordinator.shared
+            .contacts()
+            .map { OneContactEntity(id: $0.id, name: $0.name) }
+    }
+}
+
+@available(iOS 16.0, *)
+struct OneCircleEntity: AppEntity, Identifiable, Hashable {
+    let id: String
+    let name: String
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "HUSSH Circle"
+    static let defaultQuery = OneCircleEntityQuery()
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(name)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct OneCircleEntityQuery: EntityStringQuery {
+    func entities(for identifiers: [OneCircleEntity.ID]) async throws -> [OneCircleEntity] {
+        let requested = Set(identifiers)
+        return OneSystemActionInvocationCoordinator.shared
+            .circles()
+            .filter { requested.contains($0.id) }
+            .map { OneCircleEntity(id: $0.id, name: $0.name) }
+    }
+
+    func entities(matching string: String) async throws -> [OneCircleEntity] {
+        OneSystemActionInvocationCoordinator.shared
+            .circles(matching: string)
+            .map { OneCircleEntity(id: $0.id, name: $0.name) }
+    }
+
+    func suggestedEntities() async throws -> [OneCircleEntity] {
+        OneSystemActionInvocationCoordinator.shared
+            .circles()
+            .map { OneCircleEntity(id: $0.id, name: $0.name) }
+    }
+}
+
+@available(iOS 16.0, *)
+enum OneLocationDuration: String, AppEnum {
+    case fifteenMinutes = "0.25"
+    case thirtyMinutes = "0.5"
+    case oneHour = "1"
+    case twoHours = "2"
+    case fourHours = "4"
+    case eightHours = "8"
+    case twentyFourHours = "24"
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Location Duration"
+    static let caseDisplayRepresentations: [Self: DisplayRepresentation] = [
+        .fifteenMinutes: "15 minutes",
+        .thirtyMinutes: "30 minutes",
+        .oneHour: "1 hour",
+        .twoHours: "2 hours",
+        .fourHours: "4 hours",
+        .eightHours: "8 hours",
+        .twentyFourHours: "24 hours"
+    ]
+}
+
+@available(iOS 16.0, *)
+enum OneLocationStateIntentValue: String, AppEnum {
+    case on
+    case off
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Location State"
+    static let caseDisplayRepresentations: [Self: DisplayRepresentation] = [
+        .on: "On",
+        .off: "Off"
+    ]
+}
+
+// MARK: - Shared App Intent adapter
+
+@available(iOS 16.0, *)
+struct OneAppIntentActionRequest: Equatable {
+    let actionID: OneSystemActionID
+    let slots: [String: String]
+    let confirmedBySystem: Bool
+}
+
+@available(iOS 16.0, *)
+enum OneAppIntentActionRequestFactory {
+    static func shareLocation(
+        recipientID: String,
+        recipientName: String,
+        duration: OneLocationDuration
+    ) -> OneAppIntentActionRequest {
+        .init(
+            actionID: .shareLocation,
+            slots: [
+                "person": recipientName,
+                "resolvedRecipientId": recipientID,
+                "duration_hours": duration.rawValue
+            ],
+            confirmedBySystem: true
+        )
+    }
+
+    static func askForLocation(
+        personID: String,
+        personName: String,
+        duration: OneLocationDuration
+    ) -> OneAppIntentActionRequest {
+        .init(
+            actionID: .askForLocation,
+            slots: [
+                "person": personName,
+                "resolvedRecipientId": personID,
+                "duration_hours": duration.rawValue
+            ],
+            confirmedBySystem: true
+        )
+    }
+
+    static func stopShare(personID: String, personName: String) -> OneAppIntentActionRequest {
+        .init(
+            actionID: .stopShare,
+            slots: ["person": personName, "resolvedRecipientId": personID],
+            confirmedBySystem: true
+        )
+    }
+
+    static func setLocationState(_ state: OneLocationStateIntentValue) -> OneAppIntentActionRequest {
+        .init(
+            actionID: state == .on ? .resumeLocation : .pauseLocation,
+            slots: [:],
+            confirmedBySystem: state == .on
+        )
+    }
+
+    static func createCircle(name: String) -> OneAppIntentActionRequest {
+        .init(
+            actionID: .createCircle,
+            slots: ["name": name],
+            confirmedBySystem: true
+        )
+    }
+
+    static func renameCircle(
+        circleID: String,
+        circleName: String,
+        newName: String
+    ) -> OneAppIntentActionRequest {
+        .init(
+            actionID: .renameCircle,
+            slots: [
+                "circle": circleName,
+                "resolvedCircleId": circleID,
+                "name": newName
+            ],
+            confirmedBySystem: true
+        )
+    }
+
+    static func open(_ actionID: OneSystemActionID) -> OneAppIntentActionRequest {
+        .init(actionID: actionID, slots: [:], confirmedBySystem: false)
+    }
+}
+
+@available(iOS 16.0, *)
+private enum OneAppIntentActionExecutor {
+    static func run(_ request: OneAppIntentActionRequest) async -> String {
+        guard let invocation = OneSystemActionInvocationCoordinator.shared.enqueue(
+            actionID: request.actionID,
+            slots: request.slots,
+            confirmedBySystem: request.confirmedBySystem
+        ) else {
+            return "HUSSH could not prepare that action."
+        }
+        guard let completion = await OneSystemActionInvocationCoordinator.shared.waitForCompletion(
+            id: invocation.id
+        ) else {
+            return "Continue in HUSSH to finish. Your request is waiting."
+        }
+        return completion.summary
+    }
+}
+
+// MARK: - Conversational fallback
 
 @available(iOS 16.0, *)
 struct TalkToHusshOneIntent: AppIntent {
     static let title: LocalizedStringResource = "Talk to One"
     static let description = IntentDescription(
-        "Open Hussh One and begin a conversation with your private agent."
+        "Open HUSSH One and begin a conversation with your private agent."
     )
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
-
-    // AppIntent uses this on iOS 16-25. iOS 26 uses supportedModes below.
     static let openAppWhenRun = true
 
     @available(iOS 26.0, *)
@@ -22,9 +238,427 @@ struct TalkToHusshOneIntent: AppIntent {
     }
 }
 
+// MARK: - Direct Location actions
+
+@available(iOS 16.0, *)
+struct ShareLocationWithOneIntent: AppIntent {
+    static let title: LocalizedStringResource = "Share Location"
+    static let description = IntentDescription(
+        "Share your live location with an existing HUSSH connection."
+    )
+    static let authenticationPolicy: IntentAuthenticationPolicy =
+        .requiresLocalDeviceAuthentication
+    static let openAppWhenRun = true
+
+    @available(iOS 26.0, *)
+    static let supportedModes: IntentModes = [.foreground(.immediate)]
+
+    @Parameter(title: "Person")
+    var recipient: OneContactEntity
+
+    @Parameter(title: "Duration")
+    var duration: OneLocationDuration
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Share location with \(\.$recipient) for \(\.$duration)")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await requestConfirmation()
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.shareLocation(
+                recipientID: recipient.id,
+                recipientName: recipient.name,
+                duration: duration
+            )
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct AskForLocationWithOneIntent: AppIntent {
+    static let title: LocalizedStringResource = "Ask for Location"
+    static let description = IntentDescription(
+        "Ask an existing HUSSH connection to share their location."
+    )
+    static let authenticationPolicy: IntentAuthenticationPolicy =
+        .requiresLocalDeviceAuthentication
+    static let openAppWhenRun = true
+
+    @available(iOS 26.0, *)
+    static let supportedModes: IntentModes = [.foreground(.immediate)]
+
+    @Parameter(title: "Person")
+    var person: OneContactEntity
+
+    @Parameter(title: "Duration")
+    var duration: OneLocationDuration
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Ask \(\.$person) for location for \(\.$duration)")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await requestConfirmation()
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.askForLocation(
+                personID: person.id,
+                personName: person.name,
+                duration: duration
+            )
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct StopLocationSharingWithOneIntent: AppIntent {
+    static let title: LocalizedStringResource = "Stop Location Sharing"
+    static let description = IntentDescription(
+        "Stop sharing with one person, or pause all location updates."
+    )
+    static let authenticationPolicy: IntentAuthenticationPolicy =
+        .requiresLocalDeviceAuthentication
+    static let openAppWhenRun = true
+
+    @available(iOS 26.0, *)
+    static let supportedModes: IntentModes = [.foreground(.immediate)]
+
+    @Parameter(title: "Person")
+    var person: OneContactEntity?
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let summary: String
+        if let person {
+            try await requestConfirmation()
+            summary = await OneAppIntentActionExecutor.run(
+                OneAppIntentActionRequestFactory.stopShare(
+                    personID: person.id,
+                    personName: person.name
+                )
+            )
+        } else {
+            summary = await OneAppIntentActionExecutor.run(
+                OneAppIntentActionRequestFactory.setLocationState(.off)
+            )
+        }
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct SetOneLocationStateIntent: AppIntent {
+    static let title: LocalizedStringResource = "Set Location State"
+    static let description = IntentDescription(
+        "Turn HUSSH location updates on or off."
+    )
+    static let authenticationPolicy: IntentAuthenticationPolicy =
+        .requiresLocalDeviceAuthentication
+    static let openAppWhenRun = true
+
+    @available(iOS 26.0, *)
+    static let supportedModes: IntentModes = [.foreground(.immediate)]
+
+    @Parameter(title: "State")
+    var state: OneLocationStateIntentValue
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Turn HUSSH location \(\.$state)")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        if state == .on { try await requestConfirmation() }
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.setLocationState(state)
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct CreateOneCircleIntent: AppIntent {
+    static let title: LocalizedStringResource = "Create a Circle"
+    static let description = IntentDescription("Create an empty HUSSH Circle.")
+    static let authenticationPolicy: IntentAuthenticationPolicy =
+        .requiresLocalDeviceAuthentication
+    static let openAppWhenRun = true
+
+    @available(iOS 26.0, *)
+    static let supportedModes: IntentModes = [.foreground(.immediate)]
+
+    @Parameter(title: "Name")
+    var name: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Create a Circle named \(\.$name)")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await requestConfirmation()
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.createCircle(name: name)
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct RenameOneCircleIntent: AppIntent {
+    static let title: LocalizedStringResource = "Rename a Circle"
+    static let description = IntentDescription("Rename an existing HUSSH Circle.")
+    static let authenticationPolicy: IntentAuthenticationPolicy =
+        .requiresLocalDeviceAuthentication
+    static let openAppWhenRun = true
+
+    @available(iOS 26.0, *)
+    static let supportedModes: IntentModes = [.foreground(.immediate)]
+
+    @Parameter(title: "Circle")
+    var circle: OneCircleEntity
+
+    @Parameter(title: "New Name")
+    var name: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Rename \(\.$circle) to \(\.$name)")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await requestConfirmation()
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.renameCircle(
+                circleID: circle.id,
+                circleName: circle.name,
+                newName: name
+            )
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+// MARK: - Existing UI destinations (UI is the canonical executor)
+
+@available(iOS 16.0, *)
+protocol OneLocationOpenIntent: AppIntent {}
+
+@available(iOS 16.0, *)
+extension OneLocationOpenIntent {
+    static var authenticationPolicy: IntentAuthenticationPolicy {
+        .requiresLocalDeviceAuthentication
+    }
+    static var openAppWhenRun: Bool { true }
+
+    @available(iOS 26.0, *)
+    static var supportedModes: IntentModes { [.foreground(.immediate)] }
+}
+
+@available(iOS 16.0, *)
+struct OpenOneLocationIntent: OneLocationOpenIntent {
+    static let title: LocalizedStringResource = "Open Location Agent"
+    static let description = IntentDescription("Open the existing HUSSH Location experience.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.open(.openLocation)
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct OpenOneLocationMapIntent: OneLocationOpenIntent {
+    static let title: LocalizedStringResource = "Open Location Map"
+    static let description = IntentDescription("Open the existing HUSSH location map.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.open(.openLocationMap)
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct ViewOneActiveSharesIntent: OneLocationOpenIntent {
+    static let title: LocalizedStringResource = "View Active Location Shares"
+    static let description = IntentDescription("Open the list of active HUSSH location shares.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.open(.openActiveShares)
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct ViewOneSharedLocationsIntent: OneLocationOpenIntent {
+    static let title: LocalizedStringResource = "View Locations Shared With Me"
+    static let description = IntentDescription("Open locations currently shared with you.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.open(.openSharedWithMe)
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct ReviewOneLocationRequestsIntent: OneLocationOpenIntent {
+    static let title: LocalizedStringResource = "Review Location Requests"
+    static let description = IntentDescription("Open HUSSH location requests awaiting review.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.open(.openRequestsToReview)
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct OpenOneLocationSettingsIntent: OneLocationOpenIntent {
+    static let title: LocalizedStringResource = "Open Location Privacy Settings"
+    static let description = IntentDescription("Open HUSSH Location privacy settings.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.open(.openLocationSettings)
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct CreateOneTemporaryLocationLinkIntent: OneLocationOpenIntent {
+    static let title: LocalizedStringResource = "Create Temporary Location Link"
+    static let description = IntentDescription("Open the existing temporary-link composer.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.open(.openTemporaryLink)
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct CheckInWithOneIntent: OneLocationOpenIntent {
+    static let title: LocalizedStringResource = "Check In"
+    static let description = IntentDescription(
+        "Open the existing HUSSH Check-In flow to choose recipients and review before sending."
+    )
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.open(.openCheckIn)
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+@available(iOS 16.0, *)
+struct OpenOneEmergencySOSIntent: OneLocationOpenIntent {
+    static let title: LocalizedStringResource = "Open Emergency SOS"
+    static let description = IntentDescription(
+        "Open the existing HUSSH SOS review screen without sending an alert."
+    )
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.open(.openEmergencySOS)
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
+// MARK: - Zero-setup Siri phrases (Apple limits an app to ten App Shortcuts)
+
 @available(iOS 16.0, *)
 struct HusshOneAppShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: ShareLocationWithOneIntent(),
+            phrases: [
+                "Share my location with \(\.$recipient) using \(.applicationName)",
+                "Let \(\.$recipient) see my location with \(.applicationName)"
+            ],
+            shortTitle: "Share Location",
+            systemImageName: "location.fill"
+        )
+        AppShortcut(
+            intent: AskForLocationWithOneIntent(),
+            phrases: [
+                "Ask \(\.$person) for location using \(.applicationName)",
+                "Request \(\.$person)'s location with \(.applicationName)"
+            ],
+            shortTitle: "Ask for Location",
+            systemImageName: "location.magnifyingglass"
+        )
+        AppShortcut(
+            intent: StopLocationSharingWithOneIntent(),
+            phrases: [
+                "Stop sharing location with \(\.$person) using \(.applicationName)",
+                "Stop my location in \(.applicationName)"
+            ],
+            shortTitle: "Stop Sharing",
+            systemImageName: "location.slash.fill"
+        )
+        AppShortcut(
+            intent: SetOneLocationStateIntent(),
+            phrases: [
+                "Turn my \(.applicationName) location \(\.$state)"
+            ],
+            shortTitle: "Location On or Off",
+            systemImageName: "location.circle"
+        )
+        AppShortcut(
+            intent: CreateOneCircleIntent(),
+            phrases: [
+                "Create a Circle in \(.applicationName)",
+                "Make a new Circle with \(.applicationName)"
+            ],
+            shortTitle: "Create Circle",
+            systemImageName: "person.3.fill"
+        )
+        AppShortcut(
+            intent: CheckInWithOneIntent(),
+            phrases: [
+                "Check in with \(.applicationName)",
+                "Open Check In in \(.applicationName)"
+            ],
+            shortTitle: "Check In",
+            systemImageName: "checkmark.circle.fill"
+        )
+        AppShortcut(
+            intent: OpenOneLocationIntent(),
+            phrases: [
+                "Open Location Agent in \(.applicationName)",
+                "Open Location in \(.applicationName)"
+            ],
+            shortTitle: "Open Location",
+            systemImageName: "location.circle.fill"
+        )
+        AppShortcut(
+            intent: OpenOneLocationMapIntent(),
+            phrases: [
+                "Open my location map in \(.applicationName)",
+                "Show the location map in \(.applicationName)"
+            ],
+            shortTitle: "Location Map",
+            systemImageName: "map.fill"
+        )
+        AppShortcut(
+            intent: ReviewOneLocationRequestsIntent(),
+            phrases: [
+                "Review location requests in \(.applicationName)",
+                "Show pending location requests in \(.applicationName)"
+            ],
+            shortTitle: "Review Requests",
+            systemImageName: "person.crop.circle.badge.questionmark"
+        )
         AppShortcut(
             intent: TalkToHusshOneIntent(),
             phrases: [

--- a/hushh-webapp/ios/App/App/Plugins/HushhAuthPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhAuthPlugin.swift
@@ -53,6 +53,10 @@ public class HushhAuthPlugin: CAPPlugin, CAPBridgedPlugin {
         SecItemDelete(query as CFDictionary)
         HusshIMessageSessionStore.shared.clearSilently()
         OneVoiceInvocationCoordinator.shared.cancelPending(outcome: "sign_out")
+        OneSystemActionInvocationCoordinator.shared.cancelAll(
+            outcome: "sign_out",
+            clearEntityIndex: true
+        )
     }
 
     private func keychainSet(_ value: String, forKey key: String) {
@@ -384,6 +388,11 @@ public class HushhAuthPlugin: CAPPlugin, CAPBridgedPlugin {
         keychainDelete("hushh_user_email_verified")
         keychainDelete("hushh_user_phone_number")
         HusshIMessageSessionStore.shared.clearSilently()
+        OneVoiceInvocationCoordinator.shared.cancelPending(outcome: "sign_out")
+        OneSystemActionInvocationCoordinator.shared.cancelAll(
+            outcome: "sign_out",
+            clearEntityIndex: true
+        )
         
         print("✅ [\(TAG)] Signed out")
         call.resolve()

--- a/hushh-webapp/ios/App/App/Plugins/HushhVoiceInvocationPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhVoiceInvocationPlugin.swift
@@ -8,10 +8,16 @@ public final class HushhVoiceInvocationPlugin: CAPPlugin, CAPBridgedPlugin {
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "getPendingInvocation", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "claimInvocation", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "completeInvocation", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "completeInvocation", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getPendingActionInvocation", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "claimActionInvocation", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "completeActionInvocation", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "updateActionEntityIndex", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "clearActionState", returnType: CAPPluginReturnPromise)
     ]
 
     private var availabilityObserver: NSObjectProtocol?
+    private var actionAvailabilityObserver: NSObjectProtocol?
 
     public override func load() {
         availabilityObserver = NotificationCenter.default.addObserver(
@@ -21,12 +27,23 @@ public final class HushhVoiceInvocationPlugin: CAPPlugin, CAPBridgedPlugin {
         ) { [weak self] _ in
             self?.emitAvailability()
         }
+        actionAvailabilityObserver = NotificationCenter.default.addObserver(
+            forName: .oneSystemActionInvocationAvailable,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.emitActionAvailability()
+        }
         OneVoiceInvocationCoordinator.shared.publishAvailability(state: "bridge_ready")
+        OneSystemActionInvocationCoordinator.shared.publishAvailability(state: "bridge_ready")
     }
 
     deinit {
         if let availabilityObserver {
             NotificationCenter.default.removeObserver(availabilityObserver)
+        }
+        if let actionAvailabilityObserver {
+            NotificationCenter.default.removeObserver(actionAvailabilityObserver)
         }
     }
 
@@ -63,6 +80,68 @@ public final class HushhVoiceInvocationPlugin: CAPPlugin, CAPBridgedPlugin {
         call.resolve()
     }
 
+    @objc func getPendingActionInvocation(_ call: CAPPluginCall) {
+        guard let invocation = OneSystemActionInvocationCoordinator.shared.pending() else {
+            call.resolve([:])
+            return
+        }
+        call.resolve(invocation.bridgePayload)
+    }
+
+    @objc func claimActionInvocation(_ call: CAPPluginCall) {
+        guard let id = call.getString("id"), !id.isEmpty else {
+            call.reject("A non-empty action invocation id is required.")
+            return
+        }
+        call.resolve([
+            "claimed": OneSystemActionInvocationCoordinator.shared.claim(id: id)
+        ])
+    }
+
+    @objc func completeActionInvocation(_ call: CAPPluginCall) {
+        guard let id = call.getString("id"), !id.isEmpty else {
+            call.reject("A non-empty action invocation id is required.")
+            return
+        }
+        guard let outcome = call.getString("outcome"), !outcome.isEmpty else {
+            call.reject("An action completion outcome is required.")
+            return
+        }
+        let summary = call.getString("summary") ?? "HUSSH could not finish that action."
+        OneSystemActionInvocationCoordinator.shared.complete(
+            id: id,
+            outcome: outcome,
+            summary: summary
+        )
+        call.resolve()
+    }
+
+    @objc func updateActionEntityIndex(_ call: CAPPluginCall) {
+        guard let ownerID = call.getString("ownerId"), !ownerID.isEmpty else {
+            call.reject("A non-empty owner id is required.")
+            return
+        }
+        let contacts = Self.parseEntities(call.getArray("contacts", JSObject.self) ?? [])
+        let circles = Self.parseEntities(call.getArray("circles", JSObject.self) ?? [])
+        guard OneSystemActionInvocationCoordinator.shared.updateEntityIndex(
+            ownerID: ownerID,
+            contacts: contacts,
+            circles: circles
+        ) else {
+            call.reject("The HUSSH action entity index could not be updated.")
+            return
+        }
+        call.resolve(["updated": true])
+    }
+
+    @objc func clearActionState(_ call: CAPPluginCall) {
+        OneSystemActionInvocationCoordinator.shared.cancelAll(
+            outcome: call.getString("outcome") ?? "cancelled",
+            clearEntityIndex: call.getBool("clearEntityIndex") ?? false
+        )
+        call.resolve()
+    }
+
     private func emitAvailability() {
         guard let invocation = OneVoiceInvocationCoordinator.shared.pending() else {
             return
@@ -72,5 +151,26 @@ public final class HushhVoiceInvocationPlugin: CAPPlugin, CAPBridgedPlugin {
             data: invocation.bridgePayload,
             retainUntilConsumed: true
         )
+    }
+
+    private func emitActionAvailability() {
+        guard let invocation = OneSystemActionInvocationCoordinator.shared.pending() else {
+            return
+        }
+        notifyListeners(
+            "systemActionInvocationAvailable",
+            data: invocation.bridgePayload,
+            retainUntilConsumed: true
+        )
+    }
+
+    private static func parseEntities(_ values: [JSObject]) -> [OneSystemEntityIndexEntry] {
+        values.compactMap { value in
+            guard
+                let id = value["id"] as? String,
+                let name = value["name"] as? String
+            else { return nil }
+            return OneSystemEntityIndexEntry(id: id, name: name)
+        }
     }
 }

--- a/hushh-webapp/ios/App/AppTests/OneSystemActionInvocationCoordinatorTests.swift
+++ b/hushh-webapp/ios/App/AppTests/OneSystemActionInvocationCoordinatorTests.swift
@@ -1,0 +1,292 @@
+import Foundation
+import XCTest
+@testable import App
+
+private final class MemorySystemActionStore: OneSystemSecureStoring {
+    var values: [String: Data] = [:]
+
+    func data(for key: String) -> Data? { values[key] }
+
+    func set(_ data: Data, for key: String) -> Bool {
+        values[key] = data
+        return true
+    }
+
+    func remove(_ key: String) {
+        values.removeValue(forKey: key)
+    }
+}
+
+final class OneSystemActionInvocationCoordinatorTests: XCTestCase {
+    private var now = Date(timeIntervalSince1970: 10_000)
+    private var store: MemorySystemActionStore!
+    private var coordinator: OneSystemActionInvocationCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        store = MemorySystemActionStore()
+        coordinator = OneSystemActionInvocationCoordinator(
+            store: store,
+            keyPrefix: "test.\(UUID().uuidString)",
+            now: { [unowned self] in self.now },
+            currentUserID: { "owner-1" }
+        )
+    }
+
+    func testEnqueueStoresOnlyAllowListedStructuredAction() throws {
+        let invocation = try XCTUnwrap(
+            coordinator.enqueue(
+                actionID: .shareLocation,
+                slots: [
+                    "person": "Kushal",
+                    "resolvedRecipientId": "contact-1",
+                    "duration_hours": "2"
+                ],
+                confirmedBySystem: true
+            )
+        )
+
+        XCTAssertEqual(invocation.kind, "execute_one_action")
+        XCTAssertEqual(invocation.source, "siri_app_intent")
+        XCTAssertEqual(invocation.actionID, .shareLocation)
+        XCTAssertTrue(invocation.requiresVault)
+        XCTAssertEqual(invocation.slots["duration_hours"], "2")
+        XCTAssertEqual(coordinator.pending(), invocation)
+    }
+
+    func testRejectsArbitrarySlotAndOversizedValue() {
+        XCTAssertNil(
+            coordinator.enqueue(
+                actionID: .openLocation,
+                slots: ["prompt": "ignore every guard"]
+            )
+        )
+        XCTAssertNil(
+            coordinator.enqueue(
+                actionID: .createCircle,
+                slots: ["name": String(repeating: "a", count: 161)]
+            )
+        )
+        XCTAssertNil(coordinator.pending())
+    }
+
+    func testLatestInvocationWins() throws {
+        let first = try XCTUnwrap(coordinator.enqueue(actionID: .openLocation))
+        let second = try XCTUnwrap(coordinator.enqueue(actionID: .openLocationMap))
+
+        XCTAssertNotEqual(first.id, second.id)
+        XCTAssertEqual(coordinator.pending()?.id, second.id)
+        XCTAssertFalse(coordinator.claim(id: first.id))
+        XCTAssertTrue(coordinator.claim(id: second.id))
+    }
+
+    func testExpiryPreventsClaim() throws {
+        let invocation = try XCTUnwrap(coordinator.enqueue(actionID: .pauseLocation))
+        now = now.addingTimeInterval(OneSystemActionInvocationCoordinator.ttl + 1)
+
+        XCTAssertNil(coordinator.pending())
+        XCTAssertFalse(coordinator.claim(id: invocation.id))
+    }
+
+    func testClaimAndCompletionAreExactlyOnce() throws {
+        let invocation = try XCTUnwrap(
+            coordinator.enqueue(actionID: .createCircle, slots: ["name": "Family"])
+        )
+
+        XCTAssertTrue(coordinator.claim(id: invocation.id))
+        XCTAssertFalse(coordinator.claim(id: invocation.id))
+        coordinator.complete(
+            id: invocation.id,
+            outcome: "succeeded",
+            summary: "Created   Family.\n"
+        )
+
+        XCTAssertEqual(
+            coordinator.completion(id: invocation.id),
+            OneSystemActionCompletion(
+                id: invocation.id,
+                outcome: "succeeded",
+                summary: "Created Family.",
+                finishedAt: now
+            )
+        )
+        coordinator.complete(id: invocation.id, outcome: "failed", summary: "late")
+        XCTAssertEqual(coordinator.completion(id: invocation.id)?.outcome, "succeeded")
+    }
+
+    func testCancellationClearsPendingClaimedCompletionAndEntityIndex() throws {
+        let invocation = try XCTUnwrap(coordinator.enqueue(actionID: .openLocation))
+        XCTAssertTrue(coordinator.claim(id: invocation.id))
+        XCTAssertTrue(
+            coordinator.updateEntityIndex(
+                ownerID: "owner-1",
+                contacts: [.init(id: "contact-1", name: "Kushal")],
+                circles: [.init(id: "circle-1", name: "Family")]
+            )
+        )
+
+        coordinator.cancelAll(outcome: "sign_out", clearEntityIndex: true)
+
+        XCTAssertNil(coordinator.pending())
+        XCTAssertNil(coordinator.completion(id: invocation.id))
+        XCTAssertTrue(coordinator.contacts().isEmpty)
+        XCTAssertTrue(coordinator.circles().isEmpty)
+    }
+
+    func testEntityIndexResolvesExactPrefixAndAmbiguityWithoutGuessing() {
+        XCTAssertTrue(
+            coordinator.updateEntityIndex(
+                ownerID: "owner-1",
+                contacts: [
+                    .init(id: "one", name: "Alex Chen"),
+                    .init(id: "two", name: "Alex Kim"),
+                    .init(id: "three", name: "Kushal")
+                ],
+                circles: [
+                    .init(id: "family", name: "Family"),
+                    .init(id: "trip", name: "Family Trip")
+                ]
+            )
+        )
+
+        XCTAssertEqual(coordinator.contacts(matching: "Kushal").map(\.id), ["three"])
+        XCTAssertEqual(
+            Set(coordinator.contacts(matching: "Alex").map(\.id)),
+            Set(["one", "two"])
+        )
+        XCTAssertEqual(coordinator.circles(matching: "Family").first?.id, "family")
+        XCTAssertEqual(coordinator.circles(matching: "Family").count, 2)
+    }
+
+    func testEntityIndexFailsClosedForAnotherSignedInOwner() {
+        let otherCoordinator = OneSystemActionInvocationCoordinator(
+            store: store,
+            keyPrefix: "shared",
+            now: { self.now },
+            currentUserID: { "owner-2" }
+        )
+        XCTAssertTrue(
+            otherCoordinator.updateEntityIndex(
+                ownerID: "owner-1",
+                contacts: [.init(id: "one", name: "Private Name")],
+                circles: []
+            )
+        )
+        XCTAssertTrue(otherCoordinator.contacts().isEmpty)
+    }
+
+    func testActionCatalogMatchesGeneratedLocationContractIdentifiers() {
+        XCTAssertEqual(OneSystemActionID.allCases.count, 16)
+        XCTAssertEqual(OneSystemActionID.shareLocation.rawValue, "location.share_selected")
+        XCTAssertEqual(OneSystemActionID.askForLocation.rawValue, "location.send_request")
+        XCTAssertEqual(OneSystemActionID.stopShare.rawValue, "location.stop_share")
+        XCTAssertFalse(OneSystemActionID.openLocation.requiresVault)
+        XCTAssertTrue(OneSystemActionID.resumeLocation.requiresVault)
+    }
+
+    @available(iOS 16.0, *)
+    func testDirectIntentFactoriesMapPeopleAndSlotsToCanonicalActions() {
+        XCTAssertEqual(
+            OneAppIntentActionRequestFactory.shareLocation(
+                recipientID: "contact-1",
+                recipientName: "Kushal",
+                duration: .twoHours
+            ),
+            OneAppIntentActionRequest(
+                actionID: .shareLocation,
+                slots: [
+                    "person": "Kushal",
+                    "resolvedRecipientId": "contact-1",
+                    "duration_hours": "2"
+                ],
+                confirmedBySystem: true
+            )
+        )
+        XCTAssertEqual(
+            OneAppIntentActionRequestFactory.askForLocation(
+                personID: "contact-2",
+                personName: "Mom",
+                duration: .thirtyMinutes
+            ),
+            OneAppIntentActionRequest(
+                actionID: .askForLocation,
+                slots: [
+                    "person": "Mom",
+                    "resolvedRecipientId": "contact-2",
+                    "duration_hours": "0.5"
+                ],
+                confirmedBySystem: true
+            )
+        )
+        XCTAssertEqual(
+            OneAppIntentActionRequestFactory.stopShare(
+                personID: "contact-3",
+                personName: "Dad"
+            ),
+            OneAppIntentActionRequest(
+                actionID: .stopShare,
+                slots: ["person": "Dad", "resolvedRecipientId": "contact-3"],
+                confirmedBySystem: true
+            )
+        )
+    }
+
+    @available(iOS 16.0, *)
+    func testDirectIntentFactoriesMapLocationAndCircleMutations() {
+        XCTAssertEqual(
+            OneAppIntentActionRequestFactory.setLocationState(.off),
+            .init(actionID: .pauseLocation, slots: [:], confirmedBySystem: false)
+        )
+        XCTAssertEqual(
+            OneAppIntentActionRequestFactory.setLocationState(.on),
+            .init(actionID: .resumeLocation, slots: [:], confirmedBySystem: true)
+        )
+        XCTAssertEqual(
+            OneAppIntentActionRequestFactory.createCircle(name: "Family"),
+            .init(
+                actionID: .createCircle,
+                slots: ["name": "Family"],
+                confirmedBySystem: true
+            )
+        )
+        XCTAssertEqual(
+            OneAppIntentActionRequestFactory.renameCircle(
+                circleID: "circle-1",
+                circleName: "Family",
+                newName: "Home"
+            ),
+            .init(
+                actionID: .renameCircle,
+                slots: [
+                    "circle": "Family",
+                    "resolvedCircleId": "circle-1",
+                    "name": "Home"
+                ],
+                confirmedBySystem: true
+            )
+        )
+    }
+
+    @available(iOS 16.0, *)
+    func testAllNineDestinationIntentsRemainNonMutatingAdapters() {
+        let destinations: Set<OneSystemActionID> = [
+            .openLocation,
+            .openLocationMap,
+            .openActiveShares,
+            .openSharedWithMe,
+            .openRequestsToReview,
+            .openLocationSettings,
+            .openTemporaryLink,
+            .openCheckIn,
+            .openEmergencySOS
+        ]
+
+        for actionID in destinations {
+            XCTAssertEqual(
+                OneAppIntentActionRequestFactory.open(actionID),
+                .init(actionID: actionID, slots: [:], confirmedBySystem: false)
+            )
+            XCTAssertFalse(actionID.requiresVault)
+        }
+    }
+}

--- a/hushh-webapp/lib/agent/one-system-action-executor.ts
+++ b/hushh-webapp/lib/agent/one-system-action-executor.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import type { AgentActionRuntimeResult } from "@/lib/agent/agent-action-runtime";
+import type { PendingOneSystemActionInvocation } from "@/lib/capacitor/one-system-action-invocation";
+
+export type OneSystemActionExecutor = (
+  invocation: PendingOneSystemActionInvocation,
+) => Promise<AgentActionRuntimeResult>;
+
+let activeExecutor: OneSystemActionExecutor | null = null;
+let revision = 0;
+const subscribers = new Set<() => void>();
+
+export function registerOneSystemActionExecutor(
+  executor: OneSystemActionExecutor,
+): () => void {
+  activeExecutor = executor;
+  revision += 1;
+  subscribers.forEach((subscriber) => subscriber());
+  return () => {
+    if (activeExecutor !== executor) return;
+    activeExecutor = null;
+    revision += 1;
+    subscribers.forEach((subscriber) => subscriber());
+  };
+}
+
+export function isOneSystemActionExecutorReady(): boolean {
+  return activeExecutor !== null;
+}
+
+export function oneSystemActionExecutorRevision(): number {
+  return revision;
+}
+
+export function subscribeOneSystemActionExecutor(
+  subscriber: () => void,
+): () => void {
+  subscribers.add(subscriber);
+  return () => subscribers.delete(subscriber);
+}
+
+export async function executeOneSystemActionInvocation(
+  invocation: PendingOneSystemActionInvocation,
+): Promise<AgentActionRuntimeResult> {
+  const executor = activeExecutor;
+  if (!executor) {
+    return {
+      status: "blocked",
+      actionId: invocation.actionId,
+      label: null,
+      routeBefore: null,
+      resultSummary: "HUSSH is still preparing the action runtime.",
+      reason: "system_action_executor_not_ready",
+    };
+  }
+  return executor(invocation);
+}

--- a/hushh-webapp/lib/agent/one-system-action-gateway-adapter.ts
+++ b/hushh-webapp/lib/agent/one-system-action-gateway-adapter.ts
@@ -1,0 +1,159 @@
+"use client";
+
+import type { AgentActionRuntimeResult } from "@/lib/agent/agent-action-runtime";
+import type { PendingOneSystemActionInvocation } from "@/lib/capacitor/one-system-action-invocation";
+import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
+import { resolveNavigationJourney } from "@/lib/voice/navigation-journey";
+
+type GoalAuthorization = {
+  goalId: string;
+  expectedScreen: string;
+} | null;
+
+type ExecuteCanonicalAction = (
+  actionId: string,
+  slots: Record<string, unknown>,
+  goalAuthorization?: GoalAuthorization,
+) => Promise<AgentActionRuntimeResult>;
+
+/**
+ * Translates a bounded Apple-system request into the exact generated gateway
+ * calls One Voice already uses. Domain behavior remains in the mounted action
+ * handlers; this adapter only performs authored navigation and recipient
+ * selection prerequisites before invoking the canonical action id.
+ */
+export async function executeOneSystemActionThroughGateway(input: {
+  invocation: PendingOneSystemActionInvocation;
+  execute: ExecuteCanonicalAction;
+  getCurrentRoute: () => { pathname: string | null; screen: string | null };
+  waitForScreen: (screen: string) => Promise<boolean>;
+  afterSelection: () => Promise<void>;
+}): Promise<AgentActionRuntimeResult> {
+  const { invocation } = input;
+  const action = getKaiActionById(invocation.actionId);
+  if (!action) {
+    return {
+      status: "invalid",
+      actionId: invocation.actionId,
+      label: null,
+      routeBefore: null,
+      resultSummary: "HUSSH does not recognize that action.",
+      reason: "missing_action",
+    };
+  }
+  if (
+    action.execution_policy === "confirm_required" &&
+    !invocation.confirmedBySystem
+  ) {
+    return {
+      status: "blocked",
+      actionId: invocation.actionId,
+      label: action.label,
+      routeBefore: input.getCurrentRoute().pathname,
+      resultSummary: "Confirm this action with Siri before it can run.",
+      reason: "system_confirmation_missing",
+    };
+  }
+
+  const selectsRecipient =
+    invocation.actionId === "location.share_selected" ||
+    invocation.actionId === "location.send_request";
+
+  if (selectsRecipient) {
+    const resolvedRecipientId = invocation.slots.resolvedRecipientId;
+    const person = invocation.slots.person;
+    if (!resolvedRecipientId && !person) {
+      return {
+        status: "blocked",
+        actionId: invocation.actionId,
+        label: action.label,
+        routeBefore: input.getCurrentRoute().pathname,
+        resultSummary: "Choose a HUSSH connection first.",
+        reason: "system_action_recipient_missing",
+      };
+    }
+    const selectionActionId =
+      invocation.actionId === "location.share_selected"
+        ? "location.select_share_recipient"
+        : "location.select_ask_recipient";
+    const selectionJourney = resolveNavigationJourney(selectionActionId);
+    let selectionGoalAuthorization: GoalAuthorization = null;
+    if (selectionJourney) {
+      // Always open the authored composer before selecting. Screen identity is
+      // intentionally coarser than the Location sub-flow query, so merely
+      // seeing `one_location` cannot prove that Share or Ask is active.
+      const routeResult = await input.execute(
+        selectionJourney.navigationActionId,
+        {},
+      );
+      if (
+        routeResult.status !== "succeeded" &&
+        routeResult.status !== "started"
+      ) {
+        return routeResult;
+      }
+      if (!(await input.waitForScreen(selectionJourney.destinationScreen))) {
+        return {
+          status: "blocked",
+          actionId: invocation.actionId,
+          label: action.label,
+          routeBefore: routeResult.routeBefore,
+          routeAfter: routeResult.routeAfter,
+          resultSummary:
+            "Location is still opening. Your request is preserved.",
+          reason: "system_action_destination_not_ready",
+        };
+      }
+      selectionGoalAuthorization = {
+        goalId: selectionJourney.goalId,
+        expectedScreen: selectionJourney.destinationScreen,
+      };
+    }
+    const selection = await input.execute(
+      selectionActionId,
+      resolvedRecipientId ? { resolvedRecipientId } : { person },
+      selectionGoalAuthorization,
+    );
+    if (selection.status !== "succeeded") return selection;
+    await input.afterSelection();
+  }
+
+  // The generated journey belongs to the requested action itself. Recipient
+  // composites above instead use their selection action's narrower journey;
+  // authorizing the final mutation as globally navigable could apply it to
+  // stale recipients from an older composer state.
+  const journey = selectsRecipient
+    ? null
+    : resolveNavigationJourney(invocation.actionId, action);
+  let goalAuthorization: GoalAuthorization = null;
+  if (journey && input.getCurrentRoute().screen !== journey.destinationScreen) {
+    const routeResult = await input.execute(journey.navigationActionId, {});
+    if (
+      routeResult.status !== "succeeded" &&
+      routeResult.status !== "started"
+    ) {
+      return routeResult;
+    }
+    if (!(await input.waitForScreen(journey.destinationScreen))) {
+      return {
+        status: "blocked",
+        actionId: invocation.actionId,
+        label: action.label,
+        routeBefore: routeResult.routeBefore,
+        routeAfter: routeResult.routeAfter,
+        resultSummary: "Location is still opening. Your request is preserved.",
+        reason: "system_action_destination_not_ready",
+      };
+    }
+    goalAuthorization = {
+      goalId: journey.goalId,
+      expectedScreen: journey.destinationScreen,
+    };
+  }
+
+  const slots: Record<string, unknown> = { ...invocation.slots };
+  if (selectsRecipient) {
+    delete slots.resolvedRecipientId;
+  }
+  return input.execute(invocation.actionId, slots, goalAuthorization);
+}

--- a/hushh-webapp/lib/agent/siri-one-action-handoff-policy.ts
+++ b/hushh-webapp/lib/agent/siri-one-action-handoff-policy.ts
@@ -1,0 +1,42 @@
+import type { AgentAccessTier } from "@/lib/agent/agent-runtime-context";
+
+export type SiriOneActionHandoffState =
+  | "expired"
+  | "waiting_for_foreground"
+  | "waiting_for_auth_restoration"
+  | "waiting_for_auth"
+  | "waiting_for_route"
+  | "waiting_for_runtime"
+  | "waiting_for_vault"
+  | "waiting_for_executor"
+  | "dispatch";
+
+export function resolveSiriOneActionHandoffState(input: {
+  now: number;
+  expiresAt: number;
+  visible: boolean;
+  authLoading: boolean;
+  signedIn: boolean;
+  pathname: string | null;
+  loginPath: string;
+  runtimeReady: boolean;
+  tier: AgentAccessTier | null;
+  requiresVault: boolean;
+  executorReady: boolean;
+}): SiriOneActionHandoffState {
+  if (input.expiresAt <= input.now) return "expired";
+  if (!input.visible) return "waiting_for_foreground";
+  if (input.authLoading) return "waiting_for_auth_restoration";
+  if (!input.signedIn) return "waiting_for_auth";
+  if (!input.pathname || input.pathname === input.loginPath) {
+    return "waiting_for_route";
+  }
+  if (!input.runtimeReady || !input.tier?.startsWith("signed_")) {
+    return "waiting_for_runtime";
+  }
+  if (input.requiresVault && input.tier !== "signed_unlocked") {
+    return "waiting_for_vault";
+  }
+  if (!input.executorReady) return "waiting_for_executor";
+  return "dispatch";
+}

--- a/hushh-webapp/lib/capacitor/one-system-action-invocation.ts
+++ b/hushh-webapp/lib/capacitor/one-system-action-invocation.ts
@@ -1,0 +1,136 @@
+"use client";
+
+import {
+  Capacitor,
+  type PluginListenerHandle,
+} from "@capacitor/core";
+import { NativeOneVoiceInvocation } from "@/lib/capacitor/one-voice-invocation";
+
+export const ONE_SYSTEM_ACTION_IDS = [
+  "location.open_now",
+  "location.open_map",
+  "location.open_active_shares",
+  "location.open_shared_with_me",
+  "location.open_needs_review",
+  "location.open_settings",
+  "location.open_temporary_link",
+  "location.open_check_in",
+  "location.open_sos",
+  "location.share_selected",
+  "location.send_request",
+  "location.stop_share",
+  "location.pause_updates",
+  "location.resume_updates",
+  "location.create_circle",
+  "location.rename_circle",
+] as const;
+
+export type OneSystemActionId = (typeof ONE_SYSTEM_ACTION_IDS)[number];
+
+export type PendingOneSystemActionInvocation = {
+  id: string;
+  kind: "execute_one_action";
+  source: "siri_app_intent";
+  actionId: OneSystemActionId;
+  slots: Record<string, string>;
+  requiresVault: boolean;
+  confirmedBySystem: boolean;
+  createdAt: number;
+  expiresAt: number;
+};
+
+export type OneSystemActionOutcome =
+  | "succeeded"
+  | "started"
+  | "blocked"
+  | "failed"
+  | "expired"
+  | "cancelled";
+
+export type OneSystemEntityIndexEntry = { id: string; name: string };
+
+const actionIds = new Set<string>(ONE_SYSTEM_ACTION_IDS);
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.entries(value).every(
+    ([key, item]) =>
+      key.length > 0 && typeof item === "string" && item.length <= 160,
+  );
+}
+
+export function isPendingOneSystemActionInvocation(
+  value: Partial<PendingOneSystemActionInvocation> | null | undefined,
+): value is PendingOneSystemActionInvocation {
+  return (
+    value?.kind === "execute_one_action" &&
+    value.source === "siri_app_intent" &&
+    typeof value.id === "string" &&
+    value.id.length > 0 &&
+    typeof value.actionId === "string" &&
+    actionIds.has(value.actionId) &&
+    isStringRecord(value.slots) &&
+    typeof value.requiresVault === "boolean" &&
+    typeof value.confirmedBySystem === "boolean" &&
+    typeof value.createdAt === "number" &&
+    Number.isFinite(value.createdAt) &&
+    typeof value.expiresAt === "number" &&
+    Number.isFinite(value.expiresAt)
+  );
+}
+
+export const OneSystemActionInvocationBridge = {
+  isSupported(): boolean {
+    return Capacitor.isNativePlatform() && Capacitor.getPlatform() === "ios";
+  },
+
+  async getPendingInvocation(): Promise<PendingOneSystemActionInvocation | null> {
+    if (!this.isSupported()) return null;
+    const value = await NativeOneVoiceInvocation.getPendingActionInvocation();
+    return isPendingOneSystemActionInvocation(value) ? value : null;
+  },
+
+  async claimInvocation(options: {
+    id: string;
+  }): Promise<{ claimed: boolean }> {
+    if (!this.isSupported()) return { claimed: false };
+    return NativeOneVoiceInvocation.claimActionInvocation(options);
+  },
+
+  async completeInvocation(options: {
+    id: string;
+    outcome: OneSystemActionOutcome;
+    summary: string;
+  }): Promise<void> {
+    if (!this.isSupported()) return;
+    await NativeOneVoiceInvocation.completeActionInvocation(options);
+  },
+
+  async updateEntityIndex(options: {
+    ownerId: string;
+    contacts: OneSystemEntityIndexEntry[];
+    circles: OneSystemEntityIndexEntry[];
+  }): Promise<boolean> {
+    if (!this.isSupported()) return false;
+    const result = await NativeOneVoiceInvocation.updateActionEntityIndex(options);
+    return result.updated;
+  },
+
+  async clear(options: {
+    outcome: "cancelled" | "sign_out";
+    clearEntityIndex: boolean;
+  }): Promise<void> {
+    if (!this.isSupported()) return;
+    await NativeOneVoiceInvocation.clearActionState(options);
+  },
+
+  async addAvailabilityListener(
+    listener: (invocation: PendingOneSystemActionInvocation) => void,
+  ): Promise<PluginListenerHandle> {
+    if (!this.isSupported()) return { remove: async () => undefined };
+    return NativeOneVoiceInvocation.addListener(
+      "systemActionInvocationAvailable",
+      listener,
+    );
+  },
+};

--- a/hushh-webapp/lib/capacitor/one-voice-invocation.ts
+++ b/hushh-webapp/lib/capacitor/one-voice-invocation.ts
@@ -6,6 +6,11 @@ import {
   registerPlugin,
   type PluginListenerHandle,
 } from "@capacitor/core";
+import type {
+  OneSystemActionOutcome,
+  OneSystemEntityIndexEntry,
+  PendingOneSystemActionInvocation,
+} from "@/lib/capacitor/one-system-action-invocation";
 
 export type PendingOneVoiceInvocation = {
   id: string;
@@ -25,9 +30,33 @@ export interface NativeOneVoiceInvocationPlugin {
     id: string;
     outcome: OneVoiceInvocationOutcome;
   }): Promise<void>;
+  getPendingActionInvocation(): Promise<
+    Partial<PendingOneSystemActionInvocation>
+  >;
+  claimActionInvocation(options: {
+    id: string;
+  }): Promise<{ claimed: boolean }>;
+  completeActionInvocation(options: {
+    id: string;
+    outcome: OneSystemActionOutcome;
+    summary: string;
+  }): Promise<void>;
+  updateActionEntityIndex(options: {
+    ownerId: string;
+    contacts: OneSystemEntityIndexEntry[];
+    circles: OneSystemEntityIndexEntry[];
+  }): Promise<{ updated: boolean }>;
+  clearActionState(options: {
+    outcome: "cancelled" | "sign_out";
+    clearEntityIndex: boolean;
+  }): Promise<void>;
   addListener(
     eventName: "voiceInvocationAvailable",
     listener: (invocation: PendingOneVoiceInvocation) => void,
+  ): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: "systemActionInvocationAvailable",
+    listener: (invocation: PendingOneSystemActionInvocation) => void,
   ): Promise<PluginListenerHandle>;
 }
 
@@ -41,9 +70,26 @@ class OneVoiceInvocationWeb extends WebPlugin {
   }
 
   async completeInvocation(): Promise<void> {}
+
+  async getPendingActionInvocation(): Promise<Record<string, never>> {
+    return {};
+  }
+
+  async claimActionInvocation(): Promise<{ claimed: boolean }> {
+    return { claimed: false };
+  }
+
+  async completeActionInvocation(): Promise<void> {}
+
+  async updateActionEntityIndex(): Promise<{ updated: boolean }> {
+    return { updated: false };
+  }
+
+  async clearActionState(): Promise<void> {}
 }
 
-const NativeOneVoiceInvocation = registerPlugin<NativeOneVoiceInvocationPlugin>(
+export const NativeOneVoiceInvocation =
+  registerPlugin<NativeOneVoiceInvocationPlugin>(
   "HushhVoiceInvocation",
   { web: () => Promise.resolve(new OneVoiceInvocationWeb()) },
 );


### PR DESCRIPTION
# Description

Expose a bounded set of One Location capabilities to Siri and App Shortcuts through App Intents. Siri remains an iOS entry adapter: native code stores a redacted, expiring request, the Capacitor handoff restores the existing authenticated/vault runtime, and the mounted Agent Bar executes the exact generated action through the existing action gateway and browser settlement path.

This adds structured HUSSH Contact and Circle entities, direct Share/Ask/Stop/Location-state/Circle intents, Location destination shortcuts, and the existing Talk to One fallback. It does not add another microphone, voice model, router, backend action, or native business-logic implementation.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: existing `/one/location` handler accepts exact resolved recipient/Circle IDs; no route added.
- API / schema / type changes:
  - [x] Listed below: closed native/TypeScript pending-action bridge plus AppEntity query contracts; no backend API or DB schema change.
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] Listed below: iOS 16+ Siri specialization; web and Android deliberately report unsupported/no pending invocation because those platforms do not expose Apple App Intents.
- Docs updated (exact files):
  - [x] Listed below: `docs/reference/one/one-voice-runtime-architecture.md` documents the 16 exposed Location actions, 34 explicit exclusions, foreground boundary, and no-background-execution claim.
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] Auth / vault / voice-action: local-device authentication at the App Intent boundary; HUSSH session and vault gates stay in the existing runtime; generated action confirmation and settlement remain authoritative.
- Caller / proxy / backend pairing:
  - [x] Listed below with contract proof: App Intent → existing `HushhVoiceInvocation` native plugin → typed handoff → Agent Bar executor → generated gateway; generated gateway artifacts match `main` exactly and no backend diff exists.
- Rollback or safe-failure behavior:
  - [x] Listed below: five-minute TTL, latest-wins replacement, exactly-once claim/completion, clear on expiry/failure/sign-out/cancellation, no fuzzy entity guess, and fail-closed auth/vault/executor readiness.
- UI browser or Playwright proof:
  - [x] Not applicable: this is an Apple system surface. Lifecycle/component tests cover foreground, background/cold ordering, auth restoration, expiry, duplicate delivery, vault readiness, and canonical execution. Physical iPhone proof follows from the TestFlight build.
- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test`
  - [x] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit` (not an intentional fixture reset)
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000` (no backend/runtime contract change)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR extends the existing Talk intent, native plugin, Agent Bar, and generated gateway rather than duplicating them.
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `AppDelegate` registers shortcuts; `MyViewController` registers the existing plugin; providers mount the handoff; Agent Bar registers the sole executor.
- [x] New tests import and exercise production code, not only mock components/helpers defined inside the test file.
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [x] Production surface proved: App Intent request factories, native coordinator/plugin, TypeScript bridge/handoff, Agent Bar gateway adapter, and Location handlers are connected end to end.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.
- [x] If this is one PR in a stack, the predecessor PR is linked here: not a stacked PR.
- [x] If this responds to requested changes, the new commit or material explanation is described here: direct structured Location intents were requested after Talk to One alone proved insufficient for phrases such as sharing or opening Location capabilities.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: existing Next.js Agent Bar and Location handlers execute the generated action contract.
- [x] **iOS**: App Intents, AppEntity queries, native pending coordinator, and existing Capacitor plugin integration.
- [x] **Android**: explicitly not applicable for Apple App Intents; the shared bridge returns unsupported without creating a parity runtime.

## 🧪 Testing

- [x] Tested on Web through production build, exhaustive Vitest, and focused lifecycle/gateway tests.
- [ ] Tested on iOS Simulator/Device: local Xcode lacks the iOS 26.5 platform component; direct Swift typecheck passes and the release workflow runs native XCTest before archive.
- [ ] Tested on Android Emulator/Device: Apple-only system surface; static/plugin parity passes.
- [x] Commits are signed off (`git commit -s`).
- [x] If generated files changed, they were regenerated by the canonical repo command listed above: generated files do not differ from `main`.

Focused post-rebase evidence: 61 Siri/Location tests passed; TypeScript, Swift typecheck, voice gateway, route orchestration, native static parity, and native plugin parity passed. Full local PR mirror: 5,884 frontend tests passed with 6 skipped; 1,866 backend tests passed; production build and PKM compatibility gate passed.

## 📸 Screenshots / Video

No browser screenshot applies to the Siri system surface. TestFlight physical-device acceptance will validate phrase discovery and iOS presentation after the signed CI archive is uploaded.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? It exposes only owner-bound Contact/Circle IDs and display names to the local AppEntity index after vault unlock.
- [x] If yes, have you implemented `checkConsentToken()`? Existing generated action handlers retain the current consent/vault checks; no native data access or backend bypass was added.
- [x] Sensitive surface touched: auth / vault / voice-action.
- [x] Error path, rollback, or safe-failure behavior proved: invalid/expired/replaced requests, missing auth, locked vault, unresolved entities, missing confirmation, missing executor, and duplicate delivery fail closed in automated tests.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] Third-party notice impact reviewed when dependencies changed: no dependency change.
