### PR TITLE
fix(ci): materialize native Firebase source

### DIFF
--- a/.github/workflows/release-ios-appstore.yml
+++ b/.github/workflows/release-ios-appstore.yml
@@ -252,8 +252,10 @@ jobs:
           put NEXT_PUBLIC_OBSERVABILITY_DEBUG "false"
           put NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE "1"
 
-          # Native GoogleService-Info.plist for the shared Firebase authority.
-          PLIST_DEST="hushh-webapp/ios/App/App/GoogleService-Info.plist"
+          # Materialize the canonical root source consumed by
+          # sync:native-firebase-configs --platform ios. The prepare step copies
+          # this validated source into the iOS app target.
+          PLIST_SOURCE="GoogleService-Info.plist"
           if ! gcloud secrets describe IOS_GOOGLESERVICE_INFO_PLIST_B64 --project="${GCP_PROJECT_ID}" >/dev/null 2>&1; then
             echo "Missing GCP secret IOS_GOOGLESERVICE_INFO_PLIST_B64 in ${GCP_PROJECT_ID}." >&2
             echo "Create it from the UAT iOS GoogleService-Info.plist:" >&2
@@ -262,8 +264,8 @@ jobs:
             exit 1
           fi
           gcloud secrets versions access latest --secret=IOS_GOOGLESERVICE_INFO_PLIST_B64 --project="${GCP_PROJECT_ID}" \
-            | openssl base64 -d -A > "$PLIST_DEST"
-          if ! plutil -lint "$PLIST_DEST" >/dev/null 2>&1; then
+            | openssl base64 -d -A > "$PLIST_SOURCE"
+          if ! plutil -lint "$PLIST_SOURCE" >/dev/null 2>&1; then
             echo "Decoded GoogleService-Info.plist failed plist validation." >&2
             exit 1
           fi

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -215,10 +215,10 @@ jobs:
           put NEXT_PUBLIC_OBSERVABILITY_DEBUG "false"
           put NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE "1"
 
-          # Native GoogleService-Info.plist for the iOS target. This is NOT part of
-          # ios:prepare:uat, and sync:native-firebase-configs requires an Android
-          # config we don't have here, so decode the GCP secret straight into place.
-          PLIST_DEST="hushh-webapp/ios/App/App/GoogleService-Info.plist"
+          # Materialize the canonical root source consumed by
+          # sync:native-firebase-configs --platform ios. The prepare step copies
+          # this validated source into the iOS app target.
+          PLIST_SOURCE="GoogleService-Info.plist"
           if ! gcloud secrets describe IOS_GOOGLESERVICE_INFO_PLIST_B64 --project="${GCP_PROJECT_ID}" >/dev/null 2>&1; then
             echo "Missing GCP secret IOS_GOOGLESERVICE_INFO_PLIST_B64 in ${GCP_PROJECT_ID}." >&2
             echo "Create it from the iOS GoogleService-Info.plist:" >&2
@@ -227,8 +227,8 @@ jobs:
             exit 1
           fi
           gcloud secrets versions access latest --secret=IOS_GOOGLESERVICE_INFO_PLIST_B64 --project="${GCP_PROJECT_ID}" \
-            | openssl base64 -d -A > "$PLIST_DEST"
-          if ! plutil -lint "$PLIST_DEST" >/dev/null 2>&1; then
+            | openssl base64 -d -A > "$PLIST_SOURCE"
+          if ! plutil -lint "$PLIST_SOURCE" >/dev/null 2>&1; then
             echo "Decoded GoogleService-Info.plist failed plist validation." >&2
             exit 1
           fi

--- a/docs/guides/mobile/ship-ios-testflight.md
+++ b/docs/guides/mobile/ship-ios-testflight.md
@@ -97,9 +97,10 @@ The workflow decodes and imports `APPSTORE_DISTRIBUTION_CERT_P12_B64` directly i
 
 ### 3. Native iOS Firebase config
 
-The workflow decodes `IOS_GOOGLESERVICE_INFO_PLIST_B64` into `ios/App/App/GoogleService-Info.plist`
-(it does **not** run `sync:native-firebase-configs`, which hard-requires the Android
-`google-services.json`). If not already present:
+The workflow decodes `IOS_GOOGLESERVICE_INFO_PLIST_B64` into the ignored repository-root
+`GoogleService-Info.plist`. The iOS-only native sync validates its bundle id and copies it into
+`ios/App/App/GoogleService-Info.plist`; it does not require the Android `google-services.json`.
+If the secret is not already present:
 
 ```bash
 base64 -i GoogleService-Info.plist \


### PR DESCRIPTION
## Root cause
A concurrent native sync change now requires the canonical root GoogleService-Info.plist source. The iOS release workflows still decoded the GCP secret directly into the app-target destination, so ios:prepare:uat failed before archive.

## Fix
- decode the existing GCP secret into the ignored repository-root GoogleService-Info.plist
- let the existing iOS-only sync validate and copy it into the app target
- align both TestFlight and App Store archive workflows with the same native contract
- update the TestFlight runbook

## Verification
- both workflow YAML files parse
- protected-pipeline self-test and maintainer authorization pass
- paths align with sync-native-firebase-configs.mjs
- no secrets detected

## Release boundary
Retry TestFlight only after this exact head lands on main and passes post-merge smoke.