### PR TITLE
Fix Siri bundle identity and TestFlight rejection detection

### DIFF
--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -315,6 +315,12 @@ jobs:
           echo "next_build=${NEXT_BUILD}" >> "$GITHUB_OUTPUT"
           echo "Next build number: ${NEXT_BUILD}"
 
+      - name: Test App Store Connect processing gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${RUNNER_TEMP}/asc-venv/bin/python" scripts/ci/test_wait_for_testflight_build.py
+
       - name: Cache Swift packages
         uses: actions/cache@v4
         with:
@@ -421,61 +427,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          "${RUNNER_TEMP}/asc-venv/bin/python" - <<'EOF'
-          import urllib.request, json, time, jwt, os, sys
-
-          p8_path = os.environ["RUNNER_TEMP"] + "/asc.p8"
-          key_id = os.environ["ASC_KEY_ID"]
-          issuer_id = os.environ["ASC_ISSUER_ID"]
-          bundle_id = os.environ.get("IOS_BUNDLE_ID", "com.hushh.app")
-          target_version = "${{ steps.build_number.outputs.next_build }}"
-
-          with open(p8_path, "rb") as f:
-              p8_bytes = f.read()
-
-          def mint_token():
-              now = int(time.time())
-              payload = {"iss": issuer_id, "iat": now, "exp": now + 1200, "aud": "appstoreconnect-v1"}
-              headers = {"kid": key_id, "typ": "JWT"}
-              return jwt.encode(payload, p8_bytes, algorithm="ES256", headers=headers)
-
-          token = mint_token()
-          req = urllib.request.Request(f"https://api.appstoreconnect.apple.com/v1/apps?filter[bundleId]={bundle_id}", headers={"Authorization": f"Bearer {token}"})
-          with urllib.request.urlopen(req) as r:
-              app_id = json.loads(r.read())["data"][0]["id"]
-
-          print(f"Polling App Store Connect for Build {target_version} processing status...")
-          success = False
-          for attempt in range(1, 31):
-              token = mint_token()
-              url = f"https://api.appstoreconnect.apple.com/v1/builds?filter[app]={app_id}&limit=10&sort=-uploadedDate&include=buildBetaDetail"
-              req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
-              try:
-                  with urllib.request.urlopen(req) as r:
-                      data = json.loads(r.read())
-                  for b in data.get("data", []):
-                      attr = b.get("attributes") or {}
-                      ver = attr.get("version")
-                      state = attr.get("processingState")
-                      enc = attr.get("usesNonExemptEncryption")
-                      if str(ver) == str(target_version):
-                          print(f"Attempt {attempt}: Build {target_version} found! ProcessingState: {state}, EncryptionExempt: {enc == False}")
-                          if state == "VALID":
-                              print(f"==> Build {target_version} processing is VALID and TestFlight distribution is ready!")
-                              success = True
-                              break
-                          elif state in ("FAILED", "INVALID"):
-                              print(f"==> Build {target_version} processing failed on App Store Connect with state: {state}")
-                              sys.exit(1)
-              except Exception as exc:
-                  print(f"Attempt {attempt}: transient error querying ASC API: {exc}")
-              if success:
-                  break
-              time.sleep(15)
-
-          if not success:
-              print(f"==> Warning: Polling timed out before build {target_version} reached VALID state.")
-          EOF
+          MARKETING="$(grep -m1 -E 'MARKETING_VERSION[[:space:]]*=' "${PBXPROJ}" | sed -E 's/.*= *([^;]+);.*/\1/' | tr -d ' ')"
+          "${RUNNER_TEMP}/asc-venv/bin/python" scripts/ci/wait_for_testflight_build.py \
+            --p8-path "${RUNNER_TEMP}/asc.p8" \
+            --key-id "${ASC_KEY_ID}" \
+            --issuer-id "${ASC_ISSUER_ID}" \
+            --bundle-id "${IOS_BUNDLE_ID}" \
+            --marketing-version "${MARKETING}" \
+            --build-number "${{ steps.build_number.outputs.next_build }}" \
+            --timeout-seconds 1200 \
+            --poll-interval-seconds 15
+          echo "upload_state=COMPLETE" >> "$GITHUB_OUTPUT"
+          echo "processing_state=VALID" >> "$GITHUB_OUTPUT"
 
       - name: Upload build artifacts
         if: always()
@@ -507,6 +470,8 @@ jobs:
             echo "| Bundle | ${IOS_BUNDLE_ID} |"
             echo "| Backend | UAT (hushh-pda-uat) |"
             echo "| Mode | ${{ github.event.inputs.dry_run == 'true' && 'dry run (no upload)' || 'upload to TestFlight' }} |"
+            echo "| Apple upload | ${{ steps.poll_asc.outputs.upload_state || (github.event.inputs.dry_run == 'true' && 'not uploaded' || 'not verified') }} |"
+            echo "| TestFlight processing | ${{ steps.poll_asc.outputs.processing_state || (github.event.inputs.dry_run == 'true' && 'not uploaded' || 'not verified') }} |"
             if [ -n "${{ github.event.inputs.notes }}" ]; then
               echo "| Notes | ${{ github.event.inputs.notes }} |"
             fi

--- a/docs/guides/mobile/ship-ios-testflight.md
+++ b/docs/guides/mobile/ship-ios-testflight.md
@@ -40,6 +40,7 @@ xcodebuild -resolvePackageDependencies -project ios/App/App.xcodeproj -scheme Ap
 xcodebuild test -project ios/App/App.xcodeproj -scheme App -only-testing:AppTests  # blocks upload on native unit failures
 xcodebuild archive        -allowProvisioningUpdates -authenticationKey{Path,ID,IssuerID} CURRENT_PROJECT_VERSION=$NEXT_BUILD
 xcodebuild -exportArchive -exportOptionsPlist ios/ExportOptions/AppStoreConnect.plist  # destination=upload → TestFlight
+python3 scripts/ci/wait_for_testflight_build.py ... # buildUploads=COMPLETE + exact build=VALID
 ```
 
 Signing needs no build-setting overrides — `CODE_SIGN_STYLE=Automatic`,
@@ -48,6 +49,11 @@ Signing needs no build-setting overrides — `CODE_SIGN_STYLE=Automatic`,
 `CFBundleVersion=$(CURRENT_PROJECT_VERSION)`, so the resolved build number bakes in with no
 `agvtool`/pbxproj edit. `ITSAppUsesNonExemptEncryption=false` in `Info.plist` is what keeps the
 upload out of "Missing Compliance".
+
+The upload step is not the terminal release proof. The workflow polls Apple's
+exact `buildUploads` record so delivery failures (including `ITMS-*` import
+errors) fail the run, then requires the corresponding TestFlight build to reach
+`processingState=VALID`. Missing uploads, API failures, and timeouts fail closed.
 
 ## One-time setup (secret-touching — the operator does this)
 

--- a/docs/reference/one/one-voice-runtime-architecture.md
+++ b/docs/reference/one/one-voice-runtime-architecture.md
@@ -127,9 +127,11 @@ release:
   a confirmation gate. Siri may open the existing SOS review surface, but it
   cannot send the alert in this release.
 
-The installed iOS display and spoken name is `One`, so Apple's mandatory
-`applicationName` phrase token produces direct requests such as “Open One
-Location Agent” instead of requiring the harder-to-pronounce HUSSH brand name.
+The internal iOS bundle name remains the unique, previously accepted
+`Hussh One`. The installed display name and `CFBundleSpokenName` are `One`, so
+Apple's mandatory `applicationName` phrase token continues to produce direct
+requests such as “Open One Location Agent” without changing the signed bundle
+identifier or creating a second Siri runtime.
 One bounded `OneLocationDestinationEntity` represents the ten reviewed,
 non-mutating Location destinations (including map, requests, settings,
 Check-In, SOS review, and emergency SMS contacts). Its `OpenIntent` tells Siri

--- a/hushh-webapp/ios/App/App/Info.plist
+++ b/hushh-webapp/ios/App/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>One</string>
+	<string>Hussh One</string>
 	<key>CFBundleSpokenName</key>
 	<string>One</string>
 	<key>CFBundlePackageType</key>

--- a/hushh-webapp/ios/App/AppTests/OneVoiceInvocationCoordinatorTests.swift
+++ b/hushh-webapp/ios/App/AppTests/OneVoiceInvocationCoordinatorTests.swift
@@ -173,10 +173,14 @@ final class OneVoiceInvocationCoordinatorTests: XCTestCase {
 #endif
     }
 
-    func testInstalledAppUsesOneAsItsSpeakableSystemName() {
+    func testInstalledAppSeparatesBundleIdentityFromSpeakableSystemName() {
         XCTAssertEqual(
             Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String,
             "One"
+        )
+        XCTAssertEqual(
+            Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String,
+            "Hussh One"
         )
         XCTAssertEqual(
             Bundle.main.object(forInfoDictionaryKey: "CFBundleSpokenName") as? String,

--- a/hushh-webapp/scripts/native/verify-native-static-parity.mjs
+++ b/hushh-webapp/scripts/native/verify-native-static-parity.mjs
@@ -71,21 +71,25 @@ if (!contactsUsageMatch?.[1]?.trim()) {
   fail("iOS Info.plist must include non-empty NSContactsUsageDescription.");
 }
 
-// Siri requires every App Shortcut phrase to contain the system application
-// name. "One" is therefore the deliberate iOS display and spoken name: it is
-// short, pronounceable, and produces phrases such as "Open One Location
-// Agent". Branded privacy explanations continue to say "Hussh One".
+// Keep the distributed bundle identity at the unique, previously accepted
+// "Hussh One" while the visible and spoken system name remains the intentional
+// Siri-facing "One". These fields are separate contracts and must not collapse
+// back to the globally generic bundle name that App Store Connect rejected.
 //
 // Scoped to visible/spoken copy on purpose. The `hushh` CFBundleURLScheme and
 // com.hushh.app bundle identifier remain load-bearing for deep links/signing.
-const IOS_PRODUCT_NAME = "One";
-for (const key of ["CFBundleDisplayName", "CFBundleName", "CFBundleSpokenName"]) {
+const expectedIosNames = new Map([
+  ["CFBundleDisplayName", "One"],
+  ["CFBundleName", "Hussh One"],
+  ["CFBundleSpokenName", "One"],
+]);
+for (const [key, expected] of expectedIosNames) {
   const match = infoPlist.match(
     new RegExp(`<key>${key}</key>\\s*<string>([^<]*)</string>`)
   );
-  if (match?.[1] !== IOS_PRODUCT_NAME) {
+  if (match?.[1] !== expected) {
     fail(
-      `iOS Info.plist ${key} must be "${IOS_PRODUCT_NAME}" (found "${match?.[1] ?? "missing"}").`
+      `iOS Info.plist ${key} must be "${expected}" (found "${match?.[1] ?? "missing"}").`
     );
   }
 }

--- a/scripts/ci/test_wait_for_testflight_build.py
+++ b/scripts/ci/test_wait_for_testflight_build.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Hushh
+"""Unit tests for the fail-closed TestFlight processing gate."""
+
+from __future__ import annotations
+
+import unittest
+
+import wait_for_testflight_build as gate
+
+
+def upload_payload(
+    state: str,
+    *,
+    details: list[dict[str, str]] | None = None,
+    build_state: str | None = None,
+) -> dict:
+    payload: dict = {
+        "data": [
+            {
+                "type": "buildUploads",
+                "attributes": {
+                    "cfBundleShortVersionString": "1.3.9",
+                    "cfBundleVersion": "90",
+                    "state": {
+                        "state": state,
+                        "errors": details or [],
+                        "warnings": [],
+                        "infos": [],
+                    },
+                },
+            }
+        ]
+    }
+    if build_state is not None:
+        payload["included"] = [
+            {
+                "type": "builds",
+                "attributes": {
+                    "version": "90",
+                    "processingState": build_state,
+                    "usesNonExemptEncryption": False,
+                },
+            }
+        ]
+    return payload
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def now(self) -> float:
+        return self.value
+
+    def sleep(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class WaitForTestFlightBuildTests(unittest.TestCase):
+    def wait(self, payloads: list[dict], timeout: int = 30) -> dict:
+        clock = Clock()
+        remaining = list(payloads)
+
+        def get_payload(_url: str) -> dict:
+            if len(remaining) > 1:
+                return remaining.pop(0)
+            return remaining[0]
+
+        return gate.wait_for_testflight_build(
+            app_id="6757718917",
+            marketing_version="1.3.9",
+            build_number="90",
+            platform="IOS",
+            timeout_seconds=timeout,
+            poll_interval_seconds=5,
+            get_payload=get_payload,
+            now=clock.now,
+            sleep=clock.sleep,
+        )
+
+    def test_upload_failure_surfaces_apple_issue_code(self) -> None:
+        payload = upload_payload(
+            "FAILED",
+            details=[
+                {
+                    "code": "ITMS-90129",
+                    "description": "The bundle uses a display name that is already taken.",
+                }
+            ],
+        )
+        with self.assertRaisesRegex(gate.BuildUploadFailed, "ITMS-90129"):
+            self.wait([payload])
+
+    def test_complete_upload_requires_valid_testflight_build(self) -> None:
+        build = self.wait(
+            [
+                upload_payload("PROCESSING"),
+                upload_payload("COMPLETE", build_state="PROCESSING"),
+                upload_payload("COMPLETE", build_state="VALID"),
+            ]
+        )
+        self.assertEqual(build["attributes"]["processingState"], "VALID")
+
+    def test_invalid_testflight_build_fails_closed(self) -> None:
+        with self.assertRaises(gate.TestFlightBuildFailed):
+            self.wait([upload_payload("COMPLETE", build_state="INVALID")])
+
+    def test_timeout_is_an_error(self) -> None:
+        with self.assertRaisesRegex(TimeoutError, "last state: build upload PROCESSING"):
+            self.wait([upload_payload("PROCESSING")], timeout=10)
+
+    def test_repeated_transient_api_errors_fail_on_timeout(self) -> None:
+        clock = Clock()
+
+        def get_payload(_url: str) -> dict:
+            raise gate.AscTransientError("HTTP 503 while querying Apple")
+
+        with self.assertRaisesRegex(TimeoutError, "transient API error"):
+            gate.wait_for_testflight_build(
+                app_id="6757718917",
+                marketing_version="1.3.9",
+                build_number="90",
+                platform="IOS",
+                timeout_seconds=10,
+                poll_interval_seconds=5,
+                get_payload=get_payload,
+                now=clock.now,
+                sleep=clock.sleep,
+            )
+
+    def test_transient_build_lookup_recovers_after_upload_completes(self) -> None:
+        clock = Clock()
+        requests = 0
+
+        def get_payload(url: str) -> dict:
+            nonlocal requests
+            requests += 1
+            if "buildUploads" in url:
+                if requests >= 4:
+                    return upload_payload("COMPLETE", build_state="VALID")
+                return upload_payload("COMPLETE")
+            raise gate.AscTransientError("HTTP 503 while querying Apple")
+
+        build = gate.wait_for_testflight_build(
+            app_id="6757718917",
+            marketing_version="1.3.9",
+            build_number="90",
+            platform="IOS",
+            timeout_seconds=15,
+            poll_interval_seconds=5,
+            get_payload=get_payload,
+            now=clock.now,
+            sleep=clock.sleep,
+        )
+        self.assertEqual(build["attributes"]["processingState"], "VALID")
+
+    def test_exact_build_upload_is_selected(self) -> None:
+        payload = upload_payload("COMPLETE", build_state="VALID")
+        payload["data"].insert(
+            0,
+            {
+                "type": "buildUploads",
+                "attributes": {
+                    "cfBundleShortVersionString": "1.3.9",
+                    "cfBundleVersion": "89",
+                    "state": {"state": "FAILED", "errors": []},
+                },
+            },
+        )
+        build = self.wait([payload])
+        self.assertEqual(build["attributes"]["version"], "90")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/wait_for_testflight_build.py
+++ b/scripts/ci/wait_for_testflight_build.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Hushh
+"""Wait for an uploaded iOS build to become ready in TestFlight.
+
+App Store Connect exposes two related resources with different lifecycles:
+
+* ``buildUploads`` exists while Apple validates an upload and contains the
+  actionable import errors that would otherwise arrive only by email.
+* ``builds`` exists after import and reports TestFlight processing state.
+
+The release gate must inspect both. Polling ``builds`` alone cannot distinguish
+an upload that is still processing from one Apple has already rejected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from typing import Any, NoReturn
+
+ASC_API_ROOT = "https://api.appstoreconnect.apple.com"
+ASC_AUDIENCE = "appstoreconnect-v1"
+DEFAULT_BUNDLE_ID = "com.hushh.app"
+DEFAULT_PLATFORM = "IOS"
+UPLOAD_COMPLETE = "COMPLETE"
+UPLOAD_FAILED = "FAILED"
+BUILD_VALID = "VALID"
+BUILD_TERMINAL_BAD = {"FAILED", "INVALID"}
+
+
+class BuildUploadFailed(RuntimeError):
+    """Apple rejected the uploaded binary during import validation."""
+
+
+class TestFlightBuildFailed(RuntimeError):
+    """Apple imported the binary but TestFlight processing failed."""
+
+
+class AscTransientError(RuntimeError):
+    """A retryable App Store Connect transport or service failure."""
+
+
+def log(message: str) -> None:
+    print(message, flush=True)
+
+
+def die(message: str) -> NoReturn:
+    print(f"wait-for-testflight-build: {message}", file=sys.stderr, flush=True)
+    raise SystemExit(1)
+
+
+def mint_jwt(p8_path: str, key_id: str, issuer_id: str) -> str:
+    try:
+        import jwt  # PyJWT
+    except ImportError:
+        die("PyJWT is required (pip install pyjwt cryptography)")
+
+    try:
+        with open(p8_path, "r", encoding="utf-8") as handle:
+            private_key = handle.read()
+    except OSError as exc:
+        die(f"cannot read App Store Connect key at {p8_path}: {exc}")
+
+    now = int(time.time())
+    payload = {
+        "iss": issuer_id,
+        "iat": now,
+        "exp": now + 19 * 60,
+        "aud": ASC_AUDIENCE,
+    }
+    try:
+        token = jwt.encode(
+            payload,
+            private_key,
+            algorithm="ES256",
+            headers={"kid": key_id, "typ": "JWT"},
+        )
+    except Exception as exc:
+        die(f"failed to sign App Store Connect JWT: {exc}")
+    return token if isinstance(token, str) else token.decode("utf-8")
+
+
+def asc_get(url: str, token: str) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        },
+        method="GET",
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def resolve_app_id(token: str, bundle_id: str) -> str:
+    query = urllib.parse.urlencode({"filter[bundleId]": bundle_id, "limit": "1"})
+    payload = asc_get(f"{ASC_API_ROOT}/v1/apps?{query}", token)
+    data = payload.get("data") or []
+    if not data:
+        die(f"no App Store Connect app found for bundle id {bundle_id}")
+    return str(data[0]["id"])
+
+
+def build_upload_url(
+    app_id: str,
+    marketing_version: str,
+    build_number: str,
+    platform: str,
+) -> str:
+    query = urllib.parse.urlencode(
+        {
+            "filter[cfBundleShortVersionString]": marketing_version,
+            "filter[cfBundleVersion]": build_number,
+            "filter[platform]": platform,
+            "fields[buildUploads]": (
+                "cfBundleShortVersionString,cfBundleVersion,createdDate,"
+                "state,platform,uploadedDate,build"
+            ),
+            "fields[builds]": (
+                "version,uploadedDate,processingState,usesNonExemptEncryption"
+            ),
+            "include": "build",
+            "limit": "10",
+            "sort": "-uploadedDate",
+        }
+    )
+    return f"{ASC_API_ROOT}/v1/apps/{app_id}/buildUploads?{query}"
+
+
+def build_url(app_id: str, marketing_version: str, build_number: str) -> str:
+    query = urllib.parse.urlencode(
+        {
+            "filter[app]": app_id,
+            "filter[preReleaseVersion.version]": marketing_version,
+            "filter[version]": build_number,
+            "fields[builds]": (
+                "version,uploadedDate,processingState,usesNonExemptEncryption"
+            ),
+            "limit": "1",
+        }
+    )
+    return f"{ASC_API_ROOT}/v1/builds?{query}"
+
+
+def upload_state(upload: dict[str, Any]) -> tuple[str | None, list[dict[str, Any]]]:
+    raw = (upload.get("attributes") or {}).get("state")
+    if isinstance(raw, str):
+        return raw, []
+    if not isinstance(raw, dict):
+        return None, []
+    details: list[dict[str, Any]] = []
+    for key in ("errors", "warnings", "infos"):
+        values = raw.get(key) or []
+        if isinstance(values, list):
+            details.extend(item for item in values if isinstance(item, dict))
+    state = raw.get("state")
+    return str(state) if state is not None else None, details
+
+
+def matching_upload(
+    payload: dict[str, Any], marketing_version: str, build_number: str
+) -> dict[str, Any] | None:
+    for upload in payload.get("data") or []:
+        attrs = upload.get("attributes") or {}
+        if (
+            str(attrs.get("cfBundleShortVersionString")) == marketing_version
+            and str(attrs.get("cfBundleVersion")) == build_number
+        ):
+            return upload
+    return None
+
+
+def matching_build(payload: dict[str, Any], build_number: str) -> dict[str, Any] | None:
+    candidates = list(payload.get("included") or []) + list(payload.get("data") or [])
+    for resource in candidates:
+        if resource.get("type") != "builds":
+            continue
+        attrs = resource.get("attributes") or {}
+        if str(attrs.get("version")) == build_number:
+            return resource
+    return None
+
+
+def format_state_details(details: list[dict[str, Any]]) -> str:
+    rendered: list[str] = []
+    for detail in details:
+        code = str(detail.get("code") or "UNKNOWN")
+        description = " ".join(str(detail.get("description") or "").split())
+        rendered.append(f"{code}: {description}" if description else code)
+    return "; ".join(rendered) if rendered else "no error details returned"
+
+
+def wait_for_testflight_build(
+    *,
+    app_id: str,
+    marketing_version: str,
+    build_number: str,
+    platform: str,
+    timeout_seconds: int,
+    poll_interval_seconds: int,
+    get_payload: Callable[[str], dict[str, Any]],
+    now: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    deadline = now() + timeout_seconds
+    attempt = 0
+    last_state = "not found"
+
+    while now() < deadline:
+        attempt += 1
+        try:
+            upload_payload = get_payload(
+                build_upload_url(app_id, marketing_version, build_number, platform)
+            )
+        except AscTransientError as exc:
+            last_state = f"transient API error: {exc}"
+            log(f"Attempt {attempt}: {last_state}")
+            remaining = deadline - now()
+            if remaining <= 0:
+                break
+            sleep(min(float(poll_interval_seconds), remaining))
+            continue
+        upload = matching_upload(upload_payload, marketing_version, build_number)
+        if upload is None:
+            last_state = "upload not found"
+            log(f"Attempt {attempt}: {last_state}")
+        else:
+            state, details = upload_state(upload)
+            last_state = f"build upload {state or 'UNKNOWN'}"
+            log(f"Attempt {attempt}: {last_state}")
+            if state == UPLOAD_FAILED:
+                raise BuildUploadFailed(format_state_details(details))
+
+            if state == UPLOAD_COMPLETE:
+                build = matching_build(upload_payload, build_number)
+                if build is None:
+                    try:
+                        build_payload = get_payload(
+                            build_url(app_id, marketing_version, build_number)
+                        )
+                    except AscTransientError as exc:
+                        last_state = (
+                            "build upload COMPLETE; transient build API error: "
+                            f"{exc}"
+                        )
+                        log(f"Attempt {attempt}: {last_state}")
+                    else:
+                        build = matching_build(build_payload, build_number)
+                if build is not None:
+                    attrs = build.get("attributes") or {}
+                    processing_state = attrs.get("processingState")
+                    last_state = f"build upload COMPLETE; build {processing_state or 'UNKNOWN'}"
+                    log(f"Attempt {attempt}: {last_state}")
+                    if processing_state == BUILD_VALID:
+                        return build
+                    if processing_state in BUILD_TERMINAL_BAD:
+                        raise TestFlightBuildFailed(
+                            f"build processingState={processing_state}"
+                        )
+
+        remaining = deadline - now()
+        if remaining <= 0:
+            break
+        sleep(min(float(poll_interval_seconds), remaining))
+
+    raise TimeoutError(
+        f"timed out after {timeout_seconds}s waiting for "
+        f"{marketing_version} ({build_number}); last state: {last_state}"
+    )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--p8-path", default=os.environ.get("APPSTORE_CONNECT_API_KEY_PATH"))
+    parser.add_argument(
+        "--key-id",
+        default=os.environ.get("APPSTORE_CONNECT_KEY_ID") or os.environ.get("ASC_KEY_ID"),
+    )
+    parser.add_argument(
+        "--issuer-id",
+        default=os.environ.get("APPSTORE_CONNECT_ISSUER_ID")
+        or os.environ.get("ASC_ISSUER_ID"),
+    )
+    parser.add_argument(
+        "--bundle-id", default=os.environ.get("IOS_BUNDLE_ID", DEFAULT_BUNDLE_ID)
+    )
+    parser.add_argument("--marketing-version", required=True)
+    parser.add_argument("--build-number", required=True)
+    parser.add_argument("--platform", default=DEFAULT_PLATFORM)
+    parser.add_argument("--timeout-seconds", type=int, default=1200)
+    parser.add_argument("--poll-interval-seconds", type=int, default=15)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    missing = [
+        name
+        for name, value in (
+            ("--p8-path", args.p8_path),
+            ("--key-id", args.key_id),
+            ("--issuer-id", args.issuer_id),
+        )
+        if not value
+    ]
+    if missing:
+        die(f"missing required argument(s): {', '.join(missing)}")
+    if args.timeout_seconds <= 0 or args.poll_interval_seconds <= 0:
+        die("timeout and poll interval must be positive")
+
+    def get_payload(url: str) -> dict[str, Any]:
+        token = mint_jwt(args.p8_path, args.key_id, args.issuer_id)
+        try:
+            return asc_get(url, token)
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")
+            if exc.code == 429 or exc.code >= 500:
+                raise AscTransientError(
+                    f"HTTP {exc.code} while querying Apple"
+                ) from exc
+            raise RuntimeError(
+                f"App Store Connect API {exc.code} for {url}: {detail}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise AscTransientError(f"request failed: {exc.reason}") from exc
+
+    token = mint_jwt(args.p8_path, args.key_id, args.issuer_id)
+    app_id = resolve_app_id(token, args.bundle_id)
+    log(
+        "Polling App Store Connect build upload and TestFlight processing for "
+        f"{args.marketing_version} ({args.build_number})..."
+    )
+    try:
+        build = wait_for_testflight_build(
+            app_id=app_id,
+            marketing_version=args.marketing_version,
+            build_number=str(args.build_number),
+            platform=args.platform,
+            timeout_seconds=args.timeout_seconds,
+            poll_interval_seconds=args.poll_interval_seconds,
+            get_payload=get_payload,
+        )
+    except (BuildUploadFailed, TestFlightBuildFailed, TimeoutError, RuntimeError) as exc:
+        die(str(exc))
+
+    attrs = build.get("attributes") or {}
+    log(
+        f"Build {args.marketing_version} ({args.build_number}) is VALID and ready "
+        f"for TestFlight testing (encryption exempt: "
+        f"{attrs.get('usesNonExemptEncryption') is False})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

- restore the previously accepted internal iOS bundle name `Hussh One`
- keep `One` as the installed display and spoken name used by App Shortcuts
- replace the false-green App Store Connect poll with an exact, fail-closed build-upload/TestFlight gate
- add deterministic tests for upload rejection, processing failure, recovery, exact build selection, and timeout

## Incident

TestFlight upload `1.3.9 (90)` reached Apple transport successfully but failed server-side processing with `ITMS-90129`. The release workflow queried only processed builds, so the rejected upload never appeared and the timeout incorrectly exited successfully.

## Verification

- `python3 scripts/ci/test_wait_for_testflight_build.py` (7 passed)
- `plutil -lint hushh-webapp/ios/App/App/Info.plist`
- `npm run verify:capacitor:static`
- `npm run verify:capacitor:plugins`
- `npm run build:voice-gateway`
- `npm run verify:voice-gateway`
- `npm run typecheck`
- targeted voice tests (29 passed)
- targeted One live/chat backend tests (83 passed)
- `./bin/hushh docs verify`
- `gitleaks protect --staged --redact --verbose`

Local generic iOS build is unavailable because this Mac has no installed iOS platform/simulator runtime. The governed TestFlight workflow runs the complete native `AppTests` suite and archive on Xcode 26.3 before upload.

The broad local PR mirror also reports 14 pre-existing frontend test failures reproduced unchanged on current `origin/main`; none touch this PR's surfaces.

## Risk and rollback

The Siri/App Intents runtime, generated action gateway, bundle identifier, signing, and backend contract are unchanged. If Apple still rejects the user-facing display name `One`, the hardened workflow will surface the exact delivery error instead of reporting success; the fallback is to restore the display name without changing the Siri runtime.
