### PR TITLE
fix(ios): call the Siri surface Agent One

### DIFF
--- a/docs/reference/one/one-voice-runtime-architecture.md
+++ b/docs/reference/one/one-voice-runtime-architecture.md
@@ -128,18 +128,18 @@ release:
   cannot send the alert in this release.
 
 The internal iOS bundle name remains the unique, previously accepted
-`Hussh One`. The installed display name and `CFBundleSpokenName` are `One`, so
+`Hussh One`. The installed display name and `CFBundleSpokenName` are `Agent One`, so
 Apple's mandatory `applicationName` phrase token continues to produce direct
-requests such as “Open One Location Agent” without changing the signed bundle
+requests such as “Open Agent One Location Agent” without changing the signed bundle
 identifier or creating a second Siri runtime.
 One bounded `OneLocationDestinationEntity` represents the ten reviewed,
 non-mutating Location destinations (including map, requests, settings,
 Check-In, SOS review, and emergency SMS contacts). Its `OpenIntent` tells Siri
-that “Location Agent” is content inside One rather than a separate app.
+that “Location Agent” is content inside Agent One rather than a separate app.
 
 Apple limits an app to ten zero-setup App Shortcuts. The provider deliberately
 publishes eight focused shortcuts: share, ask, stop, location on/off, create
-Circle, Check-In, open a structured Location destination, and Talk to One.
+Circle, Check-In, open a structured Location destination, and Talk to Agent One.
 Mutation intents keep Apple's parameter follow-ups and native confirmation,
 then hand the exact generated action to the existing browser executor. The
 other App Intents remain discoverable in the Shortcuts app. Android and web

--- a/hushh-webapp/ios/App/App/Info.plist
+++ b/hushh-webapp/ios/App/App/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>One</string>
+	<string>Agent One</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -17,7 +17,7 @@
 	<key>CFBundleName</key>
 	<string>Hussh One</string>
 	<key>CFBundleSpokenName</key>
-	<string>One</string>
+	<string>Agent One</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
+++ b/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
@@ -9,7 +9,7 @@ struct OneContactEntity: AppEntity, Identifiable, Hashable {
     let id: String
     let name: String
 
-    static let typeDisplayRepresentation: TypeDisplayRepresentation = "One Contact"
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Agent One Contact"
     static let defaultQuery = OneContactEntityQuery()
 
     var displayRepresentation: DisplayRepresentation {
@@ -45,7 +45,7 @@ struct OneCircleEntity: AppEntity, Identifiable, Hashable {
     let id: String
     let name: String
 
-    static let typeDisplayRepresentation: TypeDisplayRepresentation = "One Circle"
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Agent One Circle"
     static let defaultQuery = OneCircleEntityQuery()
 
     var displayRepresentation: DisplayRepresentation {
@@ -61,7 +61,7 @@ struct OneLocationDestinationEntity: AppEntity, Identifiable, Hashable {
     let id: String
 
     static let typeDisplayRepresentation: TypeDisplayRepresentation =
-        "One Location Destination"
+        "Agent One Location Destination"
     static let defaultQuery = OneLocationDestinationEntityQuery()
 
     static let supportedActionIDs: [OneSystemActionID] = [
@@ -94,12 +94,12 @@ struct OneLocationDestinationEntity: AppEntity, Identifiable, Hashable {
         case .openLocation:
             return makeDisplay(
                 title: "Location Agent",
-                synonyms: ["One Location Agent", "Location Overview"]
+                synonyms: ["Agent One Location Agent", "One Location Agent", "Location Overview"]
             )
         case .openLocationMap:
             return makeDisplay(
                 title: "Location Map",
-                synonyms: ["One Location Map", "Map"]
+                synonyms: ["Agent One Location Map", "One Location Map", "Map"]
             )
         case .openActiveShares:
             return makeDisplay(
@@ -129,7 +129,7 @@ struct OneLocationDestinationEntity: AppEntity, Identifiable, Hashable {
         case .openCheckIn:
             return makeDisplay(
                 title: "Location Check In",
-                synonyms: ["Check In", "One Check In"]
+                synonyms: ["Check In", "Agent One Check In", "One Check In"]
             )
         case .openEmergencySOS:
             return makeDisplay(
@@ -142,7 +142,7 @@ struct OneLocationDestinationEntity: AppEntity, Identifiable, Hashable {
                 synonyms: ["SMS Contacts", "Emergency Contacts"]
             )
         default:
-            return "One Location"
+            return "Agent One Location"
         }
     }
 
@@ -371,12 +371,12 @@ private enum OneAppIntentActionExecutor {
             slots: request.slots,
             confirmedBySystem: request.confirmedBySystem
         ) else {
-            return "One could not prepare that action."
+            return "Agent One could not prepare that action."
         }
         guard let completion = await OneSystemActionInvocationCoordinator.shared.waitForCompletion(
             id: invocation.id
         ) else {
-            return "Continue in One to finish. Your request is waiting."
+            return "Continue in Agent One to finish. Your request is waiting."
         }
         return completion.summary
     }
@@ -386,9 +386,9 @@ private enum OneAppIntentActionExecutor {
 
 @available(iOS 16.0, *)
 struct TalkToHusshOneIntent: AppIntent {
-    static let title: LocalizedStringResource = "Talk to One"
+    static let title: LocalizedStringResource = "Talk to Agent One"
     static let description = IntentDescription(
-        "Open One and begin a conversation with your private agent."
+        "Open Agent One and begin a conversation with your private agent."
     )
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
@@ -409,7 +409,7 @@ struct TalkToHusshOneIntent: AppIntent {
 struct ShareLocationWithOneIntent: AppIntent {
     static let title: LocalizedStringResource = "Share Location"
     static let description = IntentDescription(
-        "Share your live location with an existing One connection."
+        "Share your live location with an existing Agent One connection."
     )
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
@@ -445,7 +445,7 @@ struct ShareLocationWithOneIntent: AppIntent {
 struct AskForLocationWithOneIntent: AppIntent {
     static let title: LocalizedStringResource = "Ask for Location"
     static let description = IntentDescription(
-        "Ask an existing One connection to share their location."
+        "Ask an existing Agent One connection to share their location."
     )
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
@@ -516,7 +516,7 @@ struct StopLocationSharingWithOneIntent: AppIntent {
 struct SetOneLocationStateIntent: AppIntent {
     static let title: LocalizedStringResource = "Set Location State"
     static let description = IntentDescription(
-        "Turn One Location updates on or off."
+        "Turn Agent One Location updates on or off."
     )
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
@@ -529,7 +529,7 @@ struct SetOneLocationStateIntent: AppIntent {
     var state: OneLocationStateIntentValue
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Turn One Location \(\.$state)")
+        Summary("Turn Agent One Location \(\.$state)")
     }
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
@@ -544,7 +544,7 @@ struct SetOneLocationStateIntent: AppIntent {
 @available(iOS 16.0, *)
 struct CreateOneCircleIntent: AppIntent {
     static let title: LocalizedStringResource = "Create a Circle"
-    static let description = IntentDescription("Create an empty One Circle.")
+    static let description = IntentDescription("Create an empty Agent One Circle.")
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
     static let openAppWhenRun = true
@@ -571,7 +571,7 @@ struct CreateOneCircleIntent: AppIntent {
 @available(iOS 16.0, *)
 struct RenameOneCircleIntent: AppIntent {
     static let title: LocalizedStringResource = "Rename a Circle"
-    static let description = IntentDescription("Rename an existing One Circle.")
+    static let description = IntentDescription("Rename an existing Agent One Circle.")
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
     static let openAppWhenRun = true
@@ -620,12 +620,12 @@ extension OneLocationOpenIntent {
 
 /// The canonical system-level opening action. `OpenIntent` tells Siri this is
 /// app-owned content, while the destination entity resolves phrases such as
-/// "Open One Location Agent" without creating a parallel route executor.
+/// "Open Agent One Location Agent" without creating a parallel route executor.
 @available(iOS 16.0, *)
 struct OpenOneLocationDestinationIntent: OpenIntent {
-    static let title: LocalizedStringResource = "Open One Location"
+    static let title: LocalizedStringResource = "Open Agent One Location"
     static let description = IntentDescription(
-        "Open a destination in the existing One Location experience."
+        "Open a destination in the existing Agent One Location experience."
     )
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
@@ -636,17 +636,17 @@ struct OpenOneLocationDestinationIntent: OpenIntent {
 
     @Parameter(
         title: "Destination",
-        requestValueDialog: "Which One Location destination?"
+        requestValueDialog: "Which Agent One Location destination?"
     )
     var target: OneLocationDestinationEntity
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Open \(\.$target) in One")
+        Summary("Open \(\.$target) in Agent One")
     }
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         guard let actionID = target.actionID else {
-            return .result(dialog: "That One Location destination is unavailable.")
+            return .result(dialog: "That Agent One Location destination is unavailable.")
         }
         let summary = await OneAppIntentActionExecutor.run(
             OneAppIntentActionRequestFactory.open(actionID)
@@ -658,7 +658,7 @@ struct OpenOneLocationDestinationIntent: OpenIntent {
 @available(iOS 16.0, *)
 struct OpenOneLocationIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "Open Location Agent"
-    static let description = IntentDescription("Open the existing One Location experience.")
+    static let description = IntentDescription("Open the existing Agent One Location experience.")
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let summary = await OneAppIntentActionExecutor.run(
@@ -671,7 +671,7 @@ struct OpenOneLocationIntent: OneLocationOpenIntent {
 @available(iOS 16.0, *)
 struct OpenOneLocationMapIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "Open Location Map"
-    static let description = IntentDescription("Open the existing One Location map.")
+    static let description = IntentDescription("Open the existing Agent One Location map.")
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let summary = await OneAppIntentActionExecutor.run(
@@ -684,7 +684,7 @@ struct OpenOneLocationMapIntent: OneLocationOpenIntent {
 @available(iOS 16.0, *)
 struct ViewOneActiveSharesIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "View Active Location Shares"
-    static let description = IntentDescription("Open the list of active One Location shares.")
+    static let description = IntentDescription("Open the list of active Agent One Location shares.")
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let summary = await OneAppIntentActionExecutor.run(
@@ -710,7 +710,7 @@ struct ViewOneSharedLocationsIntent: OneLocationOpenIntent {
 @available(iOS 16.0, *)
 struct ReviewOneLocationRequestsIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "Review Location Requests"
-    static let description = IntentDescription("Open One Location requests awaiting review.")
+    static let description = IntentDescription("Open Agent One Location requests awaiting review.")
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let summary = await OneAppIntentActionExecutor.run(
@@ -723,7 +723,7 @@ struct ReviewOneLocationRequestsIntent: OneLocationOpenIntent {
 @available(iOS 16.0, *)
 struct OpenOneLocationSettingsIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "Open Location Privacy Settings"
-    static let description = IntentDescription("Open One Location privacy settings.")
+    static let description = IntentDescription("Open Agent One Location privacy settings.")
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let summary = await OneAppIntentActionExecutor.run(
@@ -750,7 +750,7 @@ struct CreateOneTemporaryLocationLinkIntent: OneLocationOpenIntent {
 struct CheckInWithOneIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "Check In"
     static let description = IntentDescription(
-        "Open the existing One Check-In flow to choose recipients and review before sending."
+        "Open the existing Agent One Check-In flow to choose recipients and review before sending."
     )
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
@@ -765,7 +765,7 @@ struct CheckInWithOneIntent: OneLocationOpenIntent {
 struct OpenOneEmergencySOSIntent: OneLocationOpenIntent {
     static let title: LocalizedStringResource = "Open Emergency SOS"
     static let description = IntentDescription(
-        "Open the existing One SOS review screen without sending an alert."
+        "Open the existing Agent One SOS review screen without sending an alert."
     )
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
@@ -841,7 +841,7 @@ struct HusshOneAppShortcuts: AppShortcutsProvider {
                 "Show \(\.$target) in \(.applicationName)",
                 "Call \(.applicationName) \(\.$target)"
             ],
-            shortTitle: "Open One Location",
+            shortTitle: "Open Agent One Location",
             systemImageName: "location.circle.fill"
         )
         AppShortcut(
@@ -850,7 +850,7 @@ struct HusshOneAppShortcuts: AppShortcutsProvider {
                 "Talk to \(.applicationName)",
                 "Ask \(.applicationName)"
             ],
-            shortTitle: "Talk to One",
+            shortTitle: "Talk to Agent One",
             systemImageName: "waveform.circle.fill"
         )
     }

--- a/hushh-webapp/ios/App/AppTests/OneSystemActionInvocationCoordinatorTests.swift
+++ b/hushh-webapp/ios/App/AppTests/OneSystemActionInvocationCoordinatorTests.swift
@@ -293,8 +293,11 @@ final class OneSystemActionInvocationCoordinatorTests: XCTestCase {
     }
 
     @available(iOS 16.0, *)
-    func testLocationDestinationEntityResolvesNaturalOneVocabulary() async throws {
+    func testLocationDestinationEntityResolvesNaturalAgentOneVocabulary() async throws {
         let query = OneLocationDestinationEntityQuery()
+
+        let agentOneLocation = try await query.entities(matching: "Agent One Location Agent")
+        XCTAssertEqual(agentOneLocation.compactMap(\.actionID), [.openLocation])
 
         let locationAgent = try await query.entities(matching: "One Location Agent")
         XCTAssertEqual(locationAgent.compactMap(\.actionID), [.openLocation])

--- a/hushh-webapp/ios/App/AppTests/OneVoiceInvocationCoordinatorTests.swift
+++ b/hushh-webapp/ios/App/AppTests/OneVoiceInvocationCoordinatorTests.swift
@@ -176,7 +176,7 @@ final class OneVoiceInvocationCoordinatorTests: XCTestCase {
     func testInstalledAppSeparatesBundleIdentityFromSpeakableSystemName() {
         XCTAssertEqual(
             Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String,
-            "One"
+            "Agent One"
         )
         XCTAssertEqual(
             Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String,
@@ -184,7 +184,7 @@ final class OneVoiceInvocationCoordinatorTests: XCTestCase {
         )
         XCTAssertEqual(
             Bundle.main.object(forInfoDictionaryKey: "CFBundleSpokenName") as? String,
-            "One"
+            "Agent One"
         )
     }
 }

--- a/hushh-webapp/scripts/native/verify-native-static-parity.mjs
+++ b/hushh-webapp/scripts/native/verify-native-static-parity.mjs
@@ -73,15 +73,15 @@ if (!contactsUsageMatch?.[1]?.trim()) {
 
 // Keep the distributed bundle identity at the unique, previously accepted
 // "Hussh One" while the visible and spoken system name remains the intentional
-// Siri-facing "One". These fields are separate contracts and must not collapse
+// Siri-facing "Agent One". These fields are separate contracts and must not collapse
 // back to the globally generic bundle name that App Store Connect rejected.
 //
 // Scoped to visible/spoken copy on purpose. The `hushh` CFBundleURLScheme and
 // com.hushh.app bundle identifier remain load-bearing for deep links/signing.
 const expectedIosNames = new Map([
-  ["CFBundleDisplayName", "One"],
+  ["CFBundleDisplayName", "Agent One"],
   ["CFBundleName", "Hussh One"],
-  ["CFBundleSpokenName", "One"],
+  ["CFBundleSpokenName", "Agent One"],
 ]);
 for (const [key, expected] of expectedIosNames) {
   const match = infoPlist.match(


### PR DESCRIPTION
## Summary
- name the installed and spoken Siri surface Agent One
- keep the previously accepted internal bundle name Hussh One
- update App Shortcut titles, intent copy, and Location entity vocabulary
- retain the older One Location Agent phrase as a compatibility synonym

## Verification
- plist lint and exact bundle-name assertions
- native static and plugin parity
- TypeScript and production web build
- One voice gateway unchanged and verified
- targeted One voice tests: 83 backend tests passed
- App Store processing-gate tests: 7 passed
- repository pre-PR gate passed all relevant checks; its 14 broad frontend failures are the same pre-existing baseline failures already reproduced on main

## Release boundary
TestFlight only after the exact merged main SHA passes post-merge smoke and the iOS release workflow proves Apple upload COMPLETE and exact build VALID.