### PR TITLE
fix(ios): query TestFlight builds independently

### DIFF
--- a/docs/guides/mobile/ship-ios-testflight.md
+++ b/docs/guides/mobile/ship-ios-testflight.md
@@ -40,7 +40,7 @@ xcodebuild -resolvePackageDependencies -project ios/App/App.xcodeproj -scheme Ap
 xcodebuild test -project ios/App/App.xcodeproj -scheme App -only-testing:AppTests  # blocks upload on native unit failures
 xcodebuild archive        -allowProvisioningUpdates -authenticationKey{Path,ID,IssuerID} CURRENT_PROJECT_VERSION=$NEXT_BUILD
 xcodebuild -exportArchive -exportOptionsPlist ios/ExportOptions/AppStoreConnect.plist  # destination=upload → TestFlight
-python3 scripts/ci/wait_for_testflight_build.py ... # buildUploads=COMPLETE + exact build=VALID
+python3 scripts/ci/wait_for_testflight_build.py ... # reject failed upload; require exact build=VALID
 ```
 
 Signing needs no build-setting overrides — `CODE_SIGN_STYLE=Automatic`,
@@ -51,9 +51,11 @@ Signing needs no build-setting overrides — `CODE_SIGN_STYLE=Automatic`,
 upload out of "Missing Compliance".
 
 The upload step is not the terminal release proof. The workflow polls Apple's
-exact `buildUploads` record so delivery failures (including `ITMS-*` import
-errors) fail the run, then requires the corresponding TestFlight build to reach
-`processingState=VALID`. Missing uploads, API failures, and timeouts fail closed.
+exact `buildUploads` record and the corresponding TestFlight `build` independently:
+delivery failures (including `ITMS-*` import errors) fail the run, while a lagging
+`buildUploads` state cannot hide an already imported build. The exact build must
+reach `processingState=VALID`; missing uploads/builds, API failures, and timeouts
+fail closed.
 
 ## One-time setup (secret-touching — the operator does this)
 

--- a/scripts/ci/test_wait_for_testflight_build.py
+++ b/scripts/ci/test_wait_for_testflight_build.py
@@ -63,7 +63,9 @@ class WaitForTestFlightBuildTests(unittest.TestCase):
         clock = Clock()
         remaining = list(payloads)
 
-        def get_payload(_url: str) -> dict:
+        def get_payload(url: str) -> dict:
+            if "buildUploads" not in url:
+                return {"data": []}
             if len(remaining) > 1:
                 return remaining.pop(0)
             return remaining[0]
@@ -108,7 +110,10 @@ class WaitForTestFlightBuildTests(unittest.TestCase):
             self.wait([upload_payload("COMPLETE", build_state="INVALID")])
 
     def test_timeout_is_an_error(self) -> None:
-        with self.assertRaisesRegex(TimeoutError, "last state: build upload PROCESSING"):
+        with self.assertRaisesRegex(
+            TimeoutError,
+            "last state: build upload PROCESSING; build not found",
+        ):
             self.wait([upload_payload("PROCESSING")], timeout=10)
 
     def test_repeated_transient_api_errors_fail_on_timeout(self) -> None:
@@ -117,7 +122,7 @@ class WaitForTestFlightBuildTests(unittest.TestCase):
         def get_payload(_url: str) -> dict:
             raise gate.AscTransientError("HTTP 503 while querying Apple")
 
-        with self.assertRaisesRegex(TimeoutError, "transient API error"):
+        with self.assertRaisesRegex(TimeoutError, "transient upload API error"):
             gate.wait_for_testflight_build(
                 app_id="6757718917",
                 marketing_version="1.3.9",
@@ -132,16 +137,27 @@ class WaitForTestFlightBuildTests(unittest.TestCase):
 
     def test_transient_build_lookup_recovers_after_upload_completes(self) -> None:
         clock = Clock()
-        requests = 0
+        build_requests = 0
 
         def get_payload(url: str) -> dict:
-            nonlocal requests
-            requests += 1
+            nonlocal build_requests
             if "buildUploads" in url:
-                if requests >= 4:
-                    return upload_payload("COMPLETE", build_state="VALID")
                 return upload_payload("COMPLETE")
-            raise gate.AscTransientError("HTTP 503 while querying Apple")
+            build_requests += 1
+            if build_requests == 1:
+                raise gate.AscTransientError("HTTP 503 while querying Apple")
+            return {
+                "data": [
+                    {
+                        "type": "builds",
+                        "attributes": {
+                            "version": "90",
+                            "processingState": "VALID",
+                            "usesNonExemptEncryption": False,
+                        },
+                    }
+                ]
+            }
 
         build = gate.wait_for_testflight_build(
             app_id="6757718917",
@@ -153,6 +169,34 @@ class WaitForTestFlightBuildTests(unittest.TestCase):
             get_payload=get_payload,
             now=clock.now,
             sleep=clock.sleep,
+        )
+        self.assertEqual(build["attributes"]["processingState"], "VALID")
+
+    def test_valid_build_wins_when_upload_state_lags(self) -> None:
+        def get_payload(url: str) -> dict:
+            if "buildUploads" in url:
+                return upload_payload("AWAITING_UPLOAD")
+            return {
+                "data": [
+                    {
+                        "type": "builds",
+                        "attributes": {
+                            "version": "90",
+                            "processingState": "VALID",
+                            "usesNonExemptEncryption": False,
+                        },
+                    }
+                ]
+            }
+
+        build = gate.wait_for_testflight_build(
+            app_id="6757718917",
+            marketing_version="1.3.9",
+            build_number="90",
+            platform="IOS",
+            timeout_seconds=10,
+            poll_interval_seconds=5,
+            get_payload=get_payload,
         )
         self.assertEqual(build["attributes"]["processingState"], "VALID")
 

--- a/scripts/ci/wait_for_testflight_build.py
+++ b/scripts/ci/wait_for_testflight_build.py
@@ -6,7 +6,8 @@
 App Store Connect exposes two related resources with different lifecycles:
 
 * ``buildUploads`` exists while Apple validates an upload and contains the
-  actionable import errors that would otherwise arrive only by email.
+  actionable import errors that would otherwise arrive only by email. Its
+  state can lag behind the corresponding imported build.
 * ``builds`` exists after import and reports TestFlight processing state.
 
 The release gate must inspect both. Polling ``builds`` alone cannot distinguish
@@ -217,55 +218,52 @@ def wait_for_testflight_build(
 
     while now() < deadline:
         attempt += 1
+        upload_payload: dict[str, Any] = {}
+        upload_summary = "upload not found"
         try:
             upload_payload = get_payload(
                 build_upload_url(app_id, marketing_version, build_number, platform)
             )
         except AscTransientError as exc:
-            last_state = f"transient API error: {exc}"
-            log(f"Attempt {attempt}: {last_state}")
-            remaining = deadline - now()
-            if remaining <= 0:
-                break
-            sleep(min(float(poll_interval_seconds), remaining))
-            continue
-        upload = matching_upload(upload_payload, marketing_version, build_number)
-        if upload is None:
-            last_state = "upload not found"
-            log(f"Attempt {attempt}: {last_state}")
+            upload_summary = f"transient upload API error: {exc}"
         else:
-            state, details = upload_state(upload)
-            last_state = f"build upload {state or 'UNKNOWN'}"
-            log(f"Attempt {attempt}: {last_state}")
-            if state == UPLOAD_FAILED:
-                raise BuildUploadFailed(format_state_details(details))
+            upload = matching_upload(upload_payload, marketing_version, build_number)
+            if upload is not None:
+                state, details = upload_state(upload)
+                upload_summary = f"build upload {state or 'UNKNOWN'}"
+                if state == UPLOAD_FAILED:
+                    raise BuildUploadFailed(format_state_details(details))
 
-            if state == UPLOAD_COMPLETE:
-                build = matching_build(upload_payload, build_number)
-                if build is None:
-                    try:
-                        build_payload = get_payload(
-                            build_url(app_id, marketing_version, build_number)
-                        )
-                    except AscTransientError as exc:
-                        last_state = (
-                            "build upload COMPLETE; transient build API error: "
-                            f"{exc}"
-                        )
-                        log(f"Attempt {attempt}: {last_state}")
-                    else:
-                        build = matching_build(build_payload, build_number)
-                if build is not None:
-                    attrs = build.get("attributes") or {}
-                    processing_state = attrs.get("processingState")
-                    last_state = f"build upload COMPLETE; build {processing_state or 'UNKNOWN'}"
-                    log(f"Attempt {attempt}: {last_state}")
-                    if processing_state == BUILD_VALID:
-                        return build
-                    if processing_state in BUILD_TERMINAL_BAD:
-                        raise TestFlightBuildFailed(
-                            f"build processingState={processing_state}"
-                        )
+        # Query the definitive build resource independently. App Store Connect
+        # can expose an imported build while the related buildUploads record is
+        # still AWAITING_UPLOAD, so gating this lookup on upload COMPLETE creates
+        # a false timeout after a successful transporter delivery.
+        build = matching_build(upload_payload, build_number)
+        build_summary = "build not found"
+        if build is None:
+            try:
+                build_payload = get_payload(
+                    build_url(app_id, marketing_version, build_number)
+                )
+            except AscTransientError as exc:
+                build_summary = f"transient build API error: {exc}"
+            else:
+                build = matching_build(build_payload, build_number)
+
+        if build is not None:
+            attrs = build.get("attributes") or {}
+            processing_state = attrs.get("processingState")
+            build_summary = f"build {processing_state or 'UNKNOWN'}"
+            if processing_state == BUILD_VALID:
+                log(f"Attempt {attempt}: {upload_summary}; {build_summary}")
+                return build
+            if processing_state in BUILD_TERMINAL_BAD:
+                raise TestFlightBuildFailed(
+                    f"build processingState={processing_state}"
+                )
+
+        last_state = f"{upload_summary}; {build_summary}"
+        log(f"Attempt {attempt}: {last_state}")
 
         remaining = deadline - now()
         if remaining <= 0:


### PR DESCRIPTION
## Summary
- query the definitive App Store Connect build on every poll instead of waiting for the preliminary upload record to become complete
- preserve immediate failure for Apple upload and TestFlight processing errors
- cover the observed lagging-upload/valid-build state and document the release proof

## Verification
- `python3 scripts/ci/test_wait_for_testflight_build.py` (8 passed)
- `python3 scripts/ci/test_resolve_ios_build_number.py` (3 passed)
- `python3 scripts/ci/verify-protected-pipeline-edits.py --self-test`
- protected pipeline edit guard for maintainer actor
- `python3 -m py_compile scripts/ci/wait_for_testflight_build.py scripts/ci/test_wait_for_testflight_build.py`
- `git diff --check`

## Release evidence
Build 91 transporter upload succeeded, while App Store Connect kept its `buildUploads` record at `AWAITING_UPLOAD` for the entire 20-minute gate. The definitive `builds` endpoint must be checked independently so an already imported build is not hidden by that lag.

Signed-off-by: Pummy Kumari <94732725+ankitkumarsingh1702@users.noreply.github.com>