### PR TITLE
fix(ios): make One Location commands natural in Siri

### DIFF
--- a/docs/reference/one/one-voice-runtime-architecture.md
+++ b/docs/reference/one/one-voice-runtime-architecture.md
@@ -60,7 +60,7 @@ Both native envelopes use latest-request-wins and exact claim/completion. They
 survive ordinary cold launch and HUSSH sign-in for five minutes and clear on
 completion, failure, expiry, replacement, cancellation, or sign-out. The
 action envelope is stored in this-device-only Keychain storage and is closed
-to sixteen allowlisted generated action identifiers and per-action slot names.
+to seventeen allowlisted generated action identifiers and per-action slot names.
 The App Entity index is owner-bound and contains only existing HUSSH ids and
 display names; it contains no phone numbers, credentials, coordinates, routes,
 tokens, speech, or contact-book records.
@@ -97,6 +97,7 @@ The Siri surface exposes the following useful, bounded subset:
 | Open temporary-link composer | `location.open_temporary_link` | No | No |
 | Open Check-In composer | `location.open_check_in` | No | No |
 | Open SOS review | `location.open_sos` | No; does not send | No |
+| Open emergency SMS contacts | `location.open_sms_contacts` | No | No |
 | Share with a resolved contact | `location.share_selected` | Yes | Yes |
 | Ask a resolved contact for location | `location.send_request` | Yes | Yes |
 | Stop sharing with a resolved contact | `location.stop_share` | Yes | Yes |
@@ -105,13 +106,13 @@ The Siri surface exposes the following useful, bounded subset:
 | Create a named Circle | `location.create_circle` | Yes | Yes |
 | Rename a resolved Circle | `location.rename_circle` | Yes | Yes |
 
-The other 34 contract actions remain available through the existing One Voice
+The other 33 contract actions remain available through the existing One Voice
 and visible Location experience, but are not direct Siri intents in this
 release:
 
-- Ten redundant composer/deep-link actions (`open_people`, `open_links`,
+- Nine redundant composer/deep-link actions (`open_people`, `open_links`,
   `open_share`, `open_ask`, `open_invite`, `open_create_circle`,
-  `open_join_circle`, `open_sms_contacts`, `find_contacts`, and
+  `open_join_circle`, `find_contacts`, and
   `add_connections`) are covered by the narrower destination intents or the
   existing conversational fallback.
 - Three UI-internal selection/refresh steps (`select_ask_recipient`,
@@ -126,10 +127,20 @@ release:
   a confirmation gate. Siri may open the existing SOS review surface, but it
   cannot send the alert in this release.
 
-Apple limits an app to ten zero-setup App Shortcuts, so the provider publishes
-the highest-value phrases: share, ask, stop, location on/off, create Circle,
-Check-In, open Location, open map, review requests, and Talk to One. The other
-App Intents remain discoverable in the Shortcuts app. Android and web
+The installed iOS display and spoken name is `One`, so Apple's mandatory
+`applicationName` phrase token produces direct requests such as “Open One
+Location Agent” instead of requiring the harder-to-pronounce HUSSH brand name.
+One bounded `OneLocationDestinationEntity` represents the ten reviewed,
+non-mutating Location destinations (including map, requests, settings,
+Check-In, SOS review, and emergency SMS contacts). Its `OpenIntent` tells Siri
+that “Location Agent” is content inside One rather than a separate app.
+
+Apple limits an app to ten zero-setup App Shortcuts. The provider deliberately
+publishes eight focused shortcuts: share, ask, stop, location on/off, create
+Circle, Check-In, open a structured Location destination, and Talk to One.
+Mutation intents keep Apple's parameter follow-ups and native confirmation,
+then hand the exact generated action to the existing browser executor. The
+other App Intents remain discoverable in the Shortcuts app. Android and web
 deliberately report this Apple system surface as unsupported/no pending
 invocation.
 

--- a/hushh-webapp/__tests__/capacitor/one-system-action-invocation.test.ts
+++ b/hushh-webapp/__tests__/capacitor/one-system-action-invocation.test.ts
@@ -43,7 +43,7 @@ describe("One system action invocation bridge contract", () => {
   });
 
   it("contains only generated Location action identifiers", () => {
-    expect(ONE_SYSTEM_ACTION_IDS).toHaveLength(16);
+    expect(ONE_SYSTEM_ACTION_IDS).toHaveLength(17);
     expect(
       ONE_SYSTEM_ACTION_IDS.every((actionId) =>
         actionId.startsWith("location."),

--- a/hushh-webapp/ios/App/App/Info.plist
+++ b/hushh-webapp/ios/App/App/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Hussh One</string>
+	<string>One</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Hussh One</string>
+	<string>One</string>
+	<key>CFBundleSpokenName</key>
+	<string>One</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/hushh-webapp/ios/App/App/OneSystemActionInvocationCoordinator.swift
+++ b/hushh-webapp/ios/App/App/OneSystemActionInvocationCoordinator.swift
@@ -12,6 +12,7 @@ enum OneSystemActionID: String, Codable, CaseIterable, Sendable {
     case openTemporaryLink = "location.open_temporary_link"
     case openCheckIn = "location.open_check_in"
     case openEmergencySOS = "location.open_sos"
+    case openSMSContacts = "location.open_sms_contacts"
     case shareLocation = "location.share_selected"
     case askForLocation = "location.send_request"
     case stopShare = "location.stop_share"
@@ -27,7 +28,8 @@ enum OneSystemActionID: String, Codable, CaseIterable, Sendable {
             return true
         case .openLocation, .openLocationMap, .openActiveShares,
              .openSharedWithMe, .openRequestsToReview, .openLocationSettings,
-             .openTemporaryLink, .openCheckIn, .openEmergencySOS:
+             .openTemporaryLink, .openCheckIn, .openEmergencySOS,
+             .openSMSContacts:
             return false
         }
     }
@@ -45,7 +47,7 @@ enum OneSystemActionID: String, Codable, CaseIterable, Sendable {
         case .pauseLocation, .resumeLocation, .openLocation, .openLocationMap,
              .openActiveShares, .openSharedWithMe, .openRequestsToReview,
              .openLocationSettings, .openTemporaryLink, .openCheckIn,
-             .openEmergencySOS:
+             .openEmergencySOS, .openSMSContacts:
             return []
         }
     }

--- a/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
+++ b/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
@@ -9,7 +9,7 @@ struct OneContactEntity: AppEntity, Identifiable, Hashable {
     let id: String
     let name: String
 
-    static let typeDisplayRepresentation: TypeDisplayRepresentation = "HUSSH Contact"
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "One Contact"
     static let defaultQuery = OneContactEntityQuery()
 
     var displayRepresentation: DisplayRepresentation {
@@ -45,11 +45,176 @@ struct OneCircleEntity: AppEntity, Identifiable, Hashable {
     let id: String
     let name: String
 
-    static let typeDisplayRepresentation: TypeDisplayRepresentation = "HUSSH Circle"
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "One Circle"
     static let defaultQuery = OneCircleEntityQuery()
 
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(title: "\(name)")
+    }
+}
+
+/// A bounded, non-sensitive description of a destination inside One Location.
+/// The entity teaches Siri that "Location Agent" is content owned by One,
+/// rather than the name of another installed app.
+@available(iOS 16.0, *)
+struct OneLocationDestinationEntity: AppEntity, Identifiable, Hashable {
+    let id: String
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation =
+        "One Location Destination"
+    static let defaultQuery = OneLocationDestinationEntityQuery()
+
+    static let supportedActionIDs: [OneSystemActionID] = [
+        .openLocation,
+        .openLocationMap,
+        .openActiveShares,
+        .openSharedWithMe,
+        .openRequestsToReview,
+        .openLocationSettings,
+        .openTemporaryLink,
+        .openCheckIn,
+        .openEmergencySOS,
+        .openSMSContacts
+    ]
+
+    static let all: [Self] = supportedActionIDs.map {
+        Self(id: $0.rawValue)
+    }
+
+    var actionID: OneSystemActionID? {
+        guard
+            let candidate = OneSystemActionID(rawValue: id),
+            Self.supportedActionIDs.contains(candidate)
+        else { return nil }
+        return candidate
+    }
+
+    var displayRepresentation: DisplayRepresentation {
+        switch actionID {
+        case .openLocation:
+            return makeDisplay(
+                title: "Location Agent",
+                synonyms: ["One Location Agent", "Location Overview"]
+            )
+        case .openLocationMap:
+            return makeDisplay(
+                title: "Location Map",
+                synonyms: ["One Location Map", "Map"]
+            )
+        case .openActiveShares:
+            return makeDisplay(
+                title: "Active Location Shares",
+                synonyms: ["Active Shares", "Who Can See Me"]
+            )
+        case .openSharedWithMe:
+            return makeDisplay(
+                title: "Locations Shared With Me",
+                synonyms: ["Shared With Me", "People Sharing With Me"]
+            )
+        case .openRequestsToReview:
+            return makeDisplay(
+                title: "Location Requests",
+                synonyms: ["Pending Location Requests", "Requests to Review"]
+            )
+        case .openLocationSettings:
+            return makeDisplay(
+                title: "Location Settings",
+                synonyms: ["Location Privacy", "Location Privacy Settings"]
+            )
+        case .openTemporaryLink:
+            return makeDisplay(
+                title: "Temporary Location Link",
+                synonyms: ["Location Link", "Temporary Link"]
+            )
+        case .openCheckIn:
+            return makeDisplay(
+                title: "Location Check In",
+                synonyms: ["Check In", "One Check In"]
+            )
+        case .openEmergencySOS:
+            return makeDisplay(
+                title: "Emergency SOS Review",
+                synonyms: ["SOS Review", "Emergency Screen"]
+            )
+        case .openSMSContacts:
+            return makeDisplay(
+                title: "Emergency SMS Contacts",
+                synonyms: ["SMS Contacts", "Emergency Contacts"]
+            )
+        default:
+            return "One Location"
+        }
+    }
+
+    private func makeDisplay(
+        title: LocalizedStringResource,
+        synonyms: [LocalizedStringResource]
+    ) -> DisplayRepresentation {
+        if #available(iOS 17.0, *) {
+            return .init(title: title, synonyms: synonyms)
+        }
+        return .init(title: title)
+    }
+
+    var searchableNames: [String] {
+        switch actionID {
+        case .openLocation:
+            return ["location agent", "one location agent", "location overview"]
+        case .openLocationMap:
+            return ["location map", "one location map", "map"]
+        case .openActiveShares:
+            return ["active location shares", "active shares", "who can see me"]
+        case .openSharedWithMe:
+            return ["locations shared with me", "shared with me", "people sharing with me"]
+        case .openRequestsToReview:
+            return ["location requests", "pending location requests", "requests to review"]
+        case .openLocationSettings:
+            return ["location settings", "location privacy", "privacy settings"]
+        case .openTemporaryLink:
+            return ["temporary location link", "location link", "temporary link"]
+        case .openCheckIn:
+            return ["location check in", "check in", "check-in"]
+        case .openEmergencySOS:
+            return ["emergency sos review", "sos review", "emergency screen"]
+        case .openSMSContacts:
+            return ["emergency sms contacts", "sms contacts", "emergency contacts"]
+        default:
+            return []
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+struct OneLocationDestinationEntityQuery: EntityStringQuery {
+    func entities(
+        for identifiers: [OneLocationDestinationEntity.ID]
+    ) async throws -> [OneLocationDestinationEntity] {
+        let requested = Set(identifiers)
+        return OneLocationDestinationEntity.all.filter {
+            requested.contains($0.id)
+        }
+    }
+
+    func entities(matching string: String) async throws -> [OneLocationDestinationEntity] {
+        let query = Self.normalize(string)
+        guard !query.isEmpty else { return OneLocationDestinationEntity.all }
+        return OneLocationDestinationEntity.all.filter { destination in
+            destination.searchableNames.contains { candidate in
+                let normalized = Self.normalize(candidate)
+                return normalized == query || normalized.contains(query) || query.contains(normalized)
+            }
+        }
+    }
+
+    func suggestedEntities() async throws -> [OneLocationDestinationEntity] {
+        OneLocationDestinationEntity.all
+    }
+
+    private static func normalize(_ value: String) -> String {
+        value
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+            .joined(separator: " ")
     }
 }
 
@@ -206,12 +371,12 @@ private enum OneAppIntentActionExecutor {
             slots: request.slots,
             confirmedBySystem: request.confirmedBySystem
         ) else {
-            return "HUSSH could not prepare that action."
+            return "One could not prepare that action."
         }
         guard let completion = await OneSystemActionInvocationCoordinator.shared.waitForCompletion(
             id: invocation.id
         ) else {
-            return "Continue in HUSSH to finish. Your request is waiting."
+            return "Continue in One to finish. Your request is waiting."
         }
         return completion.summary
     }
@@ -223,7 +388,7 @@ private enum OneAppIntentActionExecutor {
 struct TalkToHusshOneIntent: AppIntent {
     static let title: LocalizedStringResource = "Talk to One"
     static let description = IntentDescription(
-        "Open HUSSH One and begin a conversation with your private agent."
+        "Open One and begin a conversation with your private agent."
     )
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
@@ -244,7 +409,7 @@ struct TalkToHusshOneIntent: AppIntent {
 struct ShareLocationWithOneIntent: AppIntent {
     static let title: LocalizedStringResource = "Share Location"
     static let description = IntentDescription(
-        "Share your live location with an existing HUSSH connection."
+        "Share your live location with an existing One connection."
     )
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
@@ -280,7 +445,7 @@ struct ShareLocationWithOneIntent: AppIntent {
 struct AskForLocationWithOneIntent: AppIntent {
     static let title: LocalizedStringResource = "Ask for Location"
     static let description = IntentDescription(
-        "Ask an existing HUSSH connection to share their location."
+        "Ask an existing One connection to share their location."
     )
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
@@ -351,7 +516,7 @@ struct StopLocationSharingWithOneIntent: AppIntent {
 struct SetOneLocationStateIntent: AppIntent {
     static let title: LocalizedStringResource = "Set Location State"
     static let description = IntentDescription(
-        "Turn HUSSH location updates on or off."
+        "Turn One Location updates on or off."
     )
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
@@ -364,7 +529,7 @@ struct SetOneLocationStateIntent: AppIntent {
     var state: OneLocationStateIntentValue
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Turn HUSSH location \(\.$state)")
+        Summary("Turn One Location \(\.$state)")
     }
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
@@ -379,7 +544,7 @@ struct SetOneLocationStateIntent: AppIntent {
 @available(iOS 16.0, *)
 struct CreateOneCircleIntent: AppIntent {
     static let title: LocalizedStringResource = "Create a Circle"
-    static let description = IntentDescription("Create an empty HUSSH Circle.")
+    static let description = IntentDescription("Create an empty One Circle.")
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
     static let openAppWhenRun = true
@@ -406,7 +571,7 @@ struct CreateOneCircleIntent: AppIntent {
 @available(iOS 16.0, *)
 struct RenameOneCircleIntent: AppIntent {
     static let title: LocalizedStringResource = "Rename a Circle"
-    static let description = IntentDescription("Rename an existing HUSSH Circle.")
+    static let description = IntentDescription("Rename an existing One Circle.")
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
     static let openAppWhenRun = true
@@ -453,10 +618,47 @@ extension OneLocationOpenIntent {
     static var supportedModes: IntentModes { [.foreground(.immediate)] }
 }
 
+/// The canonical system-level opening action. `OpenIntent` tells Siri this is
+/// app-owned content, while the destination entity resolves phrases such as
+/// "Open One Location Agent" without creating a parallel route executor.
+@available(iOS 16.0, *)
+struct OpenOneLocationDestinationIntent: OpenIntent {
+    static let title: LocalizedStringResource = "Open One Location"
+    static let description = IntentDescription(
+        "Open a destination in the existing One Location experience."
+    )
+    static let authenticationPolicy: IntentAuthenticationPolicy =
+        .requiresLocalDeviceAuthentication
+    static let openAppWhenRun = true
+
+    @available(iOS 26.0, *)
+    static let supportedModes: IntentModes = [.foreground(.immediate)]
+
+    @Parameter(
+        title: "Destination",
+        requestValueDialog: "Which One Location destination?"
+    )
+    var target: OneLocationDestinationEntity
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Open \(\.$target) in One")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        guard let actionID = target.actionID else {
+            return .result(dialog: "That One Location destination is unavailable.")
+        }
+        let summary = await OneAppIntentActionExecutor.run(
+            OneAppIntentActionRequestFactory.open(actionID)
+        )
+        return .result(dialog: "\(summary)")
+    }
+}
+
 @available(iOS 16.0, *)
 struct OpenOneLocationIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "Open Location Agent"
-    static let description = IntentDescription("Open the existing HUSSH Location experience.")
+    static let description = IntentDescription("Open the existing One Location experience.")
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let summary = await OneAppIntentActionExecutor.run(
@@ -469,7 +671,7 @@ struct OpenOneLocationIntent: OneLocationOpenIntent {
 @available(iOS 16.0, *)
 struct OpenOneLocationMapIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "Open Location Map"
-    static let description = IntentDescription("Open the existing HUSSH location map.")
+    static let description = IntentDescription("Open the existing One Location map.")
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let summary = await OneAppIntentActionExecutor.run(
@@ -482,7 +684,7 @@ struct OpenOneLocationMapIntent: OneLocationOpenIntent {
 @available(iOS 16.0, *)
 struct ViewOneActiveSharesIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "View Active Location Shares"
-    static let description = IntentDescription("Open the list of active HUSSH location shares.")
+    static let description = IntentDescription("Open the list of active One Location shares.")
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let summary = await OneAppIntentActionExecutor.run(
@@ -508,7 +710,7 @@ struct ViewOneSharedLocationsIntent: OneLocationOpenIntent {
 @available(iOS 16.0, *)
 struct ReviewOneLocationRequestsIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "Review Location Requests"
-    static let description = IntentDescription("Open HUSSH location requests awaiting review.")
+    static let description = IntentDescription("Open One Location requests awaiting review.")
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let summary = await OneAppIntentActionExecutor.run(
@@ -521,7 +723,7 @@ struct ReviewOneLocationRequestsIntent: OneLocationOpenIntent {
 @available(iOS 16.0, *)
 struct OpenOneLocationSettingsIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "Open Location Privacy Settings"
-    static let description = IntentDescription("Open HUSSH Location privacy settings.")
+    static let description = IntentDescription("Open One Location privacy settings.")
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let summary = await OneAppIntentActionExecutor.run(
@@ -548,7 +750,7 @@ struct CreateOneTemporaryLocationLinkIntent: OneLocationOpenIntent {
 struct CheckInWithOneIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "Check In"
     static let description = IntentDescription(
-        "Open the existing HUSSH Check-In flow to choose recipients and review before sending."
+        "Open the existing One Check-In flow to choose recipients and review before sending."
     )
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
@@ -563,7 +765,7 @@ struct CheckInWithOneIntent: OneLocationOpenIntent {
 struct OpenOneEmergencySOSIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "Open Emergency SOS"
     static let description = IntentDescription(
-        "Open the existing HUSSH SOS review screen without sending an alert."
+        "Open the existing One SOS review screen without sending an alert."
     )
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
@@ -582,7 +784,7 @@ struct HusshOneAppShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: ShareLocationWithOneIntent(),
             phrases: [
-                "Share my location with \(\.$recipient) using \(.applicationName)",
+                "Share my location with \(\.$recipient) in \(.applicationName) Location Agent",
                 "Let \(\.$recipient) see my location with \(.applicationName)"
             ],
             shortTitle: "Share Location",
@@ -591,7 +793,7 @@ struct HusshOneAppShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: AskForLocationWithOneIntent(),
             phrases: [
-                "Ask \(\.$person) for location using \(.applicationName)",
+                "Ask \(\.$person) for location in \(.applicationName) Location Agent",
                 "Request \(\.$person)'s location with \(.applicationName)"
             ],
             shortTitle: "Ask for Location",
@@ -600,8 +802,8 @@ struct HusshOneAppShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: StopLocationSharingWithOneIntent(),
             phrases: [
-                "Stop sharing location with \(\.$person) using \(.applicationName)",
-                "Stop my location in \(.applicationName)"
+                "Stop sharing location with \(\.$person) in \(.applicationName) Location Agent",
+                "Stop my location in \(.applicationName) Location Agent"
             ],
             shortTitle: "Stop Sharing",
             systemImageName: "location.slash.fill"
@@ -609,7 +811,7 @@ struct HusshOneAppShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: SetOneLocationStateIntent(),
             phrases: [
-                "Turn my \(.applicationName) location \(\.$state)"
+                "Turn \(.applicationName) Location \(\.$state)"
             ],
             shortTitle: "Location On or Off",
             systemImageName: "location.circle"
@@ -617,8 +819,8 @@ struct HusshOneAppShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: CreateOneCircleIntent(),
             phrases: [
-                "Create a Circle in \(.applicationName)",
-                "Make a new Circle with \(.applicationName)"
+                "Create a Circle in \(.applicationName) Location Agent",
+                "Make a new Circle in \(.applicationName) Location Agent"
             ],
             shortTitle: "Create Circle",
             systemImageName: "person.3.fill"
@@ -626,38 +828,21 @@ struct HusshOneAppShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: CheckInWithOneIntent(),
             phrases: [
-                "Check in with \(.applicationName)",
-                "Open Check In in \(.applicationName)"
+                "Check in with \(.applicationName) Location Agent",
+                "Open \(.applicationName) Location Check In"
             ],
             shortTitle: "Check In",
             systemImageName: "checkmark.circle.fill"
         )
         AppShortcut(
-            intent: OpenOneLocationIntent(),
+            intent: OpenOneLocationDestinationIntent(),
             phrases: [
-                "Open Location Agent in \(.applicationName)",
-                "Open Location in \(.applicationName)"
+                "Open \(.applicationName) \(\.$target)",
+                "Show \(\.$target) in \(.applicationName)",
+                "Call \(.applicationName) \(\.$target)"
             ],
-            shortTitle: "Open Location",
+            shortTitle: "Open One Location",
             systemImageName: "location.circle.fill"
-        )
-        AppShortcut(
-            intent: OpenOneLocationMapIntent(),
-            phrases: [
-                "Open my location map in \(.applicationName)",
-                "Show the location map in \(.applicationName)"
-            ],
-            shortTitle: "Location Map",
-            systemImageName: "map.fill"
-        )
-        AppShortcut(
-            intent: ReviewOneLocationRequestsIntent(),
-            phrases: [
-                "Review location requests in \(.applicationName)",
-                "Show pending location requests in \(.applicationName)"
-            ],
-            shortTitle: "Review Requests",
-            systemImageName: "person.crop.circle.badge.questionmark"
         )
         AppShortcut(
             intent: TalkToHusshOneIntent(),

--- a/hushh-webapp/ios/App/AppTests/OneSystemActionInvocationCoordinatorTests.swift
+++ b/hushh-webapp/ios/App/AppTests/OneSystemActionInvocationCoordinatorTests.swift
@@ -176,12 +176,13 @@ final class OneSystemActionInvocationCoordinatorTests: XCTestCase {
     }
 
     func testActionCatalogMatchesGeneratedLocationContractIdentifiers() {
-        XCTAssertEqual(OneSystemActionID.allCases.count, 16)
+        XCTAssertEqual(OneSystemActionID.allCases.count, 17)
         XCTAssertEqual(OneSystemActionID.shareLocation.rawValue, "location.share_selected")
         XCTAssertEqual(OneSystemActionID.askForLocation.rawValue, "location.send_request")
         XCTAssertEqual(OneSystemActionID.stopShare.rawValue, "location.stop_share")
         XCTAssertFalse(OneSystemActionID.openLocation.requiresVault)
         XCTAssertTrue(OneSystemActionID.resumeLocation.requiresVault)
+        XCTAssertFalse(OneSystemActionID.openSMSContacts.requiresVault)
     }
 
     @available(iOS 16.0, *)
@@ -268,7 +269,7 @@ final class OneSystemActionInvocationCoordinatorTests: XCTestCase {
     }
 
     @available(iOS 16.0, *)
-    func testAllNineDestinationIntentsRemainNonMutatingAdapters() {
+    func testAllTenDestinationIntentsRemainNonMutatingAdapters() {
         let destinations: Set<OneSystemActionID> = [
             .openLocation,
             .openLocationMap,
@@ -278,7 +279,8 @@ final class OneSystemActionInvocationCoordinatorTests: XCTestCase {
             .openLocationSettings,
             .openTemporaryLink,
             .openCheckIn,
-            .openEmergencySOS
+            .openEmergencySOS,
+            .openSMSContacts
         ]
 
         for actionID in destinations {
@@ -288,5 +290,25 @@ final class OneSystemActionInvocationCoordinatorTests: XCTestCase {
             )
             XCTAssertFalse(actionID.requiresVault)
         }
+    }
+
+    @available(iOS 16.0, *)
+    func testLocationDestinationEntityResolvesNaturalOneVocabulary() async throws {
+        let query = OneLocationDestinationEntityQuery()
+
+        let locationAgent = try await query.entities(matching: "One Location Agent")
+        XCTAssertEqual(locationAgent.compactMap(\.actionID), [.openLocation])
+
+        let map = try await query.entities(matching: "location map")
+        XCTAssertEqual(map.compactMap(\.actionID), [.openLocationMap])
+
+        let sms = try await query.entities(matching: "SMS contacts")
+        XCTAssertEqual(sms.compactMap(\.actionID), [.openSMSContacts])
+
+        XCTAssertEqual(
+            try await query.suggestedEntities().count,
+            10,
+            "Only reviewed, non-mutating Location destinations are system entities."
+        )
     }
 }

--- a/hushh-webapp/ios/App/AppTests/OneVoiceInvocationCoordinatorTests.swift
+++ b/hushh-webapp/ios/App/AppTests/OneVoiceInvocationCoordinatorTests.swift
@@ -160,8 +160,8 @@ final class OneVoiceInvocationCoordinatorTests: XCTestCase {
             )
             XCTAssertEqual(
                 HusshOneAppShortcuts.appShortcuts.count,
-                10,
-                "The App Shortcuts provider intentionally fills Apple's ten-shortcut limit."
+                8,
+                "The focused shortcuts use one destination entity instead of mirroring screens."
             )
         }
         if #available(iOS 26.0, *) {
@@ -171,5 +171,16 @@ final class OneVoiceInvocationCoordinatorTests: XCTestCase {
             )
         }
 #endif
+    }
+
+    func testInstalledAppUsesOneAsItsSpeakableSystemName() {
+        XCTAssertEqual(
+            Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String,
+            "One"
+        )
+        XCTAssertEqual(
+            Bundle.main.object(forInfoDictionaryKey: "CFBundleSpokenName") as? String,
+            "One"
+        )
     }
 }

--- a/hushh-webapp/lib/capacitor/one-system-action-invocation.ts
+++ b/hushh-webapp/lib/capacitor/one-system-action-invocation.ts
@@ -16,6 +16,7 @@ export const ONE_SYSTEM_ACTION_IDS = [
   "location.open_temporary_link",
   "location.open_check_in",
   "location.open_sos",
+  "location.open_sms_contacts",
   "location.share_selected",
   "location.send_request",
   "location.stop_share",

--- a/hushh-webapp/scripts/native/verify-native-static-parity.mjs
+++ b/hushh-webapp/scripts/native/verify-native-static-parity.mjs
@@ -71,16 +71,15 @@ if (!contactsUsageMatch?.[1]?.trim()) {
   fail("iOS Info.plist must include non-empty NSContactsUsageDescription.");
 }
 
-// Brand spelling in the strings iOS actually shows a person: the app name under
-// the icon, in Settings, and in every permission prompt. These are already
-// correct, and this asserts they stay that way — issue #5422 was a brand
-// misspelling that shipped because nothing checked notification/app copy.
+// Siri requires every App Shortcut phrase to contain the system application
+// name. "One" is therefore the deliberate iOS display and spoken name: it is
+// short, pronounceable, and produces phrases such as "Open One Location
+// Agent". Branded privacy explanations continue to say "Hussh One".
 //
-// Scoped to display copy on purpose. `hushh` is load-bearing elsewhere in this
-// same file — the `hushh` CFBundleURLScheme and the com.hushh.app bundle
-// identifier — and renaming either would break deep links and code signing.
-const IOS_PRODUCT_NAME = "Hussh One";
-for (const key of ["CFBundleDisplayName", "CFBundleName"]) {
+// Scoped to visible/spoken copy on purpose. The `hushh` CFBundleURLScheme and
+// com.hushh.app bundle identifier remain load-bearing for deep links/signing.
+const IOS_PRODUCT_NAME = "One";
+for (const key of ["CFBundleDisplayName", "CFBundleName", "CFBundleSpokenName"]) {
   const match = infoPlist.match(
     new RegExp(`<key>${key}</key>\\s*<string>([^<]*)</string>`)
   );


### PR DESCRIPTION
## Description

Physical TestFlight evidence showed Siri never reached the App Intent layer: “Location Agent” was treated as an installed app name and “Hussh One” as a phone contact. This correction makes “One” the installed iOS display/spoken application name, models the reviewed Location destinations as a bounded AppEntity/OpenIntent, and reshapes the zero-setup phrases around natural requests such as “Open One Location Agent” and “Create a Circle in One Location Agent.”

The existing One Voice microphone, generated action gateway, Location handlers, consent/vault guards, and browser settlement remain the only execution path.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] Listed below:
    - Native/TypeScript Siri allowlist adds existing generated action `location.open_sms_contacts`.
    - Adds `OneLocationDestinationEntity` and `OpenOneLocationDestinationIntent`.
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] Listed below:
    - iOS-only Apple system surface; Android and web remain intentionally unsupported.
    - iOS display/spoken app name becomes `One`; bundle id, URL scheme, signing, and branded privacy copy stay unchanged.
- Docs updated (exact files):
  - [x] Listed below:
    - `docs/reference/one/one-voice-runtime-architecture.md`
- Top-level / devex / config / generated / ignore files touched:
  - [x] Listed below with the existing workflow they attach to:
    - `hushh-webapp/scripts/native/verify-native-static-parity.mjs` updates the existing native static parity name contract.
- Trust boundary touched:
  - [x] Auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress listed below:
    - Voice-action ingress only. Structured metadata remains bounded; all mutations still require local device authentication, native confirmation, normal vault authority, and generated gateway settlement.
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Listed below:
    - Unknown destination ids fail closed.
    - Expired/auth/vault/executor lifecycle behavior is unchanged.
    - SOS remains review-only; this change cannot send SOS.
- UI browser or Playwright proof:
  - [x] Not applicable
    - No app UI changed. Physical Siri evidence is the reported regression; native CI and a new TestFlight build are the acceptance lanes.
- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] Focused Vitest: 5 files / 20 tests
  - [x] One Voice Vitest: 3 files / 29 tests
  - [x] Backend One Live/Agent Chat: 83 tests
  - [x] `npm run verify:voice-gateway`
  - [x] `npm run verify:surface-map`
  - [x] `npm run verify:capacitor:plugins`
  - [x] `npm run verify:capacitor:static`
  - [x] `./bin/hushh docs verify`
  - [x] `bash scripts/ci/orchestrate.sh governance`
  - [x] Swift iOS 16 compiler typecheck
  - [ ] Native XCTest locally (no installed iOS Simulator runtime; macOS CI is authoritative)
  - [ ] Capacitor production build locally (compile/typecheck passed; isolated worktree lacked materialized Firebase UAT key)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related merged PRs were checked; this extends PRs #6380/#6381 rather than duplicating them.
- [x] This PR changes a current reachable native app surface.
- [x] Reachable production attach point: `HusshOneAppShortcuts` → existing native pending invocation → existing Agent Bar action executor.
- [x] New tests exercise production App Entity, allowlist, Info.plist, and bridge code.
- [x] New entity/intent is wired into the existing AppShortcutsProvider.
- [x] Production surface proved: AppDelegate updates shortcut parameters at launch; entity-index changes republish parameters.
- [ ] Required GitHub checks are current and mergeable (pending CI).
- [x] Maintainer edits are enabled.
- [x] If this responds to requested changes: physical TestFlight screenshots showed generic Siri app/contact fallback.

## 🛑 Tri-Flow Architecture Check

- [ ] Web: not applicable; this is an Apple system surface, while the shared executor remains web/Capacitor code.
- [x] iOS: App Intents/App Entity plus existing Capacitor handoff.
- [ ] Android: not applicable; Android explicitly returns unsupported for Siri.

## 🧪 Testing

- [x] Tested shared web/Capacitor contracts
- [ ] Tested on iOS Simulator/Device (CI XCTest and follow-up TestFlight pending)
- [ ] Tested on Android Emulator/Device (not applicable to Siri)
- [x] Commits are signed off
- [x] Generated voice and surface artifacts verified unchanged/current

## 📸 Screenshots / Video

The physical-device failure evidence is attached in the originating task: Siri reports no app named “Location Agent” or attempts to find “Hussh One” in Contacts. The corrected build will be validated with the new exact phrases after TestFlight processing.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? It exposes only the existing owner-bound contact/Circle name index and reviewed destination names.
- [x] Existing consent/vault enforcement remains unchanged.
- [x] Sensitive surface touched: voice-action.
- [x] Error path: unknown ids, missing auth, locked vault, expiry, and missing executor all fail closed.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependency or third-party notice changes.