### PR TITLE
fix(one): ship pending non-dashboard UAT amendments

### DIFF
--- a/consent-protocol/hushh_mcp/services/feed_service.py
+++ b/consent-protocol/hushh_mcp/services/feed_service.py
@@ -259,8 +259,7 @@ class FeedService:
         for row in rows:
             metadata = row.get("metadata")
             if isinstance(metadata, dict) and _bounded_text(
-                metadata.get(_COUNTERPART_PHOTO_KEY), limit=1
-            ):
+                metadata.get(_COUNTERPART_PHOTO_KEY), limit=1            ):
                 continue
             source_row_id = str(row.get("source_row_id") or "").strip()
             if not source_row_id:

--- a/consent-protocol/tests/test_feed_metadata_allowlist.py
+++ b/consent-protocol/tests/test_feed_metadata_allowlist.py
@@ -21,7 +21,9 @@ class TestFeedMetadataAllowlist:
         assert safe.get("share_kind") == "sos"
 
     def test_counterpart_photo_url_survives_for_photo_aware_feed_rows(self):
-        safe = _safe_feed_metadata({"counterpart_photo_url": "https://cdn.example.test/avatar.jpg"})
+        safe = _safe_feed_metadata(
+            {"counterpart_photo_url": "https://cdn.example.test/avatar.jpg"}
+        )
         assert safe == {"counterpart_photo_url": "https://cdn.example.test/avatar.jpg"}
 
     def test_unknown_keys_are_still_dropped(self):

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -74,6 +74,10 @@ steps:
   # A separate step gets its own budget; failure here stops the build the same way.
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: "bash"
+    env:
+      - "_GMAIL_PERSONAL_INFORMATION_REQUEST_MONITOR_AUTH_ENABLED=${_GMAIL_PERSONAL_INFORMATION_REQUEST_MONITOR_AUTH_ENABLED}"
+      - "_GMAIL_PERSONAL_INFORMATION_REQUEST_MONITOR_AUDIENCE=${_GMAIL_PERSONAL_INFORMATION_REQUEST_MONITOR_AUDIENCE}"
+      - "_GMAIL_PERSONAL_INFORMATION_REQUEST_MONITOR_SERVICE_ACCOUNT_EMAIL=${_GMAIL_PERSONAL_INFORMATION_REQUEST_MONITOR_SERVICE_ACCOUNT_EMAIL}"
     args:
       - "-c"
       - |

--- a/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
+++ b/hushh-webapp/__tests__/app/connect/page-client.contract.test.ts
@@ -14,8 +14,7 @@ describe("Connect canonical surface contract", () => {
 
     expect(source).toContain("<AppPageShell");
     expect(source).toContain('width="agent"');
-    expect(source).toContain("<AppPageHeaderRegion>");
-    expect(source).toContain("<PageHeader");
+    expect(source).toContain("<AppPageHeaderRegion>");    expect(source).toContain("<PageHeader");
     expect(source).toContain('title="Connect"');
     expect(source).toContain('titleRole="agent"');
     expect(source).not.toContain("icon={BookUser}");
@@ -117,8 +116,8 @@ describe("Connect canonical surface contract", () => {
       "utf8",
     );
 
-    expect(routes).toContain(
-      'export type FocusedConnectCircleAction =\n  | "create-circle"\n  | "join-circle"\n  | "circle-detail";',
+    expect(routes).toMatch(
+      /export type FocusedConnectCircleAction =\s*\|\s*"create-circle"\s*\|\s*"join-circle"\s*\|\s*"circle-detail";/,
     );
     expect(source).toContain("const isFocusedCircleTask =");
     expect(source).toContain("{isFocusedCircleTask ? (");
@@ -186,8 +185,7 @@ describe("Connect canonical surface contract", () => {
     );
     expect(adaptiveSurface).toContain(
       '? "whitespace-normal break-words [overflow-wrap:anywhere]"',
-    );
-  });
+    );  });
 
   it("renders a privacy-safe masked identity when duplicate names need disambiguation", () => {
     const serviceSource = readFileSync(

--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -2089,7 +2089,6 @@ describe("Connect — Circles", () => {
     expect(screen.queryByRole("tab", { name: "Circles" })).toBeNull();
     expect(screen.queryByLabelText("Search people")).toBeNull();
   });
-
   it("names the default surface explicitly, so back to People navigates", async () => {
     // The App Router refuses a navigation whose only change is that the whole
     // query string disappears -- measured on UAT, recorded in

--- a/hushh-webapp/__tests__/components/intro-step.test.tsx
+++ b/hushh-webapp/__tests__/components/intro-step.test.tsx
@@ -55,19 +55,16 @@ describe("IntroStep voice contract", () => {
     });
   });
 
-  it("uses the standardized root quiet mark between the private-agent line and One", () => {
+  it("uses the standardized root quiet mark directly before One", () => {
     render(<IntroStep onLogin={vi.fn()} />);
 
-    const privateAgent = screen.getByText("Your private agent");
     const quietMark = screen.getByText("🤫");
     const one = screen.getByRole("heading", { name: "One" });
 
-    expect(privateAgent.compareDocumentPosition(quietMark)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
     expect(quietMark.compareDocumentPosition(one)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
+    expect(screen.queryByText("Your private agent")).toBeNull();
   });
 
   it("keeps the root public navigation to Research, Blog, and Developers", () => {

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -51,6 +51,7 @@ const {
   mockSetGrantDuration,
   mockRequestAccess,
   mockApproveRequest,
+  mockWithdrawRequest,
   mockUpdateAutoApprovePreference,
   mockCreatePublicInvite,
   mockCreateCircleInvite,
@@ -108,6 +109,7 @@ const {
   mockSetGrantDuration: vi.fn(),
   mockRequestAccess: vi.fn(),
   mockApproveRequest: vi.fn(),
+  mockWithdrawRequest: vi.fn(),
   mockUpdateAutoApprovePreference: vi.fn(),
   mockCreatePublicInvite: vi.fn(),
   mockCreateCircleInvite: vi.fn(),
@@ -339,6 +341,7 @@ vi.mock("@/lib/one-location/service", () => ({
     requestAccess: mockRequestAccess,
     updateAutoApprovePreference: mockUpdateAutoApprovePreference,
     approveRequest: mockApproveRequest,
+    withdrawRequest: mockWithdrawRequest,
     denyRequest: vi.fn(),
     referRecipient: vi.fn(),
     createPublicInvite: mockCreatePublicInvite,
@@ -721,9 +724,14 @@ async function reachLocationOnboardingFinalStep() {
   });
   await waitFor(() => expect(continueButton).toBeEnabled());
   fireEvent.click(continueButton);
-  // No contacts step here: jsdom has no Contact Picker, so the capability check
-  // reports "unavailable" and the flow skips it -- exactly what a desktop
-  // browser does. The engaged path is covered in the flow component's tests.
+  const contactsStep = await screen.findByRole("heading", {
+    name: /Find your people|You're on the map/,
+  });
+  if (/Find your people/i.test(contactsStep.textContent ?? "")) {
+    const notNow = await screen.findByRole("button", { name: "Not now" });
+    await waitFor(() => expect(notNow).toBeEnabled());
+    fireEvent.click(notNow);
+  }
   await expectLocationInviteStep();
   expect(screen.getByRole("button", { name: "Go back" })).toBeEnabled();
   expect(screen.getByRole("button", { name: "Skip" })).toBeEnabled();
@@ -912,6 +920,15 @@ async function openAskFlow() {
   expect(
     await screen.findByRole("heading", { name: "Ask for location" }),
   ).toBeTruthy();
+}
+
+async function openPeoplePersonActions(name: string) {
+  fireEvent.click(
+    await screen.findByRole("button", {
+      name: new RegExp(`Open Location actions for ${name}`, "i"),
+    }),
+  );
+  expect(await screen.findByRole("dialog", { name })).toBeTruthy();
 }
 
 async function selectAskRecipient(name: RegExp) {
@@ -1176,6 +1193,7 @@ describe("OneLocationAgentPage", () => {
     mockShortenGrant.mockResolvedValue({});
     mockSetGrantDuration.mockResolvedValue({});
     mockRequestAccess.mockResolvedValue({});
+    mockWithdrawRequest.mockResolvedValue({});
     mockCopyToClipboard.mockResolvedValue(true);
     mockCreatePublicInvite.mockResolvedValue({
       publicUrl: "/one/location/view/invite_1",
@@ -2586,7 +2604,7 @@ describe("OneLocationAgentPage", () => {
       target: { value: "Investor" },
     });
     fireEvent.click(
-      screen.getByRole("button", { name: /Share with Investor D/i }),
+      await screen.findByRole("button", { name: "Share with Investor D" }),
     );
     expect(
       await screen.findByRole("heading", { name: "Ready to share?" }),
@@ -3420,7 +3438,7 @@ describe("OneLocationAgentPage", () => {
     expect(screen.queryByText(/Token validation failed/i)).toBeNull();
   });
 
-  it("scrolls Active shares only when more than three shares are present", async () => {
+  it("opens Manage sharing when more than three shares are present", async () => {
     const baseGrant = locationState().ownerGrants[0]!;
     const baseRecipient = locationState().recipients[0]!;
     mockGetState.mockResolvedValue({
@@ -3444,7 +3462,7 @@ describe("OneLocationAgentPage", () => {
     render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
 
-    fireEvent.click(screen.getByTestId("one-location-live-share"));
+    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
     expect(
       await screen.findByRole("heading", { name: "Manage sharing" }),
     ).toBeTruthy();
@@ -5125,28 +5143,27 @@ describe("OneLocationAgentPage", () => {
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: "People" }));
-    expect(
-      await screen.findByRole("heading", { name: "Requests sent" }),
-    ).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Requests sent" })).toBeNull();
+    expect(await screen.findByText("Trusted B")).toBeTruthy();
+    expect(screen.getByText("Waiting for response")).toBeTruthy();
+    await openPeoplePersonActions("Trusted B");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel request" }));
+    await waitFor(() =>
+      expect(mockWithdrawRequest).toHaveBeenCalledWith({
+        requestId: "request_1",
+        vaultOwnerToken: "vault-token",
+      }),
+    );
     expect(screen.getAllByText("Trusted B").length).toBeGreaterThan(0);
     expect(screen.queryByText("user_b")).toBeNull();
     expect(screen.queryByText("request_1")).toBeNull();
   });
 
-  it("lets the requester delete a live (approved) request they sent", async () => {
+  it("moves received-location management out of People and into Shared with me", async () => {
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
-      requests: [
-        {
-          id: "request_live",
-          ownerUserId: "user_b",
-          requesterUserId: "user_a",
-          status: "approved",
-          approvedGrantId: "grant_from_request_live",
-          requestedAt: "2026-05-20T07:30:00.000Z",
-        },
-      ],
+      receivedGrants: [liveReceivedGrant(60)],
     });
 
     render(<OneLocationAgentPage />);
@@ -5154,50 +5171,35 @@ describe("OneLocationAgentPage", () => {
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: "People" }));
-    expect(
-      await screen.findByRole("heading", { name: "Requests sent" }),
-    ).toBeTruthy();
-    // A live request shows a real stop action, not a static "Active" label
-    // with no way off the list. The label is "Stop viewing", not "Delete": it
-    // is the same vm.onStopGrant handler the other two revoke buttons use, and
-    // it ends access rather than erasing anything.
-    expect(screen.queryByText("Active")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
-    const deleteButton = screen.getByRole("button", { name: "Stop viewing" });
-    fireEvent.click(deleteButton);
-    await waitFor(() =>
-      expect(mockRevokeGrant).toHaveBeenCalledWith({
-        vaultOwnerToken: "vault-token",
-        grantId: "grant_from_request_live",
-      }),
+    expect(screen.queryByRole("heading", { name: "Requests sent" })).toBeNull();
+    expect(await screen.findByText(/Sharing with you/i)).toBeTruthy();
+    await openPeoplePersonActions("Trusted B");
+    fireEvent.click(
+      screen.getByRole("button", { name: "View their location" }),
     );
+    expect(
+      await screen.findByRole("heading", { name: "Shared with me" }),
+    ).toBeTruthy();
   });
 
-  it("asks for 30 minutes more from an active sent request", async () => {
+  it("keeps 30-minute extension requests in the Ask flow", async () => {
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
-      requests: [
-        {
-          id: "request_live",
-          ownerUserId: "user_b",
-          requesterUserId: "user_a",
-          status: "approved",
-          approvedGrantId: "grant_from_request_live",
-          requestedAt: "2026-05-20T07:30:00.000Z",
-        },
-      ],
+      receivedGrants: [liveReceivedGrant(60)],
     });
 
     render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole("button", { name: "People" }));
-    await screen.findByRole("heading", { name: "Requests sent" });
-
-    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
-    // The spoken name carries the person as well as the amount.
+    await openAskFlow();
+    fireEvent.change(screen.getByPlaceholderText(/search/i), {
+      target: { value: "Trusted B" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Edit access for Trusted B" }),
+    );
     fireEvent.click(
       screen.getByRole("button", { name: "Ask Trusted B for 30 min more" }),
     );
@@ -5206,41 +5208,33 @@ describe("OneLocationAgentPage", () => {
       expect(mockRequestAccess).toHaveBeenCalledWith({
         vaultOwnerToken: "vault-token",
         ownerUserId: "user_b",
-        // Generated from the amount now, rather than one hardcoded sentence
-        // per option -- so it is word-for-word the label that was tapped.
         message: "Requesting 30 min more of your live location.",
         requestedDurationHours: 0.5,
         requestedDurationMode: "timed",
-        extendsGrantId: "grant_from_request_live",
+        extendsGrantId: "grant_live_ask",
       }),
     );
     expect(mockShortenGrant).not.toHaveBeenCalled();
   });
 
-  it("asks for 2 hours more from an active sent request", async () => {
+  it("keeps 2-hour extension requests in the Ask flow", async () => {
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
-      requests: [
-        {
-          id: "request_live",
-          ownerUserId: "user_b",
-          requesterUserId: "user_a",
-          status: "approved",
-          approvedGrantId: "grant_from_request_live",
-          requestedAt: "2026-05-20T07:30:00.000Z",
-        },
-      ],
+      receivedGrants: [liveReceivedGrant(60)],
     });
 
     render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole("button", { name: "People" }));
-    await screen.findByRole("heading", { name: "Requests sent" });
-
-    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
+    await openAskFlow();
+    fireEvent.change(screen.getByPlaceholderText(/search/i), {
+      target: { value: "Trusted B" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Edit access for Trusted B" }),
+    );
     fireEvent.click(
       screen.getByRole("button", { name: "Ask Trusted B for 2 hours more" }),
     );
@@ -5252,7 +5246,7 @@ describe("OneLocationAgentPage", () => {
         message: "Requesting 2 hours more of your live location.",
         requestedDurationHours: 2,
         requestedDurationMode: "timed",
-        extendsGrantId: "grant_from_request_live",
+        extendsGrantId: "grant_live_ask",
       }),
     );
     expect(mockShortenGrant).not.toHaveBeenCalled();
@@ -5804,10 +5798,10 @@ describe("OneLocationAgentPage", () => {
     // mock state.
     mockListRecipientsPage.mockClear();
     expect(
-      await screen.findByRole("button", { name: /Add people/i }),
+      await screen.findByRole("button", { name: /Add or manage people/i }),
     ).toBeTruthy();
     openDropdownMenu(
-      await screen.findByRole("button", { name: /Add people/i }),
+      await screen.findByRole("button", { name: /Add or manage people/i }),
     );
     fireEvent.click(screen.getByRole("menuitem", { name: /Find contacts/i }));
 
@@ -5835,17 +5829,15 @@ describe("OneLocationAgentPage", () => {
       ),
     ).toBeTruthy();
     expect(
-      within(screen.getByTestId("one-location-people-list")).getByLabelText(
+      within(screen.getByTestId("one-location-people-list")).queryByLabelText(
         "Connected from your contacts",
       ),
-    ).toBeTruthy();
+    ).toBeNull();
     expect(screen.queryByText(/9911|8012|4455/)).toBeNull();
-    // The scan has to SAY why this person moved. `enrichRecipientsWithContactSignal`
-    // only fills `recommendationSummary` when the server left it empty, so for
-    // anyone the server already described the match used to be invisible — the
-    // +8 ranking boost reordered the list and nothing explained it. The reason
-    // now wins the subtitle outright.
-    expect(await screen.findByText("In your contacts")).toBeTruthy();
+    // The People directory stays calm after sync: matched people may move into
+    // the list, but the contact-source badge and long permanent sync subtitle
+    // do not crowd the main hub.
+    expect(screen.queryByText("In your contacts")).toBeNull();
     expect(mockTrackEvent).toHaveBeenCalledWith(
       "one_location_contact_signal_synced",
       expect.objectContaining({
@@ -5898,7 +5890,7 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: "People" }));
     openDropdownMenu(
-      await screen.findByRole("button", { name: /Add people/i }),
+      await screen.findByRole("button", { name: /Add or manage people/i }),
     );
     fireEvent.click(screen.getByRole("menuitem", { name: /Find contacts/i }));
 
@@ -5935,7 +5927,7 @@ describe("OneLocationAgentPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "People" }));
     openDropdownMenu(
-      await screen.findByRole("button", { name: /Add people/i }),
+      await screen.findByRole("button", { name: /Add or manage people/i }),
     );
     fireEvent.click(screen.getByRole("menuitem", { name: /Find contacts/i }));
 
@@ -5955,7 +5947,7 @@ describe("OneLocationAgentPage", () => {
     );
     // And the button is usable again rather than stuck mid-scan.
     openDropdownMenu(
-      await screen.findByRole("button", { name: /Add people/i }),
+      await screen.findByRole("button", { name: /Add or manage people/i }),
     );
     expect(
       screen.getByRole("menuitem", { name: /Find contacts/i }),
@@ -6003,7 +5995,7 @@ describe("OneLocationAgentPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "People" }));
     const addPeople = await screen.findByRole("button", {
-      name: /Add people/i,
+      name: /Add or manage people/i,
     });
     openDropdownMenu(addPeople);
     fireEvent.click(screen.getByRole("menuitem", { name: /Find contacts/i }));
@@ -6022,7 +6014,7 @@ describe("OneLocationAgentPage", () => {
     await act(async () => {
       finishSync?.();
     });
-  });
+  }, 10_000);
 
   it("creates an approval-first invite path for contacts who are not One users", async () => {
     render(<OneLocationAgentPage />);
@@ -6061,7 +6053,7 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    await switchLocationTab("People", "Circles");
+    await switchLocationTab("People", "People");
 
     const search = await screen.findByPlaceholderText(/Search people/i);
     const person = await screen.findByText("Trusted B");
@@ -6080,6 +6072,7 @@ describe("OneLocationAgentPage", () => {
     ).filter(
       (el) =>
         el !== search &&
+        !el.contains(person) &&
         search.compareDocumentPosition(el) & Node.DOCUMENT_POSITION_FOLLOWING &&
         person.compareDocumentPosition(el) & Node.DOCUMENT_POSITION_PRECEDING,
     );
@@ -6090,7 +6083,9 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.queryByRole("button", { name: /Share to contacts/i }),
     ).toBeNull();
-    const addPeople = screen.getByRole("button", { name: /Add people/i });
+    const addPeople = screen.getByRole("button", {
+      name: /Add or manage people/i,
+    });
     expect(addPeople).toBeTruthy();
     expect(
       addPeople.compareDocumentPosition(search) &
@@ -6107,10 +6102,12 @@ describe("OneLocationAgentPage", () => {
       screen.getByRole("menuitem", { name: /Manage connections/i }),
     ).toBeTruthy();
     expect(
-      screen.getByRole("button", {
+      screen.queryByRole("button", {
         name: /Stop sharing with Trusted B/i,
       }),
-    ).toBeTruthy();
+    ).toBeNull();
+    await openPeoplePersonActions("Trusted B");
+    expect(screen.getByRole("button", { name: "Manage my sharing" })).toBeTruthy();
   });
 
   it("keeps desktop People actions in the same visual and keyboard order", async () => {
@@ -6130,10 +6127,12 @@ describe("OneLocationAgentPage", () => {
       render(<OneLocationAgentPage />);
       await skipLocationEntryFlow();
       await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-      await switchLocationTab("People", "Circles");
+      await switchLocationTab("People", "People");
 
       const search = await screen.findByPlaceholderText(/Search people/i);
-      const addPeople = screen.getByRole("button", { name: /Add people/i });
+      const addPeople = screen.getByRole("button", {
+        name: /Add or manage people/i,
+      });
 
       expect(
         addPeople.compareDocumentPosition(search) &
@@ -6154,33 +6153,18 @@ describe("OneLocationAgentPage", () => {
     }
   });
 
-  it("offers Create Circle and Join with code from the compact Circles add action", async () => {
+  it("opens the canonical Connect Circles manager from the compact Circles summary", async () => {
     render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    await switchLocationTab("People", "Circles");
+    await switchLocationTab("People", "People");
 
-    const section = screen.getByTestId("one-location-named-circles");
-    const heading = within(section).getByRole("heading", {
-      name: "Circles",
-    });
-    const add = within(section).getByRole("button", {
-      name: /^Add Circle$/i,
-    });
-
-    // Structural, not "somewhere after": the compact heading row owns the
-    // single add affordance, so a long circle list cannot strand it below the
-    // fold while Create and Join remain reachable from the same control.
-    expect(section.children[0]).toContainElement(heading);
-    expect(section.children[0]).toContainElement(add);
-    openDropdownMenu(add);
-    expect(
-      screen.getByRole("menuitem", { name: "Create Circle" }),
-    ).toBeTruthy();
-    expect(
-      screen.getByRole("menuitem", { name: "Join with code" }),
-    ).toBeTruthy();
+    const section = screen.getByTestId("one-location-circles-summary");
+    fireEvent.click(within(section).getByRole("button", { name: /Circles/i }));
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      "/one/connect?tab=circles&return_to=%2Fone%2Flocation%3Fview%3Dpeople",
+    );
   });
 
   it("does not show owner-grant revoke actions in the compact mobile flow", async () => {
@@ -6288,17 +6272,20 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    await switchLocationTab("People", "Circles");
-    // Empty state keeps a direct Add people CTA, while the header menu keeps
+    await switchLocationTab("People", "People");
+    // Empty state keeps a direct recovery CTA, while the header menu keeps
     // connection management, invite, and sync actions without scattering them.
-    const addPeopleButtons = screen.getAllByRole("button", {
-      name: /Add people/i,
+    const addPeopleMenu = screen.getByRole("button", {
+      name: /Add or manage people/i,
     });
-    const addPeopleCta = addPeopleButtons.find((button) =>
-      button.textContent?.includes("Add people"),
-    );
+    const addPeopleCta = screen.getByRole("button", {
+      name: /Find or invite someone/i,
+    });
+    expect(
+      addPeopleCta.textContent?.includes("Find or invite someone"),
+    ).toBe(true);
     expect(addPeopleCta).toBeTruthy();
-    openDropdownMenu(addPeopleButtons[0]);
+    openDropdownMenu(addPeopleMenu);
     expect(
       screen.getByRole("menuitem", { name: /Find contacts/i }),
     ).toBeTruthy();
@@ -6320,7 +6307,7 @@ describe("OneLocationAgentPage", () => {
     ).toBeNull();
 
     mockRouterPush.mockClear();
-    fireEvent.click(addPeopleCta!);
+    fireEvent.click(addPeopleCta);
     expect(mockRouterPush).toHaveBeenCalledWith("/one/connect");
 
     fireEvent.click(screen.getByRole("button", { name: "Links" }));

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -110,8 +110,7 @@ describe("top shell breadcrumbs", () => {
       align: "center",
       hideBack: false,
       items: [{ label: "One" }],
-    });
-  });
+    });  });
 
   it("uses the shared top-left back affordance for Calendar", () => {
     expect(resolveTopShellBreadcrumb("/one/calendar")).toEqual({

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -507,8 +507,7 @@ export default function ConnectPageClient() {
   const isFocusedCircleTask = isFocusedConnectCircleTask(
     surface,
     circleFlowAction,
-    circleFlowId,
-  );
+    circleFlowId,  );
 
   // Every navigation on this page passes `scroll: false`, because the surface
   // strip and the Circle flows are query-only states that must not jump the
@@ -547,8 +546,7 @@ export default function ConnectPageClient() {
   const directoryMenuButtonRef = useRef<HTMLButtonElement | null>(null);
   const loadMoreDirectoryRef = useRef<HTMLDivElement | null>(null);
   const [directoryMenuOpen, setDirectoryMenuOpen] = useState(false);
-  const useWebDirectoryPopover = !isNative();
-  const searchQueryParam = (searchParams.get(CONNECT_SEARCH_QUERY_PARAM) ?? "")
+  const useWebDirectoryPopover = !isNative();  const searchQueryParam = (searchParams.get(CONNECT_SEARCH_QUERY_PARAM) ?? "")
     .trim()
     .slice(0, 160);
   const [query, setQuery] = useState<string>(
@@ -2329,8 +2327,7 @@ export default function ConnectPageClient() {
     >
       {isFocusedCircleTask ? (
         <AppPageContentRegion className={CONNECT_PAGE_CONTENT_CLASSNAME}>
-          <div className="mx-auto w-full max-w-[560px]">
-            <ConnectCirclesTab
+          <div className="mx-auto w-full max-w-[560px]">            <ConnectCirclesTab
               onStateChange={setCirclesState}
               currentUserId={user?.uid ?? null}
               onRequestConnection={sendConnectRequest}
@@ -2350,8 +2347,7 @@ export default function ConnectPageClient() {
           </AppPageHeaderRegion>
 
           <AppPageContentRegion className={CONNECT_PAGE_CONTENT_CLASSNAME}>
-            <SurfaceStack compact>
-          <div
+            <SurfaceStack compact>          <div
             ref={connectStackRef}
             className="relative space-y-4 sm:space-y-5"
           >
@@ -2395,8 +2391,7 @@ export default function ConnectPageClient() {
                       {useWebDirectoryPopover ? (
                         <Popover
                           open={directoryMenuOpen}
-                          onOpenChange={setDirectoryMenuOpen}
-                        >
+                          onOpenChange={setDirectoryMenuOpen}                        >
                           <PopoverTrigger asChild>
                             <button
                               ref={directoryMenuButtonRef}
@@ -3152,8 +3147,7 @@ export default function ConnectPageClient() {
           </div>
             </SurfaceStack>
           </AppPageContentRegion>
-        </>
-      )}
+        </>      )}
 
       <Dialog
         open={batchConnectDraft !== null}

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -787,9 +787,15 @@ textarea {
   --ios-account-label: var(--foreground, #1d1d1f);
   --ios-account-secondary-label: var(--muted-foreground, #8e8e93);
   --ios-account-tertiary-label: #aeaeb2;
-  --ios-account-separator: var(--app-card-border-standard, rgba(60, 60, 67, 0.1));
+  --ios-account-separator: var(
+    --app-card-border-standard,
+    rgba(60, 60, 67, 0.1)
+  );
   --ios-account-icon-tile-background: rgba(120, 120, 128, 0.12);
-  --ios-account-utility-icon-tile-background: var(--app-icon-tile-background, #8e8e93);
+  --ios-account-utility-icon-tile-background: var(
+    --app-icon-tile-background,
+    #8e8e93
+  );
   --ios-account-utility-icon-glyph: var(--app-icon-tile-foreground, #ffffff);
   --ios-account-service-icon-tile-background: #1c1c1e;
   --ios-account-service-icon-glyph: #ffffff;
@@ -883,6 +889,7 @@ textarea {
   /* Foundation (bible): a bright white canvas carries the ambient wash while
      cards remain legible without reverting the app to an opaque flat page. */
   --background: #f2f2f7;
+  --one-launcher-background: #f3f3f7;
   --foreground: oklch(0.232 0.004 286.1);
   --card: #ffffff;
   --card-foreground: oklch(0.232 0.004 286.1);
@@ -1080,6 +1087,7 @@ textarea {
 .dark {
   --app-screen-background: #000000;
   --app-grouped-background: #000000;
+  --one-launcher-background: var(--background);
   --app-primary-surface: #1c1c1e;
   --app-secondary-surface: #2c2c2e;
   --app-elevated-surface: #2c2c2e;
@@ -1160,9 +1168,15 @@ textarea {
   --ios-account-label: var(--foreground, #ffffff);
   --ios-account-secondary-label: var(--muted-foreground, #98989d);
   --ios-account-tertiary-label: #636366;
-  --ios-account-separator: var(--app-card-border-standard, rgba(84, 84, 88, 0.65));
+  --ios-account-separator: var(
+    --app-card-border-standard,
+    rgba(84, 84, 88, 0.65)
+  );
   --ios-account-icon-tile-background: rgba(120, 120, 128, 0.24);
-  --ios-account-utility-icon-tile-background: var(--app-icon-tile-background, #636366);
+  --ios-account-utility-icon-tile-background: var(
+    --app-icon-tile-background,
+    #636366
+  );
   --ios-account-utility-icon-glyph: var(--app-icon-tile-foreground, #ffffff);
   --ios-account-service-icon-tile-background: #3a3a3c;
   --ios-account-service-icon-glyph: #ffffff;
@@ -1350,7 +1364,9 @@ body:has([data-profile-account-preview-root]) nextjs-portal {
   margin-top: 14px;
 }
 
-.profile-account-content [data-testid="settings-group"]:first-child > div:first-child {
+.profile-account-content
+  [data-testid="settings-group"]:first-child
+  > div:first-child {
   margin-top: 8px;
 }
 
@@ -1694,7 +1710,8 @@ body:has([data-profile-account-preview-root]) nextjs-portal {
     filter 180ms ease;
 }
 
-.profile-home-screen [data-profile-avatar-frame="true"][aria-busy="true"]
+.profile-home-screen
+  [data-profile-avatar-frame="true"][aria-busy="true"]
   [data-profile-avatar-display="true"] {
   filter: saturate(0.92);
   opacity: 0.82;
@@ -1788,7 +1805,9 @@ body:has([data-profile-account-preview-root]) nextjs-portal {
   margin-top: 18px;
 }
 
-.profile-home-content [data-testid="settings-group"]:first-child > div:first-child {
+.profile-home-content
+  [data-testid="settings-group"]:first-child
+  > div:first-child {
   margin-top: 8px;
 }
 
@@ -2115,9 +2134,6 @@ html.kb-open .ambient-chrome-mask--bottom {
   transition: opacity 150ms ease;
 }
 
-
-
-
 .app-page-shell {
   width: 100%;
   padding-left: var(--page-inline-gutter-standard);
@@ -2127,29 +2143,54 @@ html.kb-open .ambient-chrome-mask--bottom {
   padding-bottom: var(--app-page-content-bottom-gap);
 }
 
+body:has([data-one-launcher-root="true"]) {
+  background: var(--one-launcher-background) !important;
+}
+
+body:has([data-one-launcher-root="true"]) .foundation-public-ambient {
+  background-color: var(--one-launcher-background);
+}
+
 .one-agent-launcher-grid {
-  --one-agent-icon-size: clamp(54px, 15.2vw, 62px);
-  --one-agent-cell-height: clamp(86px, 23vw, 98px);
-  --one-agent-column-gap: clamp(8px, 3vw, 16px);
-  --one-agent-row-gap: clamp(8px, 2.3vh, 18px);
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  column-gap: 12px;
+  row-gap: 20px;
 }
 
-.one-agent-launcher-grid-inner {
-  column-gap: var(--one-agent-column-gap);
-  row-gap: var(--one-agent-row-gap);
+.one-agent-launcher-tile {
+  grid-column: span 2;
 }
 
-@media (max-height: 620px) {
+.one-agent-launcher-tile:nth-last-child(2):nth-child(3n + 1) {
+  grid-column: 2 / span 2;
+}
+
+.one-agent-launcher-tile:last-child:nth-child(3n + 2) {
+  grid-column: 4 / span 2;
+}
+
+@media (min-width: 430px) {
   .one-agent-launcher-grid {
-    --one-agent-icon-size: 52px;
-    --one-agent-cell-height: 84px;
+    column-gap: 20px;
   }
 }
 
 @media (min-width: 768px) {
   .one-agent-launcher-grid {
-    --one-agent-icon-size: 62px;
-    --one-agent-cell-height: 98px;
+    column-gap: 28px;
+    row-gap: 28px;
+  }
+}
+
+@media (max-width: 300px) {
+  .one-agent-launcher-tile {
+    grid-column: span 3;
+  }
+
+  .one-agent-launcher-tile:nth-last-child(2):nth-child(3n + 1),
+  .one-agent-launcher-tile:last-child:nth-child(3n + 2) {
+    grid-column-start: auto;
   }
 }
 
@@ -2163,7 +2204,6 @@ html.kb-open .ambient-chrome-mask--bottom {
   min-height: 0 !important;
   flex: 0 0 auto;
 }
-
 
 .app-page-shell--reading {
   max-width: 54rem;
@@ -2418,11 +2458,13 @@ html.native-ios [data-testid="one-location-onboarding"] {
 html:has([data-testid="one-location-onboarding"]) [data-app-bottom-nav],
 html:has([data-testid="one-location-onboarding"]) [data-app-bottom-shell],
 html:has([data-testid="one-location-onboarding"]) [data-agent-bar-shell],
-html:has([data-testid="one-location-onboarding"]) [data-app-bottom-chrome-glass],
+html:has([data-testid="one-location-onboarding"])
+  [data-app-bottom-chrome-glass],
 body:has([data-testid="one-location-onboarding"]) [data-app-bottom-nav],
 body:has([data-testid="one-location-onboarding"]) [data-app-bottom-shell],
 body:has([data-testid="one-location-onboarding"]) [data-agent-bar-shell],
-body:has([data-testid="one-location-onboarding"]) [data-app-bottom-chrome-glass] {
+body:has([data-testid="one-location-onboarding"])
+  [data-app-bottom-chrome-glass] {
   visibility: hidden !important;
   pointer-events: none !important;
 }
@@ -3982,9 +4024,7 @@ body:has([data-testid="one-location-onboarding"]) [data-app-bottom-chrome-glass]
     text-transform: none !important;
   }
 
-  .app-page-shell
-    .profile-home-content
-    [data-slot="settings-group-heading"],
+  .app-page-shell .profile-home-content [data-slot="settings-group-heading"],
   .app-page-shell
     .profile-home-content
     [data-slot="settings-group-heading"][role="heading"][aria-level="2"] {
@@ -4555,9 +4595,21 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
      coloured plastic. Stationary, unlike the bar's breathing aurora -- motion
      on a dialog the person is being asked to read would fight the reading. */
   background-image:
-    radial-gradient(120% 100% at 6% 0%, var(--agent-approval-hue-gold), transparent 55%),
-    radial-gradient(110% 100% at 100% 18%, var(--agent-approval-hue-indigo), transparent 58%),
-    radial-gradient(130% 120% at 62% 108%, var(--agent-approval-hue-pink), transparent 62%);
+    radial-gradient(
+      120% 100% at 6% 0%,
+      var(--agent-approval-hue-gold),
+      transparent 55%
+    ),
+    radial-gradient(
+      110% 100% at 100% 18%,
+      var(--agent-approval-hue-indigo),
+      transparent 58%
+    ),
+    radial-gradient(
+      130% 120% at 62% 108%,
+      var(--agent-approval-hue-pink),
+      transparent 62%
+    );
   -webkit-backdrop-filter: blur(var(--agent-approval-blur)) saturate(180%);
   backdrop-filter: blur(var(--agent-approval-blur)) saturate(180%);
   border: 1px solid var(--agent-approval-edge);
@@ -6108,7 +6160,12 @@ body[data-persona-surface="ria"] {
   text-transform: none !important;
 }
 
-:is(.ui-text-body, .ui-text-row-label, .ui-text-medium-row-label, .ui-text-row-label-emphasized) {
+:is(
+  .ui-text-body,
+  .ui-text-row-label,
+  .ui-text-medium-row-label,
+  .ui-text-row-label-emphasized
+) {
   color: var(--app-label) !important;
   font-family: var(--font-app-body) !important;
   font-size: var(--type-row-label-size) !important;
@@ -6280,11 +6337,26 @@ body[data-persona-surface="ria"] {
 .app-page-shell
   :is(p, span, div, label)[class*="text-muted-foreground"][class*="text-xs"],
 .app-page-shell
-  :is(p, span, div, label)[class*="text-muted-foreground"][class*="text-[10px]"],
+  :is(
+    p,
+    span,
+    div,
+    label
+  )[class*="text-muted-foreground"][class*="text-[10px]"],
 .app-page-shell
-  :is(p, span, div, label)[class*="text-muted-foreground"][class*="text-[11px]"],
+  :is(
+    p,
+    span,
+    div,
+    label
+  )[class*="text-muted-foreground"][class*="text-[11px]"],
 .app-page-shell
-  :is(p, span, div, label)[class*="text-muted-foreground"][class*="text-[12px]"],
+  :is(
+    p,
+    span,
+    div,
+    label
+  )[class*="text-muted-foreground"][class*="text-[12px]"],
 .app-page-shell
   :is(p, span, div, label)[class*="text-[#8E8E93]"][class*="text-[12px]"],
 .app-page-shell
@@ -6308,15 +6380,39 @@ body[data-persona-surface="ria"] {
 }
 
 .app-page-shell
-  :is(p, span, div, label, time)[class*="text-[color:var(--one-fg3)]"][class*="text-[10px]"],
+  :is(
+    p,
+    span,
+    div,
+    label,
+    time
+  )[class*="text-[color:var(--one-fg3)]"][class*="text-[10px]"],
 .app-page-shell
-  :is(p, span, div, label, time)[class*="text-[color:var(--one-fg3)]"][class*="text-[11px]"],
+  :is(
+    p,
+    span,
+    div,
+    label,
+    time
+  )[class*="text-[color:var(--one-fg3)]"][class*="text-[11px]"],
 .app-page-shell
-  :is(p, span, div, label, time)[class*="text-[color:var(--one-fg3)]"][class*="text-[12px]"],
+  :is(
+    p,
+    span,
+    div,
+    label,
+    time
+  )[class*="text-[color:var(--one-fg3)]"][class*="text-[12px]"],
 .app-page-shell
   :is(p, span, div, label, time)[class*="text-[#8e8e93]"][class*="text-[13px]"],
 .app-page-shell
-  :is(p, span, div, label, time)[class*="text-[color:var(--one-fg2)]"][class*="text-[12px]"] {
+  :is(
+    p,
+    span,
+    div,
+    label,
+    time
+  )[class*="text-[color:var(--one-fg2)]"][class*="text-[12px]"] {
   color: var(--app-tertiary-label) !important;
   font-family: var(--font-app-body) !important;
   font-size: var(--type-helper-text-size) !important;
@@ -6328,9 +6424,19 @@ body[data-persona-surface="ria"] {
 }
 
 .app-page-shell
-  :is(p, span, div, label)[class*="text-[color:var(--one-fg2)]"][class*="text-[13px]"],
+  :is(
+    p,
+    span,
+    div,
+    label
+  )[class*="text-[color:var(--one-fg2)]"][class*="text-[13px]"],
 .app-page-shell
-  :is(p, span, div, label)[class*="text-[color:var(--one-fg2)]"][class*="text-[14px]"],
+  :is(
+    p,
+    span,
+    div,
+    label
+  )[class*="text-[color:var(--one-fg2)]"][class*="text-[14px]"],
 .app-page-shell
   :is(p, span, div, label)[class*="text-muted-foreground"][class*="text-sm"] {
   color: var(--app-secondary-label) !important;
@@ -6355,11 +6461,25 @@ body[data-persona-surface="ria"] {
 }
 
 .app-page-shell
-  :is(p, span, div, h2, h3, label)[class*="uppercase"][class*="text-muted-foreground"],
+  :is(
+    p,
+    span,
+    div,
+    h2,
+    h3,
+    label
+  )[class*="uppercase"][class*="text-muted-foreground"],
 .app-page-shell
   :is(p, span, div, h2, h3, label)[class*="uppercase"][class*="text-[#96999e]"],
 .app-page-shell
-  :is(p, span, div, h2, h3, label)[class*="uppercase"][class*="text-[#8b93a1]"] {
+  :is(
+    p,
+    span,
+    div,
+    h2,
+    h3,
+    label
+  )[class*="uppercase"][class*="text-[#8b93a1]"] {
   letter-spacing: 0 !important;
   text-transform: none !important;
 }

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -171,8 +171,7 @@ function AppShellFrame({ children }: ProvidersProps) {
     isFocusedConnectCircleTask(
       searchParams?.get("tab") ?? null,
       searchParams?.get("action") ?? null,
-      searchParams?.get("circleId") ?? null,
-    );
+      searchParams?.get("circleId") ?? null,    );
   // Focused query-scoped Location flows clear the bottom command/navigation
   // stack while keeping the top shell route context.
   const bottomChromeHidden =

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -359,7 +359,7 @@ export function PhoneMandatePageContent() {
 
         {/* Verification is a focused task, not a hero. Keep the heading tight
             so the active field row can clear the native keyboard. */}
-        <div className="px-6 pb-3 pt-7 text-center">
+        <div className="px-6 pb-2 pt-7 text-center">
           <h1
             role="heading"
             aria-level={1}
@@ -368,9 +368,6 @@ export function PhoneMandatePageContent() {
           >
             Verify your phone number
           </h1>
-          <p className="mx-auto mt-1.5 max-w-[20rem] text-[15px] leading-[1.4] text-[rgba(23,19,12,0.6)] dark:text-[rgba(250,246,238,0.62)]">
-            Add your phone number to continue.
-          </p>
         </div>
 
         {/* The active field group owns the keyboard clearance. The keyboard
@@ -393,7 +390,9 @@ export function PhoneMandatePageContent() {
             onCompleted={continueToNextRoute}
             onContinueExisting={continueToNextRoute}
             onStepChange={setVerificationStep}
-            confirmLabel="Verify and continue"
+            sendCodeLabel="Send code"
+            confirmLabel="Verify"
+            primaryActionClassName="mx-auto max-w-[21.5rem]"
             className="gap-5"
           />
           <div id="recaptcha-container" className="mt-3 min-h-0" />

--- a/hushh-webapp/components/app-ui/agent-section-icon.tsx
+++ b/hushh-webapp/components/app-ui/agent-section-icon.tsx
@@ -76,12 +76,12 @@ const ICON_SIZE_CLASS = {
     pixels: 40,
   },
   "roster-dashboard": {
-    surface: "h-[52px] w-[52px]",
-    lucideSurface: "h-[52px] w-[52px] rounded-[14px]",
-    imageSurface: "rounded-[14px]",
-    lucide: "h-[23px] w-[23px]",
+    surface: "h-14 w-14",
+    lucideSurface: "h-14 w-14 rounded-[16px]",
+    imageSurface: "rounded-[16px]",
+    lucide: "h-6 w-6",
     image: "h-full w-full object-contain",
-    pixels: 52,
+    pixels: 56,
   },
   // Larger rounded-square tile for the dashboard grid card (reference design).
   "roster-lg": {
@@ -101,7 +101,7 @@ const PROFILE_ICON_RADIUS_CLASS: Record<AgentSectionIconSize, string> = {
   menu: "rounded-[11px]",
   setup: "rounded-[10px]",
   roster: "rounded-[12px]",
-  "roster-dashboard": "rounded-[14px]",
+  "roster-dashboard": "rounded-[16px]",
   "roster-lg": "rounded-[18px]",
 };
 
@@ -231,10 +231,7 @@ export function AgentSectionIcon({
           // ancestor cannot override the requested contrast. Branded chips
           // use dark glyphs in light mode and light glyphs in dark mode; the
           // same primitive drives the dashboard grid and the top switcher.
-          className={cn(
-            classes.lucide,
-            tone ? "!text-white" : "text-current",
-          )}
+          className={cn(classes.lucide, tone ? "!text-white" : "text-current")}
           aria-hidden
         />
       ) : null}

--- a/hushh-webapp/components/app-ui/top-shell-tabs.tsx
+++ b/hushh-webapp/components/app-ui/top-shell-tabs.tsx
@@ -253,7 +253,7 @@ export function TopShellTabs({
                   "ui-text-agent-tab-label relative truncate transition-colors duration-150",
                   usesModuleSegmentedTabs
                     ? isActive
-                      ? "font-semibold text-[color:var(--app-label)]"
+                      ? "font-semibold text-[color:var(--app-accent)]"
                       : "font-medium text-[color:var(--app-secondary-label)] hover:text-[color:var(--app-label)]"
                     : isActive
                       ? "text-[color:var(--app-accent)]"

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -103,7 +103,9 @@ type PhoneVerificationFlowProps = {
   onCompleted: (user?: User | null) => Promise<void> | void;
   onContinueExisting?: () => Promise<void> | void;
   onCancel?: () => void;
+  sendCodeLabel?: string;
   confirmLabel?: string;
+  primaryActionClassName?: string;
   className?: string;
   helperText?: string;
   style?: CSSProperties;
@@ -352,7 +354,9 @@ export function PhoneVerificationFlow({
   onCompleted,
   onContinueExisting,
   onCancel,
+  sendCodeLabel,
   confirmLabel,
+  primaryActionClassName,
   className,
   helperText,
   style,
@@ -1102,12 +1106,16 @@ export function PhoneVerificationFlow({
               effect="fill"
               size="default"
               fullWidth
-              className={`type-headline ${FLOW_CTA_CLASS_NAME}`}
+              className={cn(
+                "type-headline",
+                FLOW_CTA_CLASS_NAME,
+                primaryActionClassName,
+              )}
             >
               {busy ? (
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
               ) : (
-                "Send verification code"
+                sendCodeLabel || "Send verification code"
               )}
             </Button>
             {onCancel ? (
@@ -1189,7 +1197,11 @@ export function PhoneVerificationFlow({
             effect="fill"
             size="default"
             fullWidth
-            className={`type-headline ${FLOW_CTA_CLASS_NAME}`}
+            className={cn(
+              "type-headline",
+              FLOW_CTA_CLASS_NAME,
+              primaryActionClassName,
+            )}
           >
             {busy ? (
               <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -1068,9 +1068,9 @@ export function AuthStep({
         data-auth-content-block
       >
         {/* Center the complete sign-in group as one visual block while the
-            fixed Back control remains independently anchored above it. The
-            clusters use one deliberate rhythm: identity, provider actions,
-            then the consent and legal context. */}
+            fixed Back control remains independently anchored above it. Legal
+            copy is anchored separately at the bottom like a standard auth
+            footer, so it does not read as primary sign-in content. */}
         <div
           className="flex w-full flex-none flex-col items-center gap-6 px-6 pb-6 text-center"
           data-auth-signin-clusters
@@ -1142,45 +1142,34 @@ export function AuthStep({
               ) : null}
             </div>
 
-            <div
-              className="flex flex-col items-center gap-3"
-              data-auth-supporting-content
-            >
-              {/* Consent-first reassurance chip. */}
-              <div className="flex w-fit items-center gap-1.5 rounded-full bg-[color:var(--app-accent-tint)] px-3 py-1.5 dark:bg-white/[0.06]">
-                <Icon
-                  icon={Shield}
-                  size="sm"
-                  className="text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-deep)]"
-                />
-                <span className="type-footnote text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-deep)]">
-                  You choose what One can see.
-                </span>
-              </div>
-
-              <p className="type-footnote mx-auto max-w-[22rem] text-center leading-5 text-[#86868b] dark:text-white/45">
-                By continuing you agree to our{" "}
-                <button
-                  type="button"
-                  onClick={() => void openLegalDoc("terms")}
-                  data-voice-control-id="auth_terms"
-                  className="font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
-                >
-                  Terms
-                </button>
-                <span aria-hidden="true"> and </span>
-                <button
-                  type="button"
-                  onClick={() => void openLegalDoc("privacy")}
-                  data-voice-control-id="auth_privacy"
-                  className="font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
-                >
-                  Privacy Policy
-                </button>
-                .
-              </p>
-            </div>
           </div>
+        </div>
+      </div>
+      <div className="absolute inset-x-6 bottom-5 z-10 flex justify-center">
+        <div
+          className="flex flex-col items-center gap-3"
+          data-auth-supporting-content
+        >
+          <p className="type-footnote mx-auto max-w-[24rem] text-center leading-5 text-[#86868b] dark:text-white/45">
+            By continuing you agree to our{" "}
+            <button
+              type="button"
+              onClick={() => void openLegalDoc("terms")}
+              data-voice-control-id="auth_terms"
+              className="font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
+            >
+              Terms
+            </button>
+            <span aria-hidden="true"> and </span>
+            <button
+              type="button"
+              onClick={() => void openLegalDoc("privacy")}
+              data-voice-control-id="auth_privacy"
+              className="font-semibold text-[color:var(--app-accent-deep)] transition-opacity hover:opacity-70 dark:text-[color:var(--app-accent-deep)]"
+            >
+              Privacy Policy
+            </button>
+          </p>
         </div>
       </div>
       <AuthLegalDialog

--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -954,8 +954,7 @@ describe("NearbyCheckInSheet", () => {
     expect(drift).not.toHaveTextContent(/match against the place/i);
   });
 
-  it("keeps leaving prominent without using destructive red", async () => {
-    service.getNearbyPresence.mockResolvedValue({
+  it("makes leaving the primary active action without using destructive red", async () => {    service.getNearbyPresence.mockResolvedValue({
       presence: {
         status: "active",
         audience: "all_opted_in",
@@ -994,7 +993,6 @@ describe("NearbyCheckInSheet", () => {
       "bg-[color:var(--app-destructive)]",
     );
     expect(checkout.className).toContain("bg-[color:var(--app-neutral-fill)]");
-
     const addTime = screen.getByRole("button", { name: "Add time" });
     expect(addTime.className).toContain("text-[color:var(--app-accent)]");
 

--- a/hushh-webapp/components/one-location/redesign/__tests__/people-hub.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/people-hub.test.tsx
@@ -55,6 +55,7 @@ function vm(overrides: Partial<LocationHubViewModel> = {}): LocationHubViewModel
     incomingCircleMemberInvitesLoading: false,
     incomingCircleMemberInvitesError: null,
     incomingCircleMemberInviteFocusResolved: true,
+    recipients: [recipient],
     visibleRecipients: [recipient],
     recipientSearch: "",
     setRecipientSearch: vi.fn(),
@@ -97,10 +98,47 @@ function vm(overrides: Partial<LocationHubViewModel> = {}): LocationHubViewModel
 }
 
 describe("PeopleHub requests sent manage surface", () => {
-  it("uses the Connect avatar renderer for Location people rows", () => {
+  function renderPeopleHub({
+    viewModel = vm(),
+    onStartShare = vi.fn(),
+    onStartAsk = vi.fn(),
+    onOpenSharedWithMe = vi.fn(),
+    onOpenActiveShares = vi.fn(),
+    onAddConnections = vi.fn(),
+  }: {
+    viewModel?: LocationHubViewModel;
+    onStartShare?: ReturnType<typeof vi.fn>;
+    onStartAsk?: ReturnType<typeof vi.fn>;
+    onOpenSharedWithMe?: ReturnType<typeof vi.fn>;
+    onOpenActiveShares?: ReturnType<typeof vi.fn>;
+    onAddConnections?: ReturnType<typeof vi.fn>;
+  } = {}) {
     render(
       <PeopleHub
-        vm={vm({
+        vm={viewModel}
+        onAddConnections={onAddConnections}
+        onInvite={vi.fn()}
+        onOpenCircleManager={vi.fn()}
+        focusedInviteId={null}
+        onDismissFocusedInvite={vi.fn()}
+        onStartShare={onStartShare}
+        onStartAsk={onStartAsk}
+        onOpenActiveShares={onOpenActiveShares}
+        onOpenSharedWithMe={onOpenSharedWithMe}
+      />,
+    );
+    return {
+      onStartShare,
+      onStartAsk,
+      onOpenSharedWithMe,
+      onOpenActiveShares,
+      onAddConnections,
+    };
+  }
+
+  it("uses the Connect avatar renderer for Location people rows", () => {
+    renderPeopleHub({
+      viewModel: vm({
           requestedByMe: [],
           receivedGrants: [],
           editingGrantId: null,
@@ -111,17 +149,8 @@ describe("PeopleHub requests sent manage surface", () => {
               isRia: true,
             },
           ],
-        })}
-        onAddConnections={vi.fn()}
-        onInvite={vi.fn()}
-        onCreateCircle={vi.fn()}
-        onJoinCircle={vi.fn()}
-        onOpenCircle={vi.fn()}
-        focusedInviteId={null}
-        onDismissFocusedInvite={vi.fn()}
-        onStartShare={vi.fn()}
-      />,
-    );
+        }),
+    });
 
     const peopleList = screen.getByTestId("one-location-people-list");
     expect(
@@ -134,7 +163,7 @@ describe("PeopleHub requests sent manage surface", () => {
     ).toBeInTheDocument();
   });
 
-  it("starts Circle content at the shared tab pane top", () => {
+  it("starts People with the Circles summary row", () => {
     render(
       <PeopleHub
         vm={vm()}
@@ -151,122 +180,84 @@ describe("PeopleHub requests sent manage surface", () => {
 
     const hub = screen.getByTestId("one-location-people-hub");
     const sectionStack = hub.firstElementChild as HTMLElement | null;
-    const circles = screen.getByTestId("one-location-named-circles");
+    const circles = screen.getByTestId("one-location-circles-summary");
 
     expect(hub).not.toHaveClass("pt-5");
     expect(hub).not.toHaveClass("sm:pt-9");
-    expect(sectionStack).toHaveClass("space-y-7", "sm:space-y-10");
     expect(sectionStack?.firstElementChild).toBe(circles);
   });
 
-  it("uses quick extension actions instead of the old duration editor", () => {
-    render(
-      <PeopleHub
-        vm={vm()}
-        onAddConnections={vi.fn()}
-        onInvite={vi.fn()}
-        onCreateCircle={vi.fn()}
-        onJoinCircle={vi.fn()}
-        onOpenCircle={vi.fn()}
-        focusedInviteId={null}
-        onDismissFocusedInvite={vi.fn()}
-        onStartShare={vi.fn()}
-      />,
-    );
-
+  it("opens received-location management from the row", () => {
+    const onOpenSharedWithMe = vi.fn();
+    const onStartShare = vi.fn();
+    renderPeopleHub({ onOpenSharedWithMe, onStartShare });
     expect(screen.getByText("Sharing with you · 42 min left")).toBeTruthy();
-    expect(screen.getByText("Ask for more time")).toBeTruthy();
-
-    // Four additive amounts, in ascending order, every label saying "more".
-    // Shared with step 1 of Request location, which used to render an absolute
-    // "New duration" picker for this same decision -- see
-    // `redesign/request-more-time`.
-    expect(
-      within(screen.getByTestId("one-location-more-time-options"))
-        .getAllByRole("button")
-        .map((button) => button.textContent?.trim()),
-    ).toEqual(["15 min more", "30 min more", "1 hour more", "2 hours more"]);
-
-    // The spoken name names the person too: four buttons reading only
-    // "15 min more" tell a screen reader nothing about whose share they
-    // lengthen. It still opens with the visible label, so the two agree.
-    expect(
-      screen.getByRole("button", { name: "Ask Roopmann V for 30 min more" }),
-    ).toBeTruthy();
-
-    expect(screen.getByText("They’ll need to approve.")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Stop viewing" })).toBeTruthy();
-    expect(screen.queryByText("New duration")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
-  });
-
-  it("sends the selected extension amount with the active grant id", () => {
-    const onRequestMoreTime = vi.fn().mockResolvedValue(undefined);
-    render(
-      <PeopleHub
-        vm={vm({ onRequestMoreTime })}
-        onAddConnections={vi.fn()}
-        onInvite={vi.fn()}
-        onCreateCircle={vi.fn()}
-        onJoinCircle={vi.fn()}
-        onOpenCircle={vi.fn()}
-        focusedInviteId={null}
-        onDismissFocusedInvite={vi.fn()}
-        onStartShare={vi.fn()}
-      />,
-    );
+    expect(screen.queryByText("Ask for more time")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Stop viewing" })).toBeNull();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Ask Roopmann V for 30 min more" }),
+      screen.getByRole("button", {
+        name: /Open Location actions for Roopmann V/i,
+      }),
     );
-    expect(onRequestMoreTime).toHaveBeenCalledWith({
-      ownerUserId: "owner_roopmann",
-      grantId: "grant_live",
-      ownerLabel: "Roopmann V",
-      additionalHours: 0.5,
+
+    expect(
+      screen.getByRole("dialog", { name: "Roopmann V" }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "View their location" }));
+    expect(onOpenSharedWithMe).toHaveBeenCalled();
+    expect(onStartShare).not.toHaveBeenCalled();
+  });
+
+  it("hands neutral people to the existing Share composer without a dialog", () => {
+    const onStartShare = vi.fn();
+    const onStartAsk = vi.fn();
+    renderPeopleHub({
+      viewModel: vm({
+        requestedByMe: [],
+        receivedGrants: [],
+        editingGrantId: null,
+      }),
+      onStartShare,
+      onStartAsk,
     });
 
-    // And the reporter's own example -- "pehle 2 hours ka toh 30 minutes more
-    // ya 1 hour" -- names a rung the original pair did not have.
     fireEvent.click(
-      screen.getByRole("button", { name: "Ask Roopmann V for 1 hour more" }),
+      screen.getByRole("button", {
+        name: "Share with Roopmann V",
+      }),
     );
-    expect(onRequestMoreTime).toHaveBeenLastCalledWith(
-      expect.objectContaining({ additionalHours: 1 }),
-    );
+
+    expect(onStartShare).toHaveBeenCalledWith("owner_roopmann");
+    expect(onStartAsk).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  it("shows pending extension state and keeps Take back wired", () => {
-    const pendingExtension = {
+  it("keeps pending request cancellation in the person actions sheet", () => {
+    const pendingRequest = {
       ...approvedRequest,
-      id: "request_extension",
+      id: "request_pending",
       status: "pending",
-      extendsGrantId: activeGrant.id,
-      requestedDurationHours: 2,
+      extendsGrantId: undefined,
     } as OneLocationAccessRequest;
     const onWithdrawRequest = vi.fn();
-    render(
-      <PeopleHub
-        vm={vm({
-          requestedByMe: [approvedRequest, pendingExtension],
-          onWithdrawRequest,
-        })}
-        onAddConnections={vi.fn()}
-        onInvite={vi.fn()}
-        onCreateCircle={vi.fn()}
-        onJoinCircle={vi.fn()}
-        onOpenCircle={vi.fn()}
-        focusedInviteId={null}
-        onDismissFocusedInvite={vi.fn()}
-        onStartShare={vi.fn()}
-      />,
+    renderPeopleHub({
+      viewModel: vm({
+        requestedByMe: [pendingRequest],
+        receivedGrants: [],
+        editingGrantId: null,
+        onWithdrawRequest,
+      }),
+    });
+
+    expect(screen.getByText("Waiting for response")).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Requests sent" })).toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Open Location actions for Roopmann V/i,
+      }),
     );
-
-    expect(screen.getByText("2 hours more requested")).toBeTruthy();
-    expect(screen.getByText("Waiting for approval")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "30 min more" })).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Take back" }));
-    expect(onWithdrawRequest).toHaveBeenCalledWith("request_extension");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel request" }));
+    expect(onWithdrawRequest).toHaveBeenCalledWith("request_pending");
   });
 });

--- a/hushh-webapp/components/one-location/redesign/__tests__/share-lanes.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/share-lanes.test.tsx
@@ -288,6 +288,11 @@ const HUB = path.join(
   "components/one-location/redesign/location-redesign-hub.tsx",
 );
 const source = readFileSync(HUB, "utf8");
+const LIVE_SHARE_STATUS_CARD = path.join(
+  process.cwd(),
+  "components/one-location/redesign/live-share-status-card.tsx",
+);
+const liveShareStatusCardSource = readFileSync(LIVE_SHARE_STATUS_CARD, "utf8");
 
 describe("hub wiring", () => {
   it("no longer binds a person's Stop to the FIRST grant it can find", () => {
@@ -295,7 +300,9 @@ describe("hub wiring", () => {
     // exact shape of the bug: one tap, one grant stopped, the other left live
     // with nothing on screen admitting it exists.
     expect(source).not.toContain("(g) => g.recipientUserId === r.userId");
-    expect(source).toContain("ownerGroupsByUserId.get(r.userId)");
+    expect(source).toContain("const ownerGroupsByUserId = useMemo(() => {");
+    expect(source).toContain("ownerGroupsByUserId.get(recipient.userId)");
+    expect(source).toContain("ShareLanesDisclosure");
   });
 
   it("renders every people-listing surface from grouped grants", () => {
@@ -323,6 +330,8 @@ describe("hub wiring", () => {
     // The common case must not have grown a step: the chevron appears only for
     // somebody who genuinely holds two.
     expect(source).toContain("group.grants.length === 1");
-    expect(source).toContain("shareGroup.grants.length === 1");
+    expect(liveShareStatusCardSource).toContain(
+      "status.grantCount === 1 && Boolean(status.stoppableGrantId)",
+    );
   });
 });

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -942,8 +942,7 @@ export function JoinCircleFlow({
               <UsersRound className="h-5 w-5" />
             </span>
             <div className="min-w-0 flex-1">
-              <p className="whitespace-normal text-[17px] font-semibold leading-[22px] text-foreground [overflow-wrap:anywhere]">
-                {preview.name}
+              <p className="whitespace-normal text-[17px] font-semibold leading-[22px] text-foreground [overflow-wrap:anywhere]">                {preview.name}
               </p>
               <p className="text-[14px] leading-5 text-[color:var(--app-secondary-label)]">
                 {preview.ownerDisplayName} ·{" "}

--- a/hushh-webapp/components/one-location/redesign/live-share-status-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/live-share-status-card.tsx
@@ -307,7 +307,6 @@ export function LiveShareStatusCard({
     event.preventDefault();
     onManage();
   };
-
   return (
     <section
       aria-label="Your live location share"
@@ -317,8 +316,7 @@ export function LiveShareStatusCard({
       role={cardManageEnabled ? "button" : undefined}
       tabIndex={cardManageEnabled ? 0 : undefined}
       onClick={cardManageEnabled ? onManage : undefined}
-      onKeyDown={handleCardKeyDown}
-      className={cn(CARD_SURFACE, LIVE_SHARE_CARD_CLASSNAME)}
+      onKeyDown={handleCardKeyDown}      className={cn(CARD_SURFACE, LIVE_SHARE_CARD_CLASSNAME)}
     >
       <div className={LIVE_SHARE_HEADER_CLASSNAME}>
         <span className="inline-flex min-w-0 items-center gap-2">

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -49,7 +49,6 @@ import {
 
 import {
   requestRecipientStatus,
-  shortAgo,
   type RequestRecipientStatus,
 } from "@/lib/one-location/request-recipient-status";
 import { SmsTextIcon } from "@/components/one-location/redesign/sms-text-icon";
@@ -189,7 +188,6 @@ import { usePageEnterAnimation } from "@/lib/morphy-ux/hooks/use-page-enter";
 import { resolveSmsContactsBackAction } from "@/lib/navigation/top-shell-breadcrumbs";
 import {
   CircleDetailFlow,
-  CirclesSection,
   CreateCircleFlow,
   JoinCircleFlow,
 } from "@/components/one-location/redesign/circles/named-circle-flows";
@@ -292,6 +290,21 @@ function askFlowConnectRecoveryHref(query: string): string {
   return `${ROUTES.CONNECT}?${params.toString()}`;
 }
 
+function peopleConnectRecoveryHref(query: string): string {
+  const params = new URLSearchParams();
+  params.set("tab", "all");
+  const trimmed = query.trim();
+  if (trimmed) params.set(CONNECT_SEARCH_QUERY_PARAM, trimmed);
+  params.set(CONNECT_RETURN_PARAM, `${ROUTES.ONE_LOCATION}?view=people`);
+  return `${ROUTES.CONNECT}?${params.toString()}`;
+}
+
+function connectCirclesHref(): string {
+  const params = new URLSearchParams();
+  params.set("tab", "circles");
+  params.set(CONNECT_RETURN_PARAM, `${ROUTES.ONE_LOCATION}?view=people`);
+  return `${ROUTES.CONNECT}?${params.toString()}`;
+}
 function waitingResponsesLabel(count: number): string {
   return `Waiting for ${count} ${count === 1 ? "response" : "responses"}`;
 }
@@ -329,19 +342,6 @@ function resolveLocationHubTab(value: string | null): LocationHubTab {
     LOCATION_TAB_DEFINITION,
     value,
   ) as LocationHubTab;
-}
-
-/**
- * What a settled request says in the "Requests sent" list.
- *
- * Everything that was not live used to read "Pending", including requests that
- * had been declined or taken back -- so a request the person themselves had
- * already withdrawn still sat there claiming to be waiting on somebody.
- */
-function requestStatusWord(status: string): string {
-  if (status === "denied") return "Declined";
-  if (status === "cancelled") return "Taken back";
-  return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
 export type LocationHubViewModel = {
@@ -518,8 +518,9 @@ export type LocationHubViewModel = {
   onEnterShareConfirm: () => void;
   onConfirmShare: () => void;
   /** Reports whether any request reached the server, and whether all did. */
-  onSendRequest: (reason?: string | null) => Promise<LocationRequestSendResult>;
-  onAskReshare: (grant: OneLocationGrant) => void;
+  onSendRequest: (
+    reason?: string | null,
+  ) => Promise<LocationRequestSendResult>;  onAskReshare: (grant: OneLocationGrant) => void;
   onApprove: (
     request: OneLocationAccessRequest,
     options?: {
@@ -1266,6 +1267,16 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
     [openFlow, startShareComposer],
   );
 
+  const openAskFlowForPerson = useCallback(
+    (initialRecipientId?: string) => {
+      const recipientId = initialRecipientId?.trim();
+      if (recipientId) {
+        vm.setSelectedRequestOwnerIds([recipientId]);
+      }
+      openFlow("ask");
+    },
+    [openFlow, vm],  );
+
   const closeFlow = useCallback(
     (nextTab?: LocationHubTab) => {
       if (flow === "share") {
@@ -1695,12 +1706,13 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
               vm={vm}
               onAddConnections={() => router.push(ROUTES.CONNECT)}
               onInvite={() => openFlow("invite")}
-              onCreateCircle={() => openFlow("create-circle")}
-              onJoinCircle={() => openFlow("join-circle")}
-              onOpenCircle={openCircleDetail}
+              onOpenCircleManager={() => router.push(connectCirclesHref())}
               focusedInviteId={focusedCircleMemberInviteId}
               onDismissFocusedInvite={dismissFocusedCircleMemberInvite}
               onStartShare={openShareFlow}
+              onStartAsk={openAskFlowForPerson}
+              onOpenActiveShares={() => openFlow("active-shares")}
+              onOpenSharedWithMe={() => openFlow("shared-with-me")}
             />
           </LocationHubPanel>
 
@@ -1712,10 +1724,6 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
     </div>
   );
 }
-
-/** Quiet text actions used by the reference-style People section headers. */
-const PEOPLE_HEADER_ACTION =
-  "relative !h-auto !min-h-0 !rounded-none !px-0 !py-0 text-[16px] font-normal leading-5 tracking-[-0.24px] after:absolute after:-inset-x-2 after:-inset-y-3 after:content-[''] sm:text-[15px]";
 
 const LOCATION_GROUP_SURFACE =
   "overflow-hidden rounded-[var(--app-radius-md)] bg-[color:var(--app-primary-surface)] shadow-[var(--app-card-shadow-standard)] ring-1 ring-inset ring-[color:var(--app-separator)] dark:shadow-none";
@@ -1840,8 +1848,7 @@ function NowHub({
               ? () =>
                   vm.onEditLiveShareDurationStart(
                     vm.liveShare?.stoppableGrantId ?? undefined,
-                  )
-              : undefined
+                  )              : undefined
           }
           onShareMore={onStartShare}
           onEnded={vm.onLiveShareEnded}
@@ -3251,92 +3258,123 @@ function StopGrantTextButton({
   );
 }
 
-/** One person in the People list: avatar (+ live dot) · name · status · action. */
+/** One person in the People list: avatar (+ live dot) · name · status · direct action. */
 function PersonRow({
   name,
   photoUrl,
   verified,
-  fromContacts,
   subtitle,
   active,
   first,
   action,
   expansion,
   profileHref,
+  onOpen,
 }: {
   name: string;
   photoUrl?: string | null;
   verified?: boolean;
-  fromContacts?: boolean;
-  subtitle: string;
+  subtitle: string | null;
   /** When this person has a request profile, the name opens it. */
   profileHref?: string | null;
   /** True when there's a live connection (you're sharing or they're sharing). */
   active: boolean;
   first: boolean;
-  action: ReactNode;
+  action?: ReactNode;
   /**
    * The row's per-share breakdown, when this person holds more than one live
-   * share. Rendered UNDER the row rather than beside it: it is a list with its
-   * own controls, and the row's own line has one name, one status and one
-   * action's worth of room.
+   * share. Rendered under the row so the main line keeps one clear action.
    */
   expansion?: ReactNode;
+  onOpen?: () => void;
 }) {
-  return (
-    // The separator and the hover wash belong to the whole row INCLUDING its
-    // breakdown: a person's two shares are one row, and a hairline cutting
-    // between the name and the shares underneath it would read as two people.
-    <div
-      className={cn(
-        "relative transition-colors hover:bg-[color:var(--app-neutral-fill)] motion-reduce:transition-none",
-        !first &&
-          "before:absolute before:left-16 before:right-4 before:top-0 before:h-px before:bg-[color:var(--app-separator)] before:content-['']",
-      )}
-    >
-      <div className="flex min-h-[60px] items-center gap-3 px-4 py-2.5 sm:min-h-16">
-        <div className="relative shrink-0">
-          <ConnectionPersonAvatar
-            label={name}
-            photoUrl={photoUrl}
-            verified={verified}
-            className="h-9 w-9 text-[13px]"
-          />
-          {active ? (
-            <span
-              className={cn(
-                "absolute h-3 w-3 rounded-full border-2 border-[color:var(--app-primary-surface)] bg-[color:var(--app-success)]",
-                verified ? "-right-0.5 -top-0.5" : "bottom-0 right-0",
-              )}
-            />
-          ) : null}
-        </div>
-        <div className="min-w-0 flex-1 space-y-0.5">
-          <div className="flex min-w-0 items-start gap-1.5">
-            {profileHref ? (
-              <Link
-                href={profileHref}
-                className="min-w-0 flex-1 break-words text-left text-[17px] font-medium leading-[22px] tracking-[-0.3px] text-foreground underline-offset-4 hover:underline"
-                aria-label={`Open profile: ${name}`}
-                data-testid="one-location-person-profile-link"
-              >
-                {name}
-              </Link>
-            ) : (
-              <p className="min-w-0 flex-1 break-words text-[17px] font-medium leading-[22px] tracking-[-0.3px] text-foreground">
-                {name}
-              </p>
+  const ariaLabel = subtitle
+    ? `Open Location actions for ${name}. ${subtitle}`
+    : `Open Location actions for ${name}`;
+  const content = (
+    <>
+      <div className="relative shrink-0">
+        <ConnectionPersonAvatar
+          label={name}
+          photoUrl={photoUrl}
+          verified={verified}
+          className="h-10 w-10 text-[13px]"
+        />
+        {active ? (
+          <span
+            aria-hidden="true"
+            className={cn(
+              "absolute h-3 w-3 rounded-full border-2 border-[color:var(--app-primary-surface)] bg-[color:var(--app-success)]",
+              verified ? "-right-0.5 -top-0.5" : "bottom-0 right-0",
             )}
-            {fromContacts ? (
-              <ContactSourceBadge className="mt-px shrink-0" />
-            ) : null}
-          </div>
+          />
+        ) : null}
+      </div>
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <div className="flex min-w-0 items-start gap-1.5">
+          {profileHref ? (
+            <Link
+              href={profileHref}
+              className="min-w-0 flex-1 break-words text-left text-[17px] font-medium leading-[22px] tracking-[-0.3px] text-foreground underline-offset-4 hover:underline"
+              aria-label={`Open profile: ${name}`}
+              data-testid="one-location-person-profile-link"
+            >
+              {name}
+            </Link>
+          ) : (
+            <p className="min-w-0 flex-1 break-words text-[17px] font-medium leading-[22px] tracking-[-0.3px] text-foreground">
+              {name}
+            </p>
+          )}
+        </div>
+        {subtitle ? (
           <p className="break-words text-[13px] font-normal leading-[18px] tracking-[-0.2px] text-[color:var(--app-secondary-label)]">
             {subtitle}
           </p>
-        </div>
-        {action ? <div className="shrink-0">{action}</div> : null}
+        ) : null}
       </div>
+      {action ? (
+        <div className="shrink-0">{action}</div>
+      ) : onOpen && profileHref ? (
+        <button
+          type="button"
+          onClick={onOpen}
+          aria-label={ariaLabel}
+          className="flex h-11 w-11 shrink-0 items-center justify-end text-[color:var(--app-tertiary-label)] outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] focus-visible:ring-offset-2"
+        >
+          <ChevronRight className="h-4 w-4" aria-hidden="true" />
+        </button>
+      ) : onOpen ? (
+        <ChevronRight
+          className="h-4 w-4 shrink-0 text-[color:var(--app-tertiary-label)]"
+          aria-hidden="true"
+        />
+      ) : null}
+    </>
+  );
+  return (
+    <div
+      className={cn(
+        "relative transition-colors motion-reduce:transition-none",
+        !first &&
+          "before:absolute before:left-16 before:right-4 before:top-0 before:h-px before:bg-[color:var(--app-separator)] before:content-['']",
+        "[@media(hover:hover)]:hover:bg-[color:var(--app-neutral-fill)]",
+      )}
+    >
+      {onOpen && !profileHref ? (
+        <button
+          type="button"
+          onClick={onOpen}
+          aria-label={ariaLabel}
+          className="flex min-h-[60px] w-full items-center gap-3 px-4 py-2.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] focus-visible:ring-offset-2 sm:min-h-16"
+        >
+          {content}
+        </button>
+      ) : (
+        <div className="flex min-h-[60px] items-center gap-3 px-4 py-2.5 sm:min-h-16">
+          {content}
+        </div>
+      )}
       {expansion ? (
         <div className="px-[18px] pb-2 sm:px-6">{expansion}</div>
       ) : null}
@@ -3358,149 +3396,693 @@ function countdownAsLeft(label: string | null | undefined): string | null {
 function isGenericConnectionCopy(value: string): boolean {
   return (
     value === "Ready for private location sharing" ||
+    /^in your contacts$/i.test(value) ||
     /existing trust or sharing history/i.test(value)
   );
 }
 
-function peopleShareStatus(
-  group: OneLocationGrantLaneGroup | null,
-  receiving: boolean,
+type PeopleDirectoryStatus = {
+  label: string | null;
+  active: boolean;
+  kind: "both" | "outgoing" | "incoming" | "pending" | "neutral";
+};
+
+function shareGroupStatusLabel({
+  group,
+  countdownLabel,
+  incoming,
+}: {
+  group: OneLocationGrantLaneGroup;
   countdownLabel: (value?: string | null) => string,
-  fallback: string,
-): string {
-  if (group && receiving) {
-    return `${group.grants.length + 1} active shares`;
-  }
-  if (!group) {
-    return receiving
-      ? "Sharing with you"
-      : isGenericConnectionCopy(fallback)
-        ? "Connected"
-        : fallback;
-  }
+  incoming?: boolean;
+}): string {
   if (group.grants.length > 1) {
     return `${group.grants.length} active shares`;
   }
   const grant = group.primaryGrant;
   const left =
     grant.durationMode === "until_stopped"
-      ? "Until you stop"
+      ? incoming
+        ? "Until they stop"
+        : "Until you stop"
       : countdownAsLeft(countdownLabel(grant.expiresAt));
-  const prefix = isSmsTriggeredGrant(grant) ? "Save My Soul" : "You’re sharing";
+  const prefix = incoming
+    ? "Sharing with you"
+    : isSmsTriggeredGrant(grant)
+      ? "Save My Soul"
+      : "You’re sharing";
   return left ? `${prefix} · ${left}` : prefix;
 }
 
-function requestDurationLabel(request: OneLocationAccessRequest): string {
-  if (request.requestedDurationMode === "until_stopped") {
-    return "Until stopped";
+function peopleDirectoryStatus(input: {
+  outgoingGroup: OneLocationGrantLaneGroup | null;
+  incomingGroup: OneLocationGrantLaneGroup | null;
+  pendingRequest: OneLocationAccessRequest | null;
+  countdownLabel: (value?: string | null) => string;
+}): PeopleDirectoryStatus {
+  const { outgoingGroup, incomingGroup, pendingRequest, countdownLabel } = input;
+  if (outgoingGroup && incomingGroup) {
+    return { label: "Sharing both ways", active: true, kind: "both" };
   }
-  return formatLocationDurationLabel(request.requestedDurationHours);
+  if (outgoingGroup) {
+    return {
+      label: shareGroupStatusLabel({ group: outgoingGroup, countdownLabel }),
+      active: true,
+      kind: "outgoing",
+    };
+  }
+  if (incomingGroup) {
+    return {
+      label: shareGroupStatusLabel({
+        group: incomingGroup,
+        countdownLabel,
+        incoming: true,
+      }),
+      active: true,
+      kind: "incoming",
+    };
+  }
+  if (pendingRequest) {
+    return { label: "Waiting for response", active: false, kind: "pending" };
+  }
+  return { label: null, active: false, kind: "neutral" };
 }
 
-function sentRequestStatusLine(
-  request: OneLocationAccessRequest,
-  nowMs: number,
-  activeGrant?: OneLocationGrant | null,
-  countdownLabel?: (value?: string | null) => string,
-): string {
-  if (/active|approved|shared|granted/i.test(request.status)) {
-    const left =
-      activeGrant?.durationMode === "until_stopped"
-        ? "Until you stop"
-        : countdownAsLeft(countdownLabel?.(activeGrant?.expiresAt));
-    return left ? `Sharing with you · ${left}` : "Sharing with you";
+function personalCircleSummary(circles: readonly OneLocationCircleSummary[]) {
+  const personal = circles.filter(
+    (circle) => circle.systemKind == null && !Boolean(circle.isSystem),
+  );
+  const created = personal.filter((circle) => circle.role === "owner").length;
+  const joined = personal.filter((circle) => circle.role === "member").length;
+  return { personal, created, joined };
+}
+
+function personalCircleCountLabel({
+  created,
+  joined,
+}: {
+  created: number;
+  joined: number;
+}): string {
+  const parts: string[] = [];
+  if (created) parts.push(`${created} created`);
+  if (joined) parts.push(`${joined} joined`);
+  return parts.length ? parts.join(" · ") : "Create or join a Circle";
+}
+
+function circleInitials(value: string): string {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+function circleFlowErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message.trim()
+    ? error.message
+    : fallback;
+}
+
+function CircleIdentityStack({
+  circles,
+}: {
+  circles: readonly OneLocationCircleSummary[];
+}) {
+  const visible = circles.slice(0, 3);
+  const fallback = visible.length
+    ? visible
+    : [
+        {
+          id: "circle-summary-fallback",
+          name: "Circles",
+          memberCount: 0,
+        } as OneLocationCircleSummary,
+      ];
+  return (
+    <span
+      aria-hidden="true"
+      className="flex h-11 w-[54px] shrink-0 items-center"
+    >
+      {fallback.map((circle, index) => {
+        const isSmsCircle = circle.systemKind === "sms";
+        const isTrustedCircle = circle.systemKind === "trusted";
+        const initials = circleInitials(circle.name);
+        return (
+          <span
+            key={`${circle.id}-${index}`}
+            className={cn(
+              "inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[12px] border-2 border-[color:var(--app-primary-surface)] text-[13px] font-semibold shadow-sm",
+              index > 0 && "-ml-6",
+              isSmsCircle
+                ? "bg-[color:var(--app-destructive)] text-[color:var(--app-destructive-fg)]"
+                : "bg-[#E5E5EA] text-[#6E6E73] dark:bg-[rgba(142,142,147,0.28)] dark:text-[#F2F2F7]",
+            )}
+          >
+            {isSmsCircle ? (
+              <SmsTextIcon className="text-[10px] font-bold tracking-[-0.2px]" />
+            ) : isTrustedCircle ? (
+              <ShieldCheck className="h-[17px] w-[17px]" />
+            ) : initials ? (
+              initials
+            ) : (
+              <UsersRound className="h-[17px] w-[17px]" />
+            )}
+          </span>
+        );
+      })}
+    </span>
+  );
+}
+
+function CircleSummaryGroup({
+  circles,
+  invitationCount,
+  onOpenCircles,
+  onOpenInvitations,
+}: {
+  circles: readonly OneLocationCircleSummary[];
+  invitationCount: number;
+  onOpenCircles: () => void;
+  onOpenInvitations: () => void;
+}) {
+  const { personal, created, joined } = personalCircleSummary(circles);
+  const summary = personalCircleCountLabel({ created, joined });
+  const invitationTitle =
+    invitationCount === 1 ? "Circle invitation" : "Circle invitations";
+  return (
+    <div
+      className={LOCATION_GROUP_SURFACE}
+      data-testid="one-location-circles-summary"
+    >
+      <button
+        type="button"
+        onClick={onOpenCircles}
+        aria-label={`Circles, ${summary.replace(" · ", " and ")}`}
+        className={cn(
+          "grid min-h-[68px] w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 text-left outline-none transition-colors motion-reduce:transition-none",
+          "focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] focus-visible:ring-offset-2",
+          "[@media(hover:hover)]:hover:bg-[color:var(--app-neutral-fill)]",
+        )}
+      >
+        <CircleIdentityStack circles={personal.length ? personal : circles} />
+        <span className="min-w-0">
+          <span className="block text-[17px] font-semibold leading-[22px] tracking-[-0.3px] text-foreground">
+            Circles
+          </span>
+          <span className="mt-0.5 block text-[13px] font-normal leading-[18px] tracking-[-0.2px] text-[color:var(--app-secondary-label)]">
+            {summary}
+          </span>
+        </span>
+        <ChevronRight
+          className="h-4 w-4 text-[color:var(--app-tertiary-label)]"
+          aria-hidden="true"
+        />
+      </button>
+      {invitationCount > 0 ? (
+        <button
+          type="button"
+          onClick={onOpenInvitations}
+          aria-label={`${invitationTitle}, ${invitationCount} pending`}
+          className={cn(
+            "relative grid min-h-[56px] w-full grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 px-4 py-2.5 text-left outline-none transition-colors motion-reduce:transition-none",
+            "before:absolute before:left-4 before:right-4 before:top-0 before:h-px before:bg-[color:var(--app-separator)] before:content-['']",
+            "focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] focus-visible:ring-offset-2",
+            "[@media(hover:hover)]:hover:bg-[color:var(--app-neutral-fill)]",
+          )}
+          data-testid="one-location-circle-invitations-summary"
+        >
+          <span className="text-[15px] font-medium leading-5 text-foreground">
+            {invitationTitle}
+          </span>
+          <span className="text-[15px] font-semibold leading-5 text-[color:var(--app-accent)]">
+            {invitationCount}
+          </span>
+          <ChevronRight
+            className="h-4 w-4 text-[color:var(--app-tertiary-label)]"
+            aria-hidden="true"
+          />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function CircleInvitationsDialog({
+  open,
+  invites,
+  loading,
+  focusedInviteId,
+  focusedInviteResolutionReady,
+  inviteBusy,
+  onOpenChange,
+  onAcceptInvite,
+  onDeclineInvite,
+  onDismissFocusedInvite,
+}: {
+  open: boolean;
+  invites: OneLocationCircleMemberInvite[];
+  loading: boolean;
+  focusedInviteId: string | null;
+  focusedInviteResolutionReady: boolean;
+  inviteBusy: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAcceptInvite: (inviteId: string) => Promise<void>;
+  onDeclineInvite: (inviteId: string) => Promise<void>;
+  onDismissFocusedInvite: () => void;
+}) {
+  const [respondingInviteId, setRespondingInviteId] = useState<string | null>(
+    null,
+  );
+  const focusedInviteAvailable = focusedInviteId
+    ? invites.some((invite) => invite.id === focusedInviteId)
+    : true;
+  const showUnavailable =
+    Boolean(focusedInviteId) &&
+    focusedInviteResolutionReady &&
+    !loading &&
+    !focusedInviteAvailable;
+
+  const respondToInvite = async (
+    inviteId: string,
+    decision: "accept" | "decline",
+  ) => {
+    if (respondingInviteId || inviteBusy) return;
+    setRespondingInviteId(inviteId);
+    try {
+      if (decision === "accept") {
+        await onAcceptInvite(inviteId);
+      } else {
+        await onDeclineInvite(inviteId);
+      }
+    } catch (error) {
+      toast.error(
+        circleFlowErrorMessage(
+          error,
+          decision === "accept"
+            ? "Could not join this Circle."
+            : "Could not decline this invitation.",
+        ),
+      );
+    } finally {
+      setRespondingInviteId(null);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next);
+        if (!next && focusedInviteId) onDismissFocusedInvite();
+      }}
+    >
+      <DialogContent className="max-w-[420px] rounded-[24px] p-0">
+        <DialogHeader className="px-5 pb-2 pt-5 text-left">
+          <DialogTitle className="text-[20px] font-semibold leading-[25px] tracking-[-0.3px]">
+            Circle invitations
+          </DialogTitle>
+          {showUnavailable ? (
+            <DialogDescription>
+              This Circle invitation is no longer available.
+            </DialogDescription>
+          ) : null}
+        </DialogHeader>
+
+        {showUnavailable ? (
+          <div className="px-5 pb-5 pt-1">
+            <Button
+              type="button"
+              onClick={() => {
+                onOpenChange(false);
+                onDismissFocusedInvite();
+              }}
+              className="h-12 w-full rounded-2xl bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]"
+            >
+              Done
+            </Button>
+          </div>
+        ) : (
+          <div
+            className={cn("mx-4 mb-4", LOCATION_GROUP_SURFACE)}
+            data-testid="one-location-circle-invitations-dialog-list"
+          >
+            {invites.map((invite, index) => {
+              const responding = respondingInviteId === invite.id;
+              const inviter =
+                invite.inviterDisplayName?.trim() || "Someone you know";
+              const circleName = invite.circleName?.trim() || "Circle";
+              return (
+                <div
+                  key={invite.id}
+                  className={cn(
+                    "relative grid min-h-[68px] grid-cols-[auto_minmax(0,1fr)] gap-3 px-4 py-3 sm:grid-cols-[auto_minmax(0,1fr)_auto]",
+                    index > 0 &&
+                      "before:absolute before:left-16 before:right-4 before:top-0 before:h-px before:bg-[color:var(--app-separator)] before:content-['']",
+                  )}
+                  tabIndex={invite.id === focusedInviteId ? -1 : undefined}
+                >
+                  <span
+                    aria-hidden="true"
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-[12px] bg-[#E5E5EA] text-[13px] font-semibold text-[#6E6E73] dark:bg-[rgba(142,142,147,0.28)] dark:text-[#F2F2F7]"
+                  >
+                    {circleInitials(circleName) || (
+                      <UsersRound className="h-[17px] w-[17px]" />
+                    )}
+                  </span>
+                  <div className="min-w-0">
+                    <p className="break-words text-[17px] font-medium leading-[22px] tracking-[-0.3px] text-foreground">
+                      {circleName}
+                    </p>
+                    <p className="mt-0.5 break-words text-[13px] leading-[18px] tracking-[-0.2px] text-[color:var(--app-secondary-label)]">
+                      Invited by {inviter}
+                    </p>
+                  </div>
+                  <div className="col-span-2 flex items-center justify-end gap-2 sm:col-span-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      disabled={responding || inviteBusy}
+                      onClick={() => void respondToInvite(invite.id, "decline")}
+                      className="h-11 rounded-full px-3 text-[15px] text-[color:var(--app-secondary-label)] hover:bg-transparent"
+                    >
+                      {responding && inviteBusy ? "Declining…" : "Decline"}
+                    </Button>
+                    <Button
+                      type="button"
+                      disabled={responding || inviteBusy}
+                      onClick={() => void respondToInvite(invite.id, "accept")}
+                      className="h-11 rounded-full bg-[color:var(--app-accent)] px-4 text-[15px] text-[color:var(--app-accent-fg)]"
+                    >
+                      {responding && inviteBusy ? "Joining…" : "Join"}
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PersonActionsDialog({
+  open,
+  name,
+  photoUrl,
+  verified,
+  status,
+  shareReady,
+  pendingRequest,
+  withdrawingRequestId,
+  onOpenChange,
+  onShare,
+  onAsk,
+  onManageSharing,
+  onViewLocation,
+  onManageConnection,
+  onCancelRequest,
+}: {
+  open: boolean;
+  name: string;
+  photoUrl?: string | null;
+  verified?: boolean;
+  status: PeopleDirectoryStatus;
+  shareReady: boolean;
+  pendingRequest: OneLocationAccessRequest | null;
+  withdrawingRequestId: string | null;
+  onOpenChange: (open: boolean) => void;
+  onShare: () => void;
+  onAsk: () => void;
+  onManageSharing: () => void;
+  onViewLocation: () => void;
+  onManageConnection: () => void;
+  onCancelRequest: () => void;
+}) {
+  const cancelBusy =
+    Boolean(pendingRequest) && withdrawingRequestId === pendingRequest?.id;
+  const actionRows: ReactNode[] = [];
+  const action = (
+    key: string,
+    title: string,
+    onClick: () => void,
+    options?: { tone?: "default" | "destructive"; chevron?: boolean },
+  ) => (
+    <SettingsRow
+      key={key}
+      title={title}
+      density="compact"
+      tone={options?.tone ?? "default"}
+      chevron={options?.chevron ?? true}
+      onClick={onClick}
+      testId={`one-location-person-action-${key}`}
+    />
+  );
+
+  if (status.kind === "both") {
+    actionRows.push(action("view", "View their location", onViewLocation));
+    actionRows.push(action("manage", "Manage my sharing", onManageSharing));
+  } else if (status.kind === "outgoing") {
+    actionRows.push(action("manage", "Manage my sharing", onManageSharing));
+    if (!pendingRequest) {
+      actionRows.push(action("ask", "Ask for location", onAsk));
+    }
+  } else if (status.kind === "incoming") {
+    actionRows.push(action("view", "View their location", onViewLocation));
+    if (shareReady) {
+      actionRows.push(action("share", "Share my location", onShare));
+    }
+  } else if (status.kind === "pending" && pendingRequest) {
+    actionRows.push(
+      <SettingsRow
+        key="cancel"
+        title={cancelBusy ? "Cancelling…" : "Cancel request"}
+        density="compact"
+        tone="destructive"
+        disabled={cancelBusy}
+        onClick={onCancelRequest}
+        testId="one-location-person-action-cancel"
+      />,
+    );
+    if (shareReady) {
+      actionRows.push(action("share", "Share my location", onShare));
+    }
+  } else if (shareReady) {
+    actionRows.push(action("share", "Share my location", onShare));
+    actionRows.push(action("ask", "Ask for location", onAsk));
+  } else {
+    actionRows.push(
+      <SettingsRow
+        key="unavailable"
+        title="Location sharing is not available with this person yet."
+        density="compact"
+        disabled
+        testId="one-location-person-action-unavailable"
+      />,
+    );
+    actionRows.push(
+      action("connection", "Manage connection", onManageConnection),
+    );
   }
-  const requestedAt = request.requestedAt
-    ? Date.parse(request.requestedAt)
-    : Number.NaN;
-  const when = Number.isFinite(requestedAt)
-    ? `Requested ${shortAgo(requestedAt, nowMs)}`
-    : "Requested";
-  const duration = requestDurationLabel(request);
-  if (request.status === "pending") {
-    return duration ? `${when} · ${duration}` : when;
-  }
-  return requestStatusWord(request.status);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        aria-label={`Location actions for ${name}`}
+        className="max-w-[420px] rounded-[24px] p-0"
+      >
+        <DialogHeader className="px-5 pb-3 pt-5 text-left">
+          <div className="flex items-center gap-3">
+            <ConnectionPersonAvatar
+              label={name}
+              photoUrl={photoUrl}
+              verified={verified}
+              className="h-11 w-11 text-[14px]"
+            />
+            <div className="min-w-0">
+              <DialogTitle className="break-words text-[20px] font-semibold leading-[25px] tracking-[-0.3px]">
+                {name}
+              </DialogTitle>
+              {status.label ? (
+                <DialogDescription className="mt-0.5 text-[15px] leading-5 text-[color:var(--app-secondary-label)]">
+                  {status.label}
+                </DialogDescription>
+              ) : null}
+            </div>
+          </div>
+        </DialogHeader>
+        <div className="mx-4 mb-4">
+          <SettingsGroup separatorInset shellClassName={LOCATION_GROUP_SHELL_CLASSNAME}>
+            {actionRows.slice(0, 3)}
+          </SettingsGroup>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 export function PeopleHub({
   vm,
   onAddConnections,
   onInvite,
-  onCreateCircle,
-  onJoinCircle,
-  onOpenCircle,
+  onOpenCircleManager,
   focusedInviteId,
   onDismissFocusedInvite,
   onStartShare,
+  onStartAsk,
+  onOpenActiveShares,
+  onOpenSharedWithMe,
 }: {
   vm: LocationHubViewModel;
   onAddConnections: () => void;
   onInvite: () => void;
-  onCreateCircle: () => void;
-  onJoinCircle: () => void;
-  onOpenCircle: (circleId: string) => void;
+  onOpenCircleManager: () => void;
   focusedInviteId: string | null;
   onDismissFocusedInvite: () => void;
   onStartShare: (initialRecipientId?: string) => void;
+  onStartAsk: (initialRecipientId?: string) => void;
+  onOpenActiveShares: () => void;
+  onOpenSharedWithMe: () => void;
 }) {
   const hasSearch = vm.recipientSearch.trim().length > 0;
   const filtered = vm.visibleRecipients;
-  // Your live shares, by the person they point at -- ALL of them, not the
-  // first one found. This list used to read `activeOwnerGrants.find(...)`,
-  // which was correct only while a pair could hold one grant. Once an ordinary
-  // share and an SMS (SOS) share can both be live with the same person, `find`
-  // bound the row's single Stop to whichever happened to come first and left
-  // the other share running with no way to see it, let alone end it.
+  const [invitationsOpen, setInvitationsOpen] = useState(false);
+  const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
+  const { expandedLaneUserIds, toggleLaneExpansion } = useExpandedShareLanes();
+
   const ownerGroupsByUserId = useMemo(() => {
     const byUserId = new globalThis.Map<string, OneLocationGrantLaneGroup>();
     for (const group of groupGrantsByCounterpart(
-      vm.activeOwnerGrants,
+      vm.activeOwnerGrants.filter((grant) => grant.status === "active"),
       "owner",
     )) {
       byUserId.set(group.counterpartUserId, group);
     }
     return byUserId;
   }, [vm.activeOwnerGrants]);
-  const activeReceivedGrantById = useMemo(() => {
-    const byId = new globalThis.Map<string, OneLocationGrant>();
-    for (const grant of vm.receivedGrants) {
-      if (grant.status === "active") byId.set(grant.id, grant);
+
+  const receivedGroupsByOwnerId = useMemo(() => {
+    const byUserId = new globalThis.Map<string, OneLocationGrantLaneGroup>();
+    for (const group of groupGrantsByCounterpart(
+      vm.receivedGrants.filter((grant) => grant.status === "active"),
+      "recipient",
+    )) {
+      byUserId.set(group.counterpartUserId, group);
     }
-    return byId;
+    return byUserId;
   }, [vm.receivedGrants]);
-  const pendingExtensionByGrantId = useMemo(() => {
-    const byGrantId = new globalThis.Map<string, OneLocationAccessRequest>();
+
+  const pendingRequestByOwnerId = useMemo(() => {
+    const byUserId = new globalThis.Map<string, OneLocationAccessRequest>();
     for (const request of vm.requestedByMe) {
-      if (request.status !== "pending" || !request.extendsGrantId) continue;
-      if (!byGrantId.has(request.extendsGrantId)) {
-        byGrantId.set(request.extendsGrantId, request);
+      if (request.status !== "pending" || request.extendsGrantId) continue;
+      if (!byUserId.has(request.ownerUserId)) {
+        byUserId.set(request.ownerUserId, request);
       }
     }
-    return byGrantId;
+    return byUserId;
   }, [vm.requestedByMe]);
-  const requestsSentRows = useMemo(
+
+  const [selectedPersonId, setSelectedPersonId] = useState<string | null>(null);
+  const selectedPerson = useMemo(
     () =>
-      vm.requestedByMe.filter(
-        (request) => !(request.status === "pending" && request.extendsGrantId),
-      ),
-    [vm.requestedByMe],
+      selectedPersonId
+        ? (vm.recipients.find((recipient) => recipient.userId === selectedPersonId) ??
+          filtered.find((recipient) => recipient.userId === selectedPersonId) ??
+          null)
+        : null,
+    [filtered, selectedPersonId, vm.recipients],
   );
-  const { expandedLaneUserIds, toggleLaneExpansion } = useExpandedShareLanes();
-  const addPeopleEmptyAction = (
+  const selectedPersonName = selectedPerson
+    ? vm.recipientLabel(selectedPerson)
+    : "";
+  const selectedOutgoingGroup = selectedPerson
+    ? (ownerGroupsByUserId.get(selectedPerson.userId) ?? null)
+    : null;
+  const selectedIncomingGroup = selectedPerson
+    ? (receivedGroupsByOwnerId.get(selectedPerson.userId) ?? null)
+    : null;
+  const selectedPendingRequest = selectedPerson
+    ? (pendingRequestByOwnerId.get(selectedPerson.userId) ?? null)
+    : null;
+  const selectedPersonStatus = selectedPerson
+    ? peopleDirectoryStatus({
+        outgoingGroup: selectedOutgoingGroup,
+        incomingGroup: selectedIncomingGroup,
+        pendingRequest: selectedPendingRequest,
+        countdownLabel: vm.expiresCountdownLabel,
+      })
+    : null;
+
+  const recipientPageHasMore = vm.recipientPageHasMore;
+  const recipientPageLoading = vm.recipientPageLoading;
+  const onLoadMoreRecipients = vm.onLoadMoreRecipients;
+
+  useEffect(() => {
+    if (!focusedInviteId) return;
+    if (
+      vm.incomingCircleMemberInvitesLoading ||
+      !vm.incomingCircleMemberInviteFocusResolved
+    ) {
+      return;
+    }
+    setInvitationsOpen(true);
+  }, [
+    focusedInviteId,
+    vm.incomingCircleMemberInviteFocusResolved,
+    vm.incomingCircleMemberInvitesLoading,
+  ]);
+
+  useEffect(() => {
+    if (
+      !recipientPageHasMore ||
+      recipientPageLoading ||
+      typeof IntersectionObserver === "undefined"
+    ) {
+      return;
+    }
+    const node = loadMoreSentinelRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          void onLoadMoreRecipients();
+        }
+      },
+      { rootMargin: "240px 0px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [
+    onLoadMoreRecipients,
+    recipientPageHasMore,
+    recipientPageLoading,
+  ]);
+
+  const addPeopleEmptyAction = hasSearch ? (
+    <Link
+      href={peopleConnectRecoveryHref(vm.recipientSearch)}
+      data-testid="one-location-people-find-or-invite"
+      className="inline-flex h-11 min-h-11 items-center justify-center rounded-full bg-[color:var(--app-accent)] px-6 text-[16px] font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent-hover)]"
+    >
+      Find or invite someone
+    </Link>
+  ) : (
     <Button
       type="button"
       onClick={onAddConnections}
       data-voice-control-id="one-location-add-connections"
       className="h-11 min-h-11 rounded-full bg-[color:var(--app-accent)] px-6 text-[16px] font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent-hover)]"
     >
-      Add people
+      Find or invite someone
     </Button>
   );
   const addConnectionsMenu = (
     <ActionMenu
-      label="Add people"
-      title="Connections"
+      label="Add or manage people"
+      title="People"
       triggerIcon={Plus}
       testId="one-location-add-people"
       items={[
@@ -3547,355 +4129,223 @@ export function PeopleHub({
   );
 
   return (
-    <div className="pt-5 sm:pt-9" data-testid="one-location-people-hub">
-      <div className="space-y-7 sm:space-y-10">
-        <CirclesSection
-          circles={vm.circles}
-          incomingInvites={vm.incomingCircleMemberInvites}
-          incomingInvitesLoading={vm.incomingCircleMemberInvitesLoading}
-          incomingInvitesError={vm.incomingCircleMemberInvitesError}
-          focusedInviteId={focusedInviteId}
-          focusedInviteResolutionReady={
-            vm.incomingCircleMemberInviteFocusResolved
-          }
-          inviteBusy={vm.busy === "circleMemberInvite"}
-          onCreate={onCreateCircle}
-          onJoin={onJoinCircle}
-          onOpen={onOpenCircle}
-          onAcceptInvite={vm.onAcceptNamedCircleMemberInvite}
-          onDeclineInvite={vm.onDeclineNamedCircleMemberInvite}
-          onRetryInvites={vm.onRetryNamedCircleMemberInvites}
-          onDismissFocusedInvite={onDismissFocusedInvite}
-        />
+    <div className="pt-4 sm:pt-5" data-testid="one-location-people-hub">
+      <div className="mx-auto w-full max-w-[640px] space-y-5">
+        {!hasSearch ? (
+          <CircleSummaryGroup
+            circles={vm.circles}
+            invitationCount={vm.incomingCircleMemberInvites.length}
+            onOpenCircles={onOpenCircleManager}
+            onOpenInvitations={() => setInvitationsOpen(true)}
+          />
+        ) : null}
 
-        <div className="space-y-7 sm:space-y-9">
-          <section
-            aria-labelledby="one-location-connections-heading"
-            className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-4 sm:grid-cols-[minmax(0,1fr)_auto_auto_auto] sm:gap-x-6"
-            data-testid="one-location-people-connections"
-          >
-            <h2
-              id="one-location-connections-heading"
-              className="col-start-1 row-start-1 text-[15px] font-medium leading-5 tracking-[-0.01em] text-[color:var(--app-section-label)]"
-            >
-              Connections · {vm.recipientPageTotalCount}
-            </h2>
-
-            {vm.contactSyncSummary && vm.onViewContactSyncResults ? (
-              <button
-                type="button"
-                className="col-start-2 row-start-1 min-h-11 justify-self-end rounded-full px-2 text-[13px] font-medium text-[color:var(--app-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)]"
-                onClick={vm.onViewContactSyncResults}
+        <section
+          aria-labelledby="one-location-people-heading"
+          className="space-y-3"
+          data-testid="one-location-people-connections"
+        >
+          {!hasSearch ? (
+            <div className="flex items-center justify-between gap-4">
+              <h2
+                id="one-location-people-heading"
+                className="text-[20px] font-semibold leading-[25px] tracking-[-0.3px] text-[color:var(--app-section-label)]"
               >
-                {vm.contactSyncSummary.unknownCount
-                  ? `${vm.contactSyncSummary.unknownCount} need confirmation · View results`
-                  : vm.contactSyncSummary.connectedCount
-                    ? `${vm.contactSyncSummary.connectedCount} connected · View results`
-                    : `${vm.contactSyncSummary.matchedCount} matched · View results`}
-              </button>
-            ) : null}
-
-            <div className="col-start-3 row-start-1 justify-self-end sm:col-start-4">
+                People
+              </h2>
               {addConnectionsMenu}
             </div>
+          ) : (
+            <span id="one-location-people-heading" className="sr-only">
+              People
+            </span>
+          )}
 
+          <div
+            className={cn(
+              "[&_input]:h-[46px] [&_input]:rounded-[14px] [&_input]:border-0 [&_input]:bg-[color:var(--app-primary-surface)] [&_input]:pl-[46px] [&_input]:pr-[18px] [&_input]:text-[16px] [&_input]:leading-[22px] dark:[&_input]:bg-[color:var(--app-secondary-surface)]",
+              "[&_svg]:left-[18px] [&_svg]:text-[color:var(--app-tertiary-label)]",
+            )}
+            data-testid="one-location-people-search"
+          >
+            <PersonSearchInput
+              value={vm.recipientSearch}
+              onChange={vm.setRecipientSearch}
+              placeholder="Search people"
+            />
+          </div>
+
+          {filtered.length ? (
             <div
-              className={cn(
-                "col-span-3 row-start-2 mt-3 sm:col-span-4 sm:mt-3.5",
-                "[&_input]:h-[46px] [&_input]:rounded-full [&_input]:border-0 [&_input]:bg-[color:var(--app-primary-surface)] [&_input]:pl-[46px] [&_input]:pr-[18px] [&_input]:text-[17px] [&_input]:leading-[22px] [&_input]:tracking-[-0.3px] dark:[&_input]:bg-[color:var(--app-secondary-surface)]",
-                "[&_svg]:left-[18px] [&_svg]:text-[color:var(--app-tertiary-label)]",
-                "sm:[&_input]:h-12 sm:[&_input]:rounded-[var(--app-radius-md)] sm:[&_input]:pl-12 sm:[&_input]:pr-5 sm:[&_input]:text-base sm:[&_svg]:left-5",
-              )}
-              data-testid="one-location-people-search"
+              className={LOCATION_GROUP_SURFACE}
+              data-testid="one-location-people-list"
+              aria-busy={vm.recipientPageLoading || undefined}
             >
-              <PersonSearchInput
-                value={vm.recipientSearch}
-                onChange={vm.setRecipientSearch}
-                placeholder="Search people"
-              />
-            </div>
-
-            <div className="col-span-3 row-start-3 mt-3 sm:col-span-4 sm:mt-3.5">
-              {filtered.length ? (
-                <div
-                  className={LOCATION_GROUP_SURFACE}
-                  data-testid="one-location-people-list"
-                >
-                  {filtered.map((r, i) => {
-                    const shareGroup =
-                      ownerGroupsByUserId.get(r.userId) ?? null;
-                    const sharing = Boolean(shareGroup);
-                    // One share is still one tap: the row keeps its single
-                    // Stop and grows nothing. The breakdown appears only for a
-                    // person who genuinely has two.
-                    const singleGrant =
-                      shareGroup && shareGroup.grants.length === 1
-                        ? shareGroup.primaryGrant
-                        : null;
-                    const lanesExpanded = expandedLaneUserIds.has(r.userId);
-                    const lanesId = `one-location-people-lanes-${r.userId}`;
-                    const receiving = vm.receivedGrants.some(
-                      (g) => g.ownerUserId === r.userId,
-                    );
-                    const ready = vm.isRecipientShareReady(r);
-                    const name = vm.recipientLabel(r);
-                    return (
-                      <PersonRow
-                        key={r.userId}
-                        name={name}
-                        profileHref={
-                          r.publicPersonRef
-                            ? buildPersonProfileRoute(r.publicPersonRef, { from: ROUTES.ONE_LOCATION })
-                            : null
-                        }
-                        photoUrl={r.photoUrl}
-                        verified={Boolean(r.isRia)}
-                        fromContacts={r.connectedFromContacts}
-                        expansion={
-                          shareGroup && !singleGrant ? (
-                            <div id={lanesId} hidden={!lanesExpanded}>
-                              {/* Stopping the SMS share here is exactly the
-                                  same act as stopping it from the Emergency
-                                  help screen: the same grant id through the
-                                  same `revokeGrant`. The normal share keeps
-                                  its original countdown, and stopping the
-                                  normal share never touches the SMS one --
-                                  that is the whole of #5506, made visible. */}
-                              <PersonShareLanes
-                                group={shareGroup}
-                                counterpartName={name}
-                                onStopGrant={vm.onStopGrant}
-                                revokingGrantId={vm.revokingGrantId}
-                              />
-                            </div>
-                          ) : null
-                        }
-                        // Someone sharing location with you right now
-                        // used to read "Ready for private location sharing" —
-                        // the recommendation line, which describes what COULD
-                        // happen and so says the opposite of what is. The row
-                        // already knew (`receiving`), and spent it on an accent
-                        // colour. Two people with the same name, one sharing
-                        // and one not, were then indistinguishable except by a
-                        // tint, which is the whole reason "is this the same
-                        // person or a different one" is hard to answer here.
-                        subtitle={peopleShareStatus(
-                          shareGroup,
-                          receiving,
-                          vm.expiresCountdownLabel,
-                          vm.recipientSubtitle(r),
-                        )}
-                        active={sharing || receiving}
-                        first={i === 0}
-                        action={
-                          singleGrant ? (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => vm.onStopGrant(singleGrant.id)}
-                              isLoading={vm.revokingGrantId === singleGrant.id}
-                              aria-label={`Stop sharing with ${name}`}
-                              className="relative h-9 min-h-9 rounded-full px-2 text-[15px] font-medium text-[#FF3B30] after:absolute after:-inset-y-1 after:inset-x-0 after:content-[''] hover:bg-transparent hover:text-[#D70015]"
-                            >
-                              Stop
-                            </Button>
-                          ) : shareGroup ? (
-                            <ShareLanesDisclosure
-                              expanded={lanesExpanded}
-                              onToggle={() => toggleLaneExpansion(r.userId)}
-                              controlsId={lanesId}
-                              label={`Manage your shares with ${name}`}
-                            />
-                          ) : ready ? (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => onStartShare(r.userId)}
-                              aria-label={`Share with ${name}`}
-                              className="relative h-9 min-h-9 rounded-full px-2 text-[15px] font-medium text-[color:var(--app-accent)] after:absolute after:-inset-y-1 after:inset-x-0 after:content-[''] hover:bg-transparent hover:text-[color:var(--app-accent-hover)]"
-                            >
-                              Share
-                            </Button>
-                          ) : null
-                        }
-                      />
-                    );
-                  })}
-                </div>
-              ) : (
-                <div className="[&>[data-ui-role=grouped-card]]:rounded-[var(--app-radius-md)] [&>[data-ui-role=grouped-card]]:!bg-[color:var(--app-primary-surface)] [&>[data-ui-role=grouped-card]]:shadow-[var(--app-card-shadow-standard)] dark:[&>[data-ui-role=grouped-card]]:shadow-none">
-                  <EmptyState
-                    title={
-                      hasSearch ? "No matching people" : "No connections yet"
+              {filtered.map((recipient, index) => {
+                const name = vm.recipientLabel(recipient);
+                const outgoingGroup =
+                  ownerGroupsByUserId.get(recipient.userId) ?? null;
+                const incomingGroup =
+                  receivedGroupsByOwnerId.get(recipient.userId) ?? null;
+                const pendingRequest =
+                  pendingRequestByOwnerId.get(recipient.userId) ?? null;
+                const status = peopleDirectoryStatus({
+                  outgoingGroup,
+                  incomingGroup,
+                  pendingRequest,
+                  countdownLabel: vm.expiresCountdownLabel,
+                });
+                const singleGrant =
+                  outgoingGroup && outgoingGroup.grants.length === 1
+                    ? outgoingGroup.primaryGrant
+                    : null;
+                const lanesExpanded = expandedLaneUserIds.has(recipient.userId);
+                const lanesId = `one-location-people-lanes-${recipient.userId}`;
+                const shareReady = vm.isRecipientShareReady(recipient);
+                const subtitle =
+                  status.label ??
+                  (isGenericConnectionCopy(vm.recipientSubtitle(recipient))
+                    ? "Connected"
+                    : vm.recipientSubtitle(recipient));
+                return (
+                  <PersonRow
+                    key={recipient.userId}
+                    name={name}
+                    profileHref={
+                      recipient.publicPersonRef
+                        ? buildPersonProfileRoute(recipient.publicPersonRef, {
+                            from: ROUTES.ONE_LOCATION,
+                          })
+                        : null
                     }
-                    description={
-                      hasSearch
-                        ? "Try another name."
-                        : "Add people to share location privately."
+                    photoUrl={recipient.photoUrl}
+                    verified={Boolean(recipient.isRia)}
+                    expansion={
+                      outgoingGroup && !singleGrant ? (
+                        <div id={lanesId} hidden={!lanesExpanded}>
+                          <PersonShareLanes
+                            group={outgoingGroup}
+                            counterpartName={name}
+                            onStopGrant={vm.onStopGrant}
+                            revokingGrantId={vm.revokingGrantId}
+                          />
+                        </div>
+                      ) : null
                     }
-                    // The first link in a chain that already had its other
-                    // two. A name matching nobody here usually belongs to
-                    // someone not connected yet, so this hands over to
-                    // Connect -- where a search that also finds nobody offers
-                    // "Invite them to One". Without it the person had to guess
-                    // that Connect was the next place to look.
-                    //
-                    // The header actions sit above the list and are out of
-                    // view once results have scrolled, so the way out belongs
-                    // here, where the dead end is.
+                    subtitle={subtitle}
+                    active={status.active}
+                    first={index === 0}
+                    onOpen={
+                      status.kind !== "neutral" && !(outgoingGroup && !singleGrant)
+                        ? () => setSelectedPersonId(recipient.userId)
+                        : undefined
+                    }
                     action={
-                      hasSearch ? (
+                      outgoingGroup && !singleGrant ? (
+                        <ShareLanesDisclosure
+                          expanded={lanesExpanded}
+                          onToggle={() => toggleLaneExpansion(recipient.userId)}
+                          controlsId={lanesId}
+                          label={`Manage your shares with ${name}`}
+                        />
+                      ) : status.kind === "neutral" && shareReady ? (
                         <Button
-                          type="button"
-                          variant="link"
+                          variant="ghost"
                           size="sm"
-                          onClick={onAddConnections}
-                          data-voice-control-id="one-location-empty-connect-bridge"
-                          className={PEOPLE_HEADER_ACTION}
+                          onClick={() => onStartShare(recipient.userId)}
+                          aria-label={`Share with ${name}`}
+                          className="relative h-9 min-h-9 rounded-full px-2 text-[15px] font-medium text-[color:var(--app-accent)] after:absolute after:-inset-y-1 after:inset-x-0 after:content-[''] hover:bg-transparent hover:text-[color:var(--app-accent-hover)]"
                         >
-                          Manage connections
+                          Share
                         </Button>
-                      ) : (
-                        addPeopleEmptyAction
-                      )
+                      ) : null
                     }
                   />
-                </div>
-              )}
-              {vm.recipientPageHasMore ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={vm.recipientPageLoading}
-                  isLoading={vm.recipientPageLoading}
-                  onClick={() => void vm.onLoadMoreRecipients()}
-                  className="mt-3 h-11 w-full rounded-full"
-                  data-testid="one-location-people-load-more"
-                >
-                  Load more connections
-                </Button>
-              ) : null}
-            </div>
-          </section>
-
-          {requestsSentRows.length ? (
-            <SettingsGroup
-              title="Requests sent"
-              separatorInset
-              shellClassName="[--settings-group-radius:var(--app-radius-md)] !rounded-[var(--app-radius-md)] !bg-[color:var(--app-primary-surface)] !shadow-[var(--app-card-shadow-standard)]"
-            >
-              {requestsSentRows.map((request) => {
-                const isLive = /active|approved|shared|granted/i.test(
-                  request.status,
-                );
-                const grantId = request.approvedGrantId;
-                const activeGrant = grantId
-                  ? activeReceivedGrantById.get(grantId)
-                  : null;
-                const pendingExtension = grantId
-                  ? pendingExtensionByGrantId.get(grantId)
-                  : null;
-                const canEdit = isLive && Boolean(grantId);
-                const isEditing =
-                  Boolean(grantId) && vm.editingGrantId === grantId;
-                const ownerLabel = vm.requestOwnerLabel(request);
-                return (
-                  <div key={request.id}>
-                    <SettingsRow
-                      title={ownerLabel}
-                      description={sentRequestStatusLine(
-                        request,
-                        vm.nowMs,
-                        activeGrant,
-                        vm.expiresCountdownLabel,
-                      )}
-                      trailing={
-                        canEdit && grantId ? (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-9 px-2 text-[15px] font-medium text-[color:var(--app-accent)] hover:bg-transparent hover:text-[color:var(--app-accent-hover)]"
-                            onClick={() =>
-                              isEditing
-                                ? vm.onEditGrantCancel()
-                                : vm.onEditGrantStart(grantId)
-                            }
-                          >
-                            {isEditing ? "Done" : "Manage"}
-                          </Button>
-                        ) : isLive ? (
-                          "Active"
-                        ) : request.status === "pending" ? (
-                          // "Pending" as bare text was the whole trailing slot:
-                          // the state was reported and there was nothing to do
-                          // about it. The button replaces the word rather than
-                          // joining it -- a row you can still take back IS the
-                          // waiting one, and every settled row names itself.
-                          //
-                          // Measured, not assumed: word plus button came to
-                          // 161px in this fixed-width slot against the shipped
-                          // Edit/Stop pair's 115px, which wrapped the person's
-                          // name onto a second line at 320px. The button alone
-                          // is 99px. See the layout contract in e2e/.
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-9 px-2 text-[15px] font-medium text-[#FF3B30] hover:bg-transparent hover:text-[#D70015]"
-                            onClick={() => vm.onWithdrawRequest(request.id)}
-                            disabled={vm.withdrawingRequestId === request.id}
-                            aria-label={`Take back your request to ${ownerLabel}`}
-                          >
-                            Take back
-                          </Button>
-                        ) : (
-                          requestStatusWord(request.status)
-                        )
-                      }
-                      density="compact"
-                      className={cn(
-                        "[--settings-row-gap:12px] [--settings-row-px:16px] [--settings-row-py:10px]",
-                        "[&>button]:min-h-[60px] sm:[&>button]:min-h-16 [&>div]:min-h-[60px] sm:[&>div]:min-h-16",
-                        "[&_[data-slot=settings-row-title]]:!text-[17px] [&_[data-slot=settings-row-title]]:!font-medium [&_[data-slot=settings-row-title]]:!leading-[22px] [&_[data-slot=settings-row-title]]:!tracking-[-0.3px]",
-                        "[&_[data-slot=settings-row-description]]:!text-[13px] [&_[data-slot=settings-row-description]]:!font-normal [&_[data-slot=settings-row-description]]:!leading-[18px] [&_[data-slot=settings-row-description]]:!tracking-[-0.2px]",
-                      )}
-                    />
-                    {isEditing && grantId ? (
-                      <div className="space-y-3 px-4 pb-4 pt-1">
-                        {/* The same control step 1 of Request location shows,
-                            because it is the same decision about the same
-                            share. That screen used to render an absolute
-                            "New duration" picker here instead -- see
-                            `redesign/request-more-time`. */}
-                        <AskForMoreTime
-                          grantId={grantId}
-                          ownerUserId={request.ownerUserId}
-                          ownerLabel={ownerLabel}
-                          pendingExtension={pendingExtension}
-                          requestingMoreTimeKey={vm.requestingMoreTimeKey}
-                          withdrawingRequestId={vm.withdrawingRequestId}
-                          onRequestMoreTime={vm.onRequestMoreTime}
-                          onWithdrawRequest={vm.onWithdrawRequest}
-                        />
-                        <div className="border-t border-[color:var(--app-separator)] pt-1">
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-11 min-h-11 rounded-full px-0 text-[15px] font-medium text-[#FF3B30] hover:bg-transparent hover:text-[#D70015]"
-                            onClick={() => vm.onStopGrant(grantId)}
-                            disabled={vm.revokingGrantId === grantId}
-                          >
-                            Stop viewing
-                          </Button>
-                        </div>
-                      </div>
-                    ) : null}
-                  </div>
                 );
               })}
-            </SettingsGroup>
-          ) : null}
-        </div>
+              {vm.recipientPageHasMore ? (
+                <div
+                  ref={loadMoreSentinelRef}
+                  role="status"
+                  data-testid="one-location-people-load-more-sentinel"
+                  className="border-t border-[color:var(--app-separator)] px-4 py-3 text-center text-[13px] leading-[18px] text-[color:var(--app-secondary-label)]"
+                >
+                  {vm.recipientPageLoading ? "Loading more…" : ""}
+                </div>
+              ) : null}
+            </div>
+          ) : (
+            <div className="[&>[data-ui-role=grouped-card]]:rounded-[var(--app-radius-md)] [&>[data-ui-role=grouped-card]]:!bg-[color:var(--app-primary-surface)] [&>[data-ui-role=grouped-card]]:shadow-[var(--app-card-shadow-standard)] dark:[&>[data-ui-role=grouped-card]]:shadow-none">
+              <EmptyState
+                title={
+                  hasSearch
+                    ? `No match for “${vm.recipientSearch.trim()}”`
+                    : "No people yet"
+                }
+                description={
+                  hasSearch
+                    ? "They may not be in your connections yet."
+                    : "Find or invite someone to start sharing privately."
+                }
+                action={addPeopleEmptyAction}
+              />
+            </div>
+          )}
+        </section>
       </div>
+
+      {selectedPerson && selectedPersonStatus ? (
+        <PersonActionsDialog
+          open={Boolean(selectedPerson)}
+          name={selectedPersonName}
+          photoUrl={selectedPerson.photoUrl}
+          verified={Boolean(selectedPerson.isRia)}
+          status={selectedPersonStatus}
+          shareReady={vm.isRecipientShareReady(selectedPerson)}
+          pendingRequest={selectedPendingRequest}
+          withdrawingRequestId={vm.withdrawingRequestId}
+          onOpenChange={(open) =>
+            setSelectedPersonId(open ? selectedPerson.userId : null)
+          }
+          onShare={() => {
+            setSelectedPersonId(null);
+            onStartShare(selectedPerson.userId);
+          }}
+          onAsk={() => {
+            setSelectedPersonId(null);
+            onStartAsk(selectedPerson.userId);
+          }}
+          onManageSharing={() => {
+            setSelectedPersonId(null);
+            onOpenActiveShares();
+          }}
+          onViewLocation={() => {
+            setSelectedPersonId(null);
+            onOpenSharedWithMe();
+          }}
+          onManageConnection={() => {
+            setSelectedPersonId(null);
+            onAddConnections();
+          }}
+          onCancelRequest={() => {
+            if (!selectedPendingRequest) return;
+            void vm.onWithdrawRequest(selectedPendingRequest.id);
+          }}
+        />
+      ) : null}
+
+      <CircleInvitationsDialog
+        open={invitationsOpen}
+        invites={vm.incomingCircleMemberInvites}
+        loading={vm.incomingCircleMemberInvitesLoading}
+        focusedInviteId={focusedInviteId}
+        focusedInviteResolutionReady={vm.incomingCircleMemberInviteFocusResolved}
+        inviteBusy={vm.busy === "circleMemberInvite"}
+        onOpenChange={setInvitationsOpen}
+        onAcceptInvite={vm.onAcceptNamedCircleMemberInvite}
+        onDeclineInvite={vm.onDeclineNamedCircleMemberInvite}
+        onDismissFocusedInvite={onDismissFocusedInvite}
+      />
     </div>
   );
 }
@@ -5376,8 +5826,7 @@ function AskFlow({
   const pendingNewRequestCount = useMemo(
     () =>
       vm.requestedByMe.filter(
-        (request) => request.status === "pending" && !request.extendsGrantId,
-      ).length,
+        (request) => request.status === "pending" && !request.extendsGrantId,      ).length,
     [vm.requestedByMe],
   );
 
@@ -5614,8 +6063,7 @@ function AskFlow({
                 searchActive &&
                 recipientLabel
                   .toLowerCase()
-                  .includes(normalizedRecipientSearch);
-              const showStateActions = !status.selectable && exactStatusSearch;
+                  .includes(normalizedRecipientSearch);              const showStateActions = !status.selectable && exactStatusSearch;
               return (
                 <RequestRecipientListRow
                   key={r.userId}

--- a/hushh-webapp/components/wallet-card/wallet-card-setup.tsx
+++ b/hushh-webapp/components/wallet-card/wallet-card-setup.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { ChevronDown } from "lucide-react";
 
-import { SegmentedTabs as SettingsSegmentedTabs } from "@/components/profile/settings-ui";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { SegmentedTabs as SettingsSegmentedTabs } from "@/components/profile/settings-ui";import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";

--- a/hushh-webapp/lib/morphy-ux/ui/segmented-tabs.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/segmented-tabs.tsx
@@ -60,8 +60,7 @@ export function SegmentedTabs({
             role="tab"
             aria-label={option.accessibleLabel}
             aria-selected={isActive}
-            tabIndex={isActive ? 0 : -1}
-            disabled={disabled}
+            tabIndex={isActive ? 0 : -1}            disabled={disabled}
             data-state={isActive ? "active" : "inactive"}
             onClick={() => {
               if (!disabled && !isActive) onValueChange(option.value);

--- a/hushh-webapp/lib/navigation/connect-routes.ts
+++ b/hushh-webapp/lib/navigation/connect-routes.ts
@@ -15,7 +15,6 @@ export type FocusedConnectCircleAction =
   | "create-circle"
   | "join-circle"
   | "circle-detail";
-
 export function readConnectSurface(value: string | null): ConnectSurface {
   return value === "circles" ? "circles" : "all";
 }
@@ -39,8 +38,7 @@ export function isFocusedConnectCircleTask(
     surface === "circles" &&
     (action === "create-circle" ||
       action === "join-circle" ||
-      (action === "circle-detail" && Boolean(circleId?.trim())))
-  );
+      (action === "circle-detail" && Boolean(circleId?.trim())))  );
 }
 
 export function connectCircleTaskTitle(

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -16,8 +16,7 @@ import {
 import {
   CONNECT_CIRCLES_LIST_HREF,
   connectCircleTaskTitle,
-  isFocusedConnectCircleTask,
-  readConnectCircleAction,
+  isFocusedConnectCircleTask,  readConnectCircleAction,
 } from "@/lib/navigation/connect-routes";
 import {
   buildNearbyCheckInResumeHref,
@@ -1026,8 +1025,7 @@ function resolveTopShellBreadcrumbInner(
       action,
       searchParams?.get("circleId") ?? null,
     );
-    if (label && isFocusedTask) {
-      return {
+    if (label && isFocusedTask) {      return {
         // Back closes the flow and returns to the list, naming the tab
         // explicitly -- the App Router refuses a navigation whose only change
         // is the whole query string disappearing.
@@ -1036,8 +1034,7 @@ function resolveTopShellBreadcrumbInner(
         width: "profile",
         align: "center",
         hideBack: false,
-        items: [{ label }],
-      };
+        items: [{ label }],      };
     }
   }
 


### PR DESCRIPTION
## Summary
- Ships pending Hushh One non-dashboard UAT amendments across Connect, Location, Feed, onboarding/auth, phone verification, Talk to One chrome, and related shared primitives.
- Keeps the root `/one` dashboard/launcher work out of this PR per local-only approval gate.
- Adds a Cloud Build substitution exposure fix for Gmail monitor deploy variables so UAT does not roll back on unmatched substitutions.

## Dashboard exclusion
Not included:
- hushh-webapp/app/one/page.tsx
- hushh-webapp/components/dashboard/*
- one-dashboard visual preview work

## Validation
- `npm run typecheck -- --pretty false`
- `npm test -- --run __tests__/app/connect/page-client.test.tsx __tests__/app/connect/page-client.contract.test.ts`
- `npm test -- --run __tests__/components/one-location-agent-page.test.tsx __tests__/utils/top-shell-breadcrumbs.test.ts __tests__/components/intro-step.test.tsx __tests__/components/auth-step-layout.contract.test.ts __tests__/components/navbar-agent-trigger.contract.test.ts __tests__/components/feed-actionable-row.test.tsx`
- `python -m pytest tests/test_feed_metadata_allowlist.py tests/services/test_feed_service.py tests/test_cloudbuild_step_arg_limit.py`