### PR TITLE
fix(connect): fix UAT person profile rendering

### DIFF
--- a/hushh-webapp/__tests__/app/people/public-person-profile-page.test.tsx
+++ b/hushh-webapp/__tests__/app/people/public-person-profile-page.test.tsx
@@ -3,15 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   connection: vi.fn(),
   fetchPythonApi: vi.fn(),
-  notFound: vi.fn(),
 }));
 
 vi.mock("next/server", () => ({
   connection: mocks.connection,
-}));
-
-vi.mock("next/navigation", () => ({
-  notFound: mocks.notFound,
 }));
 
 vi.mock("@/app/api/_utils/backend", () => ({
@@ -31,18 +26,6 @@ describe("public person profile route", () => {
 
   beforeEach(() => {
     process.env.CAPACITOR_BUILD = "";
-    mocks.connection.mockResolvedValue(undefined);
-    mocks.fetchPythonApi.mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          personRef: "public-person-ref",
-          displayName: "Public Person",
-          photoUrl: null,
-          verifiedRole: null,
-        }),
-        { status: 200 },
-      ),
-    );
   });
 
   afterEach(() => {
@@ -50,29 +33,20 @@ describe("public person profile route", () => {
     vi.clearAllMocks();
   });
 
-  it("binds web requests to the live request before the no-store profile fetch", async () => {
+  it("renders a static hosted web shell and leaves profile loading to the client service", async () => {
     const element = await PublicPersonProfileRoute({
       params: Promise.resolve({ personRef: "public-person-ref" }),
     });
 
-    expect(mocks.connection).toHaveBeenCalledTimes(1);
-    expect(mocks.fetchPythonApi).toHaveBeenCalledWith(
-      "/api/public/people/public-person-ref",
-      expect.objectContaining({ cache: "no-store" }),
-    );
-    expect(mocks.connection.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.fetchPythonApi.mock.invocationCallOrder[0],
-    );
+    expect(mocks.connection).not.toHaveBeenCalled();
+    expect(mocks.fetchPythonApi).not.toHaveBeenCalled();
     expect(element.props).toMatchObject({
       personRef: "public-person-ref",
-      initialProfile: {
-        personRef: "public-person-ref",
-        displayName: "Public Person",
-      },
+      initialProfile: null,
     });
   });
 
-  it("keeps the Capacitor static shell free of web-only server fetches", async () => {
+  it("keeps the Capacitor static shell on the placeholder export path", async () => {
     process.env.CAPACITOR_BUILD = "true";
 
     const element = await PublicPersonProfileRoute({

--- a/hushh-webapp/app/people/[personRef]/page.tsx
+++ b/hushh-webapp/app/people/[personRef]/page.tsx
@@ -1,9 +1,4 @@
-import { notFound } from "next/navigation";
-import { connection } from "next/server";
-
 import { PersonProfilePage } from "@/components/connections/person-profile-page";
-import { fetchPythonApi } from "@/app/api/_utils/backend";
-import type { PublicPersonProfile } from "@/lib/services/person-profile-service";
 
 const nativeStaticPersonRef =
   process.env.ONE_PERSON_PROFILE_NATIVE_TEST_REF ||
@@ -21,16 +16,5 @@ export default async function PublicPersonProfileRoute({
   params: Promise<{ personRef: string }>;
 }) {
   const { personRef } = await params;
-  if (process.env.CAPACITOR_BUILD === "true") {
-    return <PersonProfilePage personRef={personRef} initialProfile={null} />;
-  }
-  await connection();
-  const response = await fetchPythonApi(
-    `/api/public/people/${encodeURIComponent(personRef)}`,
-    { cache: "no-store", signal: AbortSignal.timeout(15_000) },
-  ).catch(() => null);
-  if (!response || response.status === 404) notFound();
-  if (!response.ok) throw new Error("Person profile is unavailable.");
-  const profile = (await response.json()) as PublicPersonProfile;
-  return <PersonProfilePage personRef={personRef} initialProfile={profile} />;
+  return <PersonProfilePage personRef={personRef} initialProfile={null} />;
 }


### PR DESCRIPTION
## Summary

- Follow up on merged PR #6284.
- Keep `/people/[personRef]` as a static route shell.
- Remove the server-side `connection()`/backend fetch path that caused the UAT static-to-dynamic runtime 500.
- Leave profile data loading to the existing `PersonProfilePage` client/service flow.

## Verification

- Focused Connect/Profile route tests: passed locally.
- `npm run typecheck`: passed locally.
- targeted ESLint: passed locally.
- `npm run lint`: passed locally.
- `npm run verify:design-system`: passed locally.
- `npm run verify:capacitor:static`: passed locally.
- `npm run cap:build`: passed locally.
- `git diff --check`: passed locally.

## Scope

This contains only the UAT `/people/[personRef]` rendering fix for the Connect → Profile follow-up to PR #6284.