### PR TITLE
test(ios): await Siri destinations before assertion

### DIFF
--- a/hushh-webapp/ios/App/AppTests/OneSystemActionInvocationCoordinatorTests.swift
+++ b/hushh-webapp/ios/App/AppTests/OneSystemActionInvocationCoordinatorTests.swift
@@ -305,8 +305,9 @@ final class OneSystemActionInvocationCoordinatorTests: XCTestCase {
         let sms = try await query.entities(matching: "SMS contacts")
         XCTAssertEqual(sms.compactMap(\.actionID), [.openSMSContacts])
 
+        let suggestedDestinations = try await query.suggestedEntities()
         XCTAssertEqual(
-            try await query.suggestedEntities().count,
+            suggestedDestinations.count,
             10,
             "Only reviewed, non-mutating Location destinations are system entities."
         )


### PR DESCRIPTION
## Summary

Fix the native Siri destination query test caught by the TestFlight release gate. Swift/XCTest does not support an async call inside the `XCTAssertEqual` autoclosure, so the test now awaits the destinations first and asserts the resulting count.

## Impact map

- production behavior: unchanged
- App Intent metadata: unchanged
- native tests: compile fix only
- backend/generated action gateway: unchanged

## Verification

- App Intent Swift sources typecheck for the iOS 16 simulator target
- `git diff --check` passes
- branch is exactly one signed commit ahead of current `origin/main`
- authoritative Xcode XCTest/archive remains the governed TestFlight pipeline gate

## Release context

Follow-up to #6383 and failed TestFlight run 33574976973. No archive or upload occurred in that failed run.