### PR TITLE
fix(location): keep Circle selection counts scoped

### DIFF
--- a/hushh-webapp/__tests__/circle-recipient-selection.test.ts
+++ b/hushh-webapp/__tests__/circle-recipient-selection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  countSelectedCircleRecipients,
   isCircleSelectionFullySelected,
   mergeRecipientsByUserId,
   resolveCircleRecipientSelection,
@@ -109,6 +110,38 @@ describe("isCircleSelectionFullySelected", () => {
     expect(
       isCircleSelectionFullySelected({ ...selection(), ready: [] }, []),
     ).toBe(false);
+  });
+});
+
+describe("countSelectedCircleRecipients", () => {
+  it("does not let hand-picked outsiders inflate the Circle row count", () => {
+    const resolved = resolveCircleRecipientSelection({
+      circle: circle(),
+      currentUserId: "owner",
+    });
+    const readyIds = resolved.ready.map((target) => target.recipient.userId);
+
+    expect(readyIds).toEqual(["ready", "no-phone"]);
+    expect(
+      countSelectedCircleRecipients(resolved, [
+        ...readyIds,
+        "outsider-one",
+        "outsider-two",
+      ]),
+    ).toBe(2);
+  });
+
+  it("counts the unique selected intersection for partial or empty state", () => {
+    const resolved = resolveCircleRecipientSelection({
+      circle: circle(),
+      currentUserId: "owner",
+    });
+
+    expect(
+      countSelectedCircleRecipients(resolved, ["ready", "ready", "outsider"]),
+    ).toBe(1);
+    expect(countSelectedCircleRecipients(resolved, [])).toBe(0);
+    expect(countSelectedCircleRecipients(null, ["ready"])).toBe(0);
   });
 });
 

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -118,6 +118,7 @@ import type {
 } from "@/lib/one-location/types";
 import { locationStatusLabel } from "@/lib/one-location/location-readiness";
 import {
+  countSelectedCircleRecipients,
   isCircleSelectionFullySelected,
   type CircleRecipientSelection,
 } from "@/lib/one-location/circle-recipient-selection";
@@ -4518,6 +4519,10 @@ function ShareFlow({
     vm.selectedShareCircleSelection,
     vm.selectedRecipientIds,
   );
+  const selectedShareCircleRecipientCount = countSelectedCircleRecipients(
+    vm.selectedShareCircleSelection,
+    vm.selectedRecipientIds,
+  );
 
   // Step 2 of 2 — "Details" and the old separate "Consent check" merged.
   //
@@ -4729,6 +4734,9 @@ function ShareFlow({
             const selected =
               vm.selectedShareCircleSelection?.circle.id === circle.id &&
               shareCircleFullySelected;
+            const circleSelectionDescription = selected
+              ? `${selectedShareCircleRecipientCount} selected`
+              : circleMemberCountLabel(circle.memberCount);
             const circleRole = roleClasses("people");
             return (
               <SettingsRow
@@ -4737,7 +4745,7 @@ function ShareFlow({
                 disabled={vm.busy === "shareCircle"}
                 onClick={() => void vm.onSelectShareCircle(circle.id)}
                 ariaPressed={selected}
-                ariaLabel={`${selected ? "Deselect" : "Select"} the ${circle.name} Circle`}
+                ariaLabel={`${selected ? "Deselect" : "Select"} the ${circle.name} Circle, ${circleSelectionDescription}`}
                 leading={
                   <span
                     className={cn(
@@ -4753,9 +4761,7 @@ function ShareFlow({
                 description={
                   vm.busy === "shareCircle"
                     ? "Loading…"
-                    : selected
-                      ? `${selectedReady.length} selected`
-                      : circleMemberCountLabel(circle.memberCount)
+                    : circleSelectionDescription
                 }
                 trailing={<SelectionDot selected={selected} />}
               />

--- a/hushh-webapp/lib/one-location/circle-recipient-selection.ts
+++ b/hushh-webapp/lib/one-location/circle-recipient-selection.ts
@@ -119,6 +119,28 @@ export function isCircleSelectionFullySelected(
   return ready.every((target) => selected.has(target.recipient.userId));
 }
 
+/**
+ * Counts only selected recipients that belong to this resolved Circle snapshot.
+ *
+ * The share composer may contain extra hand-picked people while a whole Circle
+ * remains selected. Those people belong in the composer-wide total, but never
+ * in the Circle row's own count.
+ */
+export function countSelectedCircleRecipients(
+  selection: CircleRecipientSelection | null | undefined,
+  selectedRecipientIds: readonly string[],
+): number {
+  if (!selection?.ready.length || !selectedRecipientIds.length) return 0;
+
+  const selected = new Set(selectedRecipientIds);
+  const counted = new Set<string>();
+  for (const target of selection.ready) {
+    const userId = target.recipient.userId;
+    if (userId && selected.has(userId)) counted.add(userId);
+  }
+  return counted.size;
+}
+
 export function mergeRecipientsByUserId(
   ...groups: OneLocationRecipient[][]
 ): OneLocationRecipient[] {


### PR DESCRIPTION
## Summary
- keep selected Circle row counts scoped to the Circle roster even when extra people are hand-picked
- add a shared count helper plus direct unit coverage

## Validation
- npm run typecheck
- npm run verify:one-location
- npx vitest run __tests__/circle-recipient-selection.test.ts