### PR TITLE
fix(email): resolve status tile duplication and persistence after sync

### DIFF
--- a/hushh-webapp/lib/profile/gmail-connector-store.ts
+++ b/hushh-webapp/lib/profile/gmail-connector-store.ts
@@ -232,6 +232,7 @@ function deriveConnectorTaskKind(
     .trim()
     .toLowerCase();
   if (triggerSource === "connect") return "gmail_bootstrap";
+  if (triggerSource === "user_manual") return "gmail_manual_sync";
   if (
     triggerSource === "auto_daily" ||
     triggerSource === "backfill" ||

--- a/hushh-webapp/lib/services/app-background-task-service.ts
+++ b/hushh-webapp/lib/services/app-background-task-service.ts
@@ -183,7 +183,6 @@ class AppBackgroundTaskManager {
   private scheduleAutoClear(task: AppBackgroundTask): void {
     this.clearAutoClearTimer(task.taskId);
     if (
-      task.visibility !== "passive" ||
       task.dismissedAt ||
       task.autoClearAfterMs <= 0 ||
       (task.status !== "completed" && task.status !== "canceled")


### PR DESCRIPTION
## Summary
Fixes GitHub #6305 where completing an Email Agent sync caused the "Synced" status tile to render twice and persist indefinitely on screen.

## Root Causes & Fixes
1. **Deduplication (`gmail-connector-store.ts`)**:
   - Reordered `deriveConnectorTaskKind()` so `triggerSource === "user_manual"` is evaluated before matching `sync_mode === "incremental"`.
   - Ensures user-initiated manual syncs are classified strictly as `gmail_manual_sync` (`primary`), preventing the concurrent creation of a second `gmail_backfill` (`passive`) task ID for the same run.
   - Preserves routine background backfills (`auto_daily`, `backfill`, `scheduled`, etc.) as passive tasks, keeping the earlier button-cycling fix intact.

2. **Auto-Clear Dismissal (`app-background-task-service.ts`)**:
   - Removed the `task.visibility !== "passive"` guard from `scheduleAutoClear()`.
   - Allows completed primary tasks with `autoClearAfterMs > 0` (such as manual syncs with a 10s auto-clear timer) to schedule dismissal automatically instead of remaining in session state indefinitely.

## Verification
- Unit Tests: `npx vitest run` -> **11/11 Passed**.
- Production Build: `npm run build` -> **TypeScript type check passed with 0 errors**.
- Scope Control: Strictly 2 files modified.