### PR TITLE
fix(gemini): 3.1 Pro preview maps MINIMAL thinking to LOW; probe and docs fixes for the UAT release

### DIFF
--- a/.codex/skills/puppy-one-harness/SKILL.md
+++ b/.codex/skills/puppy-one-harness/SKILL.md
@@ -38,6 +38,8 @@ Non-owned surfaces:
 1. Running the benchmark or the judge over a local model.
 2. Grading a review queue, or reviewing someone else's verdicts.
 3. Adding a model to the ladder, or reading the ledger for a trend.
+4. Grading the device's real daily jobs (the cron quality suite, see
+   `.codex/skills/puppy-one-harness/references/cron-quality-suite.md`).
 
 ## Do Not Use
 

--- a/.codex/skills/puppy-one-harness/references/cron-quality-suite.md
+++ b/.codex/skills/puppy-one-harness/references/cron-quality-suite.md
@@ -1,0 +1,76 @@
+# The cron quality suite: the daily jobs are the exam
+
+Added 2026-09-02. The owner measures the on-device model by whether its real
+scheduled jobs work, not by exam numbers. So the jobs are graded directly, in
+the Hermes fork (`hermes puppy jobs collect` and `hermes puppy jobs report`),
+under the same discipline as every other suite in the judging contract:
+blinded queue, closed rule set, planted controls, and a run that voids rather
+than publishing a number with a caveat.
+
+## Two halves, never summed
+
+**Deterministic contract checks**, read off each job's own prompt:
+
+- the exact branded header, or the `[SILENT]` token when the prompt allows
+  silence;
+- required lines (the wiki job must print "Commits in the last 36h:" and
+  "Wiki scan:");
+- required tool calls (the wiki job must really call `wiki_search` or
+  `wiki_list`) and forbidden ones (the Auto-Dream model half touches no
+  files);
+- a write counts only when its tool result reports success;
+- the artifact a job promises exists on disk (the previous month's
+  timesheet);
+- no leaked tracebacks, and phone-length brevity.
+
+**A blinded judge pass** with a closed rule set. A `wrong` verdict may cite
+only one of: `format-contract`, `no-work`, `contradicts-evidence`,
+`wrong-recipient`, `leaked-error`, `incomplete`, `hallucinated-detail`. Every
+citation is checked against the delivered text or its evidence, exactly as in
+the PKM and goal-progress suites.
+
+## Controls
+
+Cross-job swaps: one job's real output presented as another job's. It is
+structurally fine and wrong by construction, which is precisely what the
+deterministic half cannot catch. Positive controls are unmodified rows that
+passed every contract check; flagging one voids the run.
+
+## Injected facts are part of the contract
+
+When a pre-run script hands the model a number (commits in the last 36 hours,
+the wiki page count), the report must copy it exactly. The failure this suite
+exists to catch is a report that reads well and describes work that never
+happened: a run once reported "wiki_list, 236 pages" after calling only a
+prompt-listing tool twice.
+
+## Two rules learned the hard way
+
+- **Only active jobs count.** Jobs the owner disabled on purpose are excluded
+  from the frozen corpus, the replay exam and the learning loop. Grading a
+  disabled job's old sessions manufactures failures nobody asked to fix.
+- **The model thinks, the script writes.** After repeated runs in which the
+  on-device model claimed a consolidation it had not performed, and one that
+  destroyed memory files with a whole-file write, the Auto-Dream job was split
+  in two: the model answers with one JSON object, and a script snapshots the
+  memory layers and applies it. The two halves are graded separately, and the
+  brief that says what was applied is checked against what the script
+  recorded.
+
+## Who judges
+
+Never the on-device model grading its own day. The audit half runs unattended
+on the device: a silent script after the last daily job names only the runs
+that broke their contract and the queue path a judge should grade. The
+verdicts come from a separate session, and the ledger row records the probe
+mode so a day is only compared with a day asked the same question.
+
+## Where it lives
+
+The runner, contracts and tests are in the Hermes fork
+(`hermes_cli/hussh_one_routing/exam/jobs.py`, `hermes_cli/puppy_cmd.py`),
+and the jobs themselves are versioned there under `scripts/hussh-one-cron/`
+with a manifest and a sync that the daily updater runs whenever the fork
+fast-forwards. The narrative of the first three judged passes (3 of 8, then
+0 of 2, then 3 of 3 production grade in one day) is in that repository's
+`docs/hussh-one/features/on-device-model-onboarding.md`.

--- a/.codex/skills/puppy-one-harness/references/judging-contract.md
+++ b/.codex/skills/puppy-one-harness/references/judging-contract.md
@@ -216,4 +216,4 @@ On-path is progress, not arrival. A true goal-achievement probe needs a
 multi-turn rollout in a sandboxed worktree with a deterministic gate deciding
 success; until that exists, goal progress is the honest ceiling of what a
 single-action judgement can claim, and it is reported beside structural and
-agreement as a third number that is never added to either.
+agreement as a third number that is never added to either. The device's real daily jobs are graded under this same discipline; see `.codex/skills/puppy-one-harness/references/cron-quality-suite.md`.

--- a/.codex/skills/repo-operations/references/admin-release-sop.md
+++ b/.codex/skills/repo-operations/references/admin-release-sop.md
@@ -155,9 +155,9 @@ Production requires an explicit production request and an actor in
 
 - **Deploy-surface changes get their own local proof before the PR.** When `deploy/`,
   a workflow substitution string, or an agent manifest changes, run
-  `tests/test_cloudbuild_step_arg_limit.py` (the 10,000-character Cloud Build arg cap,
+  `consent-protocol/tests/test_cloudbuild_step_arg_limit.py` (the 10,000-character Cloud Build arg cap,
   per-lane after substitution) and the readiness probe's manifest collection
-  (`scripts/verify_managed_vertex_runtime.py::_managed_manifest_models` with the lane's
+  (`consent-protocol/scripts/verify_managed_vertex_runtime.py` (its manifest model collection) with the lane's
   `HUSSH_GEMINI_TEXT_MODEL`). A protocol lane that stops at mypy never reaches pytest, so
   a "clean" local run can hide a failing test; rerun the lane after the mypy fix.
 - **A lane's Gemini project is not the deploy project.** UAT deploys to `hushh-pda-uat`

--- a/.codex/skills/repo-operations/references/admin-release-sop.md
+++ b/.codex/skills/repo-operations/references/admin-release-sop.md
@@ -151,6 +151,27 @@ Production requires an explicit production request and an actor in
    remove only temporary branches created by this session, and leave the tree
    clean.
 
+### Lessons from the 2026-09-02 Wallet release
+
+- **Deploy-surface changes get their own local proof before the PR.** When `deploy/`,
+  a workflow substitution string, or an agent manifest changes, run
+  `tests/test_cloudbuild_step_arg_limit.py` (the 10,000-character Cloud Build arg cap,
+  per-lane after substitution) and the readiness probe's manifest collection
+  (`scripts/verify_managed_vertex_runtime.py::_managed_manifest_models` with the lane's
+  `HUSSH_GEMINI_TEXT_MODEL`). A protocol lane that stops at mypy never reaches pytest, so
+  a "clean" local run can hide a failing test; rerun the lane after the mypy fix.
+- **A lane's Gemini project is not the deploy project.** UAT deploys to `hushh-pda-uat`
+  but its Gemini calls go to `hushh-gemini-bridge`; a model admitted in one allowlist can
+  still be rejected by the other. Probe the lane's Gemini project directly before flipping
+  the fleet model switch for that lane.
+- **Prove a run's conclusion, never its watcher.** `gh run watch --exit-status` reported
+  exit 0 for a failed UAT deploy; read `gh run view <id> --json conclusion` and the
+  job list before acting on a result.
+- **The serving worktree never switches branches.** The founder's localhost is served
+  from `.claude/worktrees/adk-orchestration`; while it sat on a release branch, the old
+  wording came back on screen. Land from the workstream branch, fast-forward it after
+  each landing, and give scratch work its own worktree.
+
 ## Stop conditions
 
 Stop rather than improvise when the exact head changes, required checks are not

--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -446,6 +446,20 @@ class TrustedDeviceHeartbeatRequest(BaseModel):
     busy: bool | None = None
     active_sessions: int | None = Field(default=None, ge=0, le=10_000)
     next_cron_at: int | None = Field(default=None, ge=0)
+    # Machine specs and power, so the owner sees the machine their agent runs
+    # on. Every one of these is on the service allow-list; before they were
+    # declared here, Pydantic dropped them at the route boundary and the
+    # service never saw them. Names only: brand and processor describe a
+    # machine, never identify one. Ranges are enforced again by the service,
+    # which drops rather than clamps.
+    brand: str | None = Field(default=None, max_length=120)
+    processor: str | None = Field(default=None, max_length=120)
+    ram_total_gb: float | None = Field(default=None, ge=0, le=4096)
+    ram_used_pct: float | None = Field(default=None, ge=0, le=100)
+    battery_pct: float | None = Field(default=None, ge=0, le=100)
+    battery_minutes_remaining: int | None = Field(default=None, ge=0, le=100_000)
+    battery_charging: bool | None = None
+    on_ac: bool | None = None
 
 
 @router.post("/trusted-devices/{device_id}/heartbeat")

--- a/consent-protocol/hushh_mcp/runtime_providers/gemini_config.py
+++ b/consent-protocol/hushh_mcp/runtime_providers/gemini_config.py
@@ -85,6 +85,33 @@ def _sanitize_thinking_config_for_flash_v3(thinking_cfg: Any) -> Any:
     return thinking_cfg
 
 
+def _coerce_thinking_level_for_31_pro(thinking_cfg: Any) -> Any:
+    """3.1 Pro preview rejects thinking_level MINIMAL (400 INVALID_ARGUMENT, verified live
+    2026-09-02) but accepts LOW; map the one unsupported level and leave everything else."""
+    if thinking_cfg is None:
+        return None
+    if isinstance(thinking_cfg, dict):
+        level = thinking_cfg.get("thinking_level")
+        if level is not None and str(getattr(level, "value", level)).upper().endswith("MINIMAL"):
+            return {**thinking_cfg, "thinking_level": _low_thinking_level_like(level)}
+        return thinking_cfg
+    level = getattr(thinking_cfg, "thinking_level", None)
+    if level is not None and str(getattr(level, "value", level)).upper().endswith("MINIMAL"):
+        try:
+            thinking_cfg.thinking_level = _low_thinking_level_like(level)
+        except Exception:
+            return thinking_cfg
+    return thinking_cfg
+
+
+def _low_thinking_level_like(level: Any) -> Any:
+    """Return LOW in the same shape as the incoming level (enum member or string)."""
+    enum_type = type(level)
+    if hasattr(enum_type, "LOW"):
+        return enum_type.LOW
+    return "LOW"
+
+
 def generation_config_kwargs(model: str | None, **kwargs: Any) -> dict[str, Any]:
     """Return provider-compatible kwargs without changing non-3.x flash callers."""
     result = {key: value for key, value in kwargs.items() if value is not None}
@@ -100,6 +127,8 @@ def generation_config_kwargs(model: str | None, **kwargs: Any) -> dict[str, Any]
     elif is_gemini_31_pro_preview(model):
         for field in _GEMINI_31_PRO_UNSUPPORTED_FIELDS:
             result.pop(field, None)
+        if "thinking_config" in result:
+            result["thinking_config"] = _coerce_thinking_level_for_31_pro(result["thinking_config"])
     return result
 
 

--- a/consent-protocol/tests/test_fleet_text_model_switch.py
+++ b/consent-protocol/tests/test_fleet_text_model_switch.py
@@ -81,3 +81,32 @@ def test_vertex_readiness_probe_never_probes_the_alias(monkeypatch: pytest.Monke
     assert "gemini-default" not in text_models
     assert "gemini-3.8-flash" in text_models
     assert live_model == "gemini-3.1-flash-live-preview"
+
+
+def test_31_pro_preview_maps_minimal_thinking_to_low() -> None:
+    """Vertex rejects thinking_level MINIMAL for gemini-3.1-pro-preview (400, verified live
+    2026-09-02) and accepts LOW; the readiness probe sends MINIMAL for every text model."""
+    from google.genai import types
+
+    minimal = gemini_config.build_generate_content_config(
+        types,
+        "gemini-3.1-pro-preview",
+        thinking_config=types.ThinkingConfig(thinking_level=types.ThinkingLevel.MINIMAL),
+    )
+    assert minimal.thinking_config.thinking_level == types.ThinkingLevel.LOW
+    high = gemini_config.build_generate_content_config(
+        types,
+        "gemini-3.1-pro-preview",
+        thinking_config=types.ThinkingConfig(thinking_level=types.ThinkingLevel.HIGH),
+    )
+    assert high.thinking_config.thinking_level == types.ThinkingLevel.HIGH
+    as_dict = gemini_config.build_generate_content_config(
+        types, "gemini-3.1-pro-preview", thinking_config={"thinking_level": "MINIMAL"}
+    )
+    assert str(as_dict.thinking_config.thinking_level).upper().endswith("LOW")
+    flash = gemini_config.build_generate_content_config(
+        types,
+        "gemini-3.7-flash",
+        thinking_config=types.ThinkingConfig(thinking_level=types.ThinkingLevel.MINIMAL),
+    )
+    assert flash.thinking_config is None

--- a/consent-protocol/tests/test_trusted_device_heartbeat.py
+++ b/consent-protocol/tests/test_trusted_device_heartbeat.py
@@ -245,3 +245,62 @@ async def test_heartbeat_route_records_and_acknowledges(
     assert result["recorded"] is True
     assert isinstance(result["server_time_ms"], int)
     assert seen[0]["snapshot"]["current_model"] == "gemini-3.6-flash"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_route_forwards_machine_specs_and_power(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The request model must declare every field the service allow-lists.
+
+    Pydantic drops undeclared fields at the route boundary, so before these
+    were declared a device posting its brand, processor, RAM and battery had
+    them silently discarded and the service never saw them. The devices page
+    could then never show the machine the agent runs on.
+    """
+    from api.routes import account
+
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    seen: list[dict[str, Any]] = []
+
+    class _Svc:
+        def record_heartbeat(self, **kwargs: Any) -> None:
+            seen.append(kwargs)
+
+    monkeypatch.setattr(account, "TrustedDeviceService", lambda: _Svc())
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+
+    payload = account.TrustedDeviceHeartbeatRequest.model_validate(
+        {
+            "machine_id": "gw-studio",
+            "current_model": "google/gemma-4-26b-a4b-qat",
+            "brand": "Apple",
+            "processor": "Apple M4 Max",
+            "ram_total_gb": 128,
+            "ram_used_pct": 61.5,
+            "battery_pct": 88,
+            "battery_charging": True,
+            "on_ac": True,
+            "battery_minutes_remaining": 240,
+            "serial_number": "must-not-pass",
+        }
+    )
+    await account.trusted_device_heartbeat(device_id=DEVICE_ID, payload=payload, firebase_uid="u1")
+    snapshot = seen[0]["snapshot"]
+    for key in (
+        "brand",
+        "processor",
+        "ram_total_gb",
+        "ram_used_pct",
+        "battery_pct",
+        "battery_charging",
+        "on_ac",
+        "battery_minutes_remaining",
+    ):
+        assert key in snapshot, key
+    assert snapshot["brand"] == "Apple"
+    assert snapshot["ram_total_gb"] == 128
+    # Identifying fields are not declared, so they never reach the service.
+    assert "serial_number" not in snapshot

--- a/docs/reference/ai/puppy-one-on-device.md
+++ b/docs/reference/ai/puppy-one-on-device.md
@@ -1,6 +1,7 @@
 # Puppy One: the on-device tier
 
-**Status:** implemented and measured on real hardware, 2026-08-28.
+**Status:** implemented and measured on real hardware, 2026-08-28; status and
+toggle wiring audited and repaired 2026-09-02 (see the last section).
 
 ## Visual Map
 
@@ -206,3 +207,35 @@ become work items rather than N/A.
 | AG-UI translation | `hushh-webapp/app/api/hermes/chat/stream/route.ts` |
 | Model picker | `hushh-webapp/components/agent/puppy-model-picker.tsx` |
 | Heartbeat allow-list | `consent-protocol/hushh_mcp/services/trusted_device_service.py` |
+
+## Status and toggles, audited 2026-09-02
+
+Every status the owner can see and every toggle they can flip, with its source
+of truth, after an end-to-end audit of both repositories. The Hermes side is
+in the fork at
+[hushh-labs/hussh-one-hermes](https://github.com/hushh-labs/hussh-one-hermes).
+
+| Surface | Source of truth | State after the audit |
+| --- | --- | --- |
+| `/one/puppy` header dot and model name | `GET /api/hermes/status` reading the gateway's `/health/detailed` on loopback | Repaired. The gateway did not name its model in that payload and the route read a field that never existed, so a connected agent showed no model. The gateway now reports `model` and `provider` there and the route reads every shape. |
+| Model picker | `GET /api/hermes/models` reading the gateway's `/api/model/options` | Repaired. The gateway names a provider by `slug` and lists models as strings with a capabilities map; the route mapped `id` and `{id}` objects, so every provider and model rendered as an empty string. |
+| Model pin | `POST /api/hermes/models` to the gateway's `/api/model/set` | Repaired. That route existed only in the Hermes dashboard, never in the loopback API server, so every pin from One answered "could not change the model". The API server now serves it with the same expensive-model confirmation and next-session semantics. |
+| `on-device` / `any model` pill | Browser state, sent per turn as the provider pin | Now remembered per browser. It reset to on-device on every reload while the header kept the last choice. |
+| Bridge on/off | `HERMES_API_SERVER_KEY` in the webapp's server-side env, same value as `API_SERVER_KEY` in `~/.hermes/.env` | Documented in `.env.example`. It was absent from every env template, so a localhost stack rendered "not connected" with a healthy gateway beside it. |
+| Devices page liveness | `trusted_devices.last_heartbeat_at` and `heartbeat`, posted by the device to the environment it enrolled in | Working, with one consequence to know: a device enrolls in one environment (`api_base` in its identity record), so the founder's machine reports to UAT and is invisible to a localhost or dev stack. |
+| Machine specs on the heartbeat | `TrustedDeviceHeartbeatRequest` | Repaired. The request model declared six of the fourteen allow-listed fields, so brand, processor, RAM and battery were dropped before the service saw them. No surface renders them yet. |
+| On-device gate | `hussh_one.on_device_only` in the Hermes config, read by the auxiliary client and the egress audit | On for the founder's machine; readable only on the device (`hermes_cli.hussh_one_egress_audit`, the health index). Not exposed to One. |
+| Vault while the screen is locked | `hussh_one.vault.lock_with_workstation`, default off | On-device config only. The always-on agent keeps its vault while the console is locked unless the owner opts in. |
+| Daily jobs, harness, learning loop | Versioned in the fork under `scripts/hussh-one-cron/`; graded by `hermes puppy jobs`; ledger at `~/.hermes/evolution-ledger.jsonl` | On-device only. Nothing ships the health index, the doctor state, the ledger or the job audit off the machine. |
+
+Two surfaces remain dangling and are recorded rather than hidden:
+`/one/profile/preferences/device` (breadcrumb "On-device first") has no panel
+behind it, and the Capacitor `HushhAgent` plugin with its `useRemoteLLM` and
+`preferredLLMProvider` settings has no callers and no native implementation.
+Neither is reachable from a control the owner can see.
+
+What a phone could read today without new plumbing is exactly the heartbeat
+record: model, sessions, busy, version, machine specs and power, and the seal
+state. Everything else on the device (gate, doctor, ledger, job audit, every
+`hussh_one.*` toggle) needs either a new heartbeat field or the outbound
+rendezvous the live-bridge design describes.

--- a/docs/reference/ai/puppy-one-on-device.md
+++ b/docs/reference/ai/puppy-one-on-device.md
@@ -226,7 +226,7 @@ in the fork at
 | Machine specs on the heartbeat | `TrustedDeviceHeartbeatRequest` | Repaired. The request model declared six of the fourteen allow-listed fields, so brand, processor, RAM and battery were dropped before the service saw them. No surface renders them yet. |
 | On-device gate | `hussh_one.on_device_only` in the Hermes config, read by the auxiliary client and the egress audit | On for the founder's machine; readable only on the device (`hermes_cli.hussh_one_egress_audit`, the health index). Not exposed to One. |
 | Vault while the screen is locked | `hussh_one.vault.lock_with_workstation`, default off | On-device config only. The always-on agent keeps its vault while the console is locked unless the owner opts in. |
-| Daily jobs, harness, learning loop | Versioned in the fork under `scripts/hussh-one-cron/`; graded by `hermes puppy jobs`; ledger at `~/.hermes/evolution-ledger.jsonl` | On-device only. Nothing ships the health index, the doctor state, the ledger or the job audit off the machine. |
+| Daily jobs, harness, learning loop | Versioned in the Hermes fork (its scripts/hussh-one-cron directory, not this repo); graded by `hermes puppy jobs`; ledger at `~/.hermes/evolution-ledger.jsonl` | On-device only. Nothing ships the health index, the doctor state, the ledger or the job audit off the machine. |
 
 Two surfaces remain dangling and are recorded rather than hidden:
 `/one/profile/preferences/device` (breadcrumb "On-device first") has no panel

--- a/docs/reference/iam/hermes-trusted-device-vault-enrollment.md
+++ b/docs/reference/iam/hermes-trusted-device-vault-enrollment.md
@@ -260,7 +260,7 @@ disconnecting and clearing local custody first.
 only when the device pulls the PKM sync channel, so an agent that is running but
 idle reads as days stale.
 
-Migration 186 adds `last_heartbeat_at` and a `heartbeat` JSONB column, written by
+Migration 189 adds `last_heartbeat_at` and a `heartbeat` JSONB column, written by
 `POST /api/account/trusted-devices/{device_id}/heartbeat`. The endpoint is
 Firebase-authed like the own-device status read: a heartbeat grants nothing, so
 it needs no device signature.
@@ -276,17 +276,25 @@ consults these columns: trust remains decided by `status` and
 `is_trusted_device_active`.
 
 The devices surface reports `Active now` only while a heartbeat is fresher than
-eleven minutes, and otherwise falls back to the trust-only label.
+21 minutes (`HEARTBEAT_FRESH_MS` in `hushh-webapp/lib/trusted-device/sync-display.ts`,
+kept above twice the agent's 600-second keepalive so one missed beat does not
+show a live machine as gone), and otherwise falls back to the trust-only label.
+The heartbeat is posted to whichever environment the device enrolled in
+(`api_base` in the device's identity record), so a device enrolled against UAT
+shows as live on the UAT devices page and nowhere else.
 
 ## Talking To The Agent On This Machine
 
-The One agent chat carries a `One | This Mac` toggle. "This Mac" is a separate
-thread, not a mode of the cloud conversation, because it is a different agent
-with a different model and a different memory, doing its work on the user's own
-hardware; mixing those turns into one transcript would make the transcript lie
-about where each answer came from.
+Puppy One is its own surface, `/one/puppy`, not a mode of the cloud
+conversation: it is a different agent with a different model and a different
+memory, doing its work on the user's own hardware, and mixing its turns into
+the cloud transcript would make the transcript lie about where each answer
+came from. The surface carries an `on-device` / `any model` pill that pins the
+turn to the local provider, and a model picker that labels each provider as
+staying on this machine or leaving it.
 
-Requests go to `/api/hermes/status` and `/api/hermes/chat`, Next route handlers
+Requests go to `/api/hermes/status`, `/api/hermes/models` and
+`/api/hermes/chat/stream`, Next route handlers
 that run on the same machine and forward to the Hermes `api_server` on loopback
 `127.0.0.1:8642`. The `api_server` bearer key is effectively host
 remote-code-execution, so it is read server-side from `HERMES_API_SERVER_KEY`

--- a/hushh-webapp/.env.example
+++ b/hushh-webapp/.env.example
@@ -102,3 +102,8 @@ NEXT_PUBLIC_HUSHH_LOCAL_CRM_ENABLED=false
 # MAIL_API_KEY=
 # Maintainer-only overlay values such as app-review, native signing,
 # REVIEWER_UID / REVIEWER_VAULT_PASSPHRASE, and rehearsal toggles should live in an untracked overlay file.
+
+# Puppy One bridge (server-only, loopback). Same value as API_SERVER_KEY in ~/.hermes/.env on this machine.
+# Unset = the /one/puppy surface renders "not connected"; never expose to the browser.
+HERMES_API_SERVER_KEY=
+HERMES_API_SERVER_URL=http://127.0.0.1:8642

--- a/hushh-webapp/__tests__/agent/puppy-model-route.test.ts
+++ b/hushh-webapp/__tests__/agent/puppy-model-route.test.ts
@@ -64,6 +64,45 @@ describe("GET /api/hermes/models", () => {
     expect(byId).toEqual({ lmstudio: true, openai: false });
   });
 
+  it("reads the shape Hermes actually sends: slug, string models, a capabilities map", async () => {
+    process.env.HERMES_API_SERVER_KEY = "k";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          provider: "lmstudio",
+          model: "google/gemma-4-26b-a4b-qat",
+          providers: [
+            {
+              slug: "lmstudio",
+              name: "LM Studio",
+              is_current: true,
+              models: ["google/gemma-4-26b-a4b-qat", "qwen/qwen3.8-27b"],
+              capabilities: {
+                "google/gemma-4-26b-a4b-qat": { fast: false, reasoning: true },
+                "qwen/qwen3.8-27b": { fast: false, reasoning: false },
+              },
+            },
+            // Unconfigured cloud entries come back with no models at all.
+            { slug: "openrouter", name: "OpenRouter", models: [], capabilities: {} },
+          ],
+        }),
+      ),
+    );
+
+    const body = await (await GET(request("http://localhost/api/hermes/models"))).json();
+    // Before this mapping every provider and model rendered as "": the picker
+    // was the one surface that lied about the runtime.
+    expect(body.providers.map((p: { id: string }) => p.id)).toEqual(["lmstudio", "openrouter"]);
+    expect(body.providers[0].isCurrent).toBe(true);
+    expect(body.providers[0].onDevice).toBe(true);
+    expect(body.providers[0].models).toEqual([
+      { id: "google/gemma-4-26b-a4b-qat", supportsReasoning: true },
+      { id: "qwen/qwen3.8-27b", supportsReasoning: false },
+    ]);
+    expect(body.current).toEqual({ model: "google/gemma-4-26b-a4b-qat", provider: "lmstudio" });
+  });
+
   it("never forwards the loopback key to the browser", async () => {
     process.env.HERMES_API_SERVER_KEY = "super-secret-host-rce-key";
     vi.stubGlobal(

--- a/hushh-webapp/app/api/hermes/models/route.ts
+++ b/hushh-webapp/app/api/hermes/models/route.ts
@@ -80,14 +80,54 @@ export async function GET(request: NextRequest) {
   }
 
   const payload = (await upstream.json().catch(() => ({}))) as {
-    providers?: Array<{ id?: unknown; name?: unknown; models?: unknown }>;
+    providers?: Array<{
+      id?: unknown;
+      slug?: unknown;
+      name?: unknown;
+      models?: unknown;
+      capabilities?: unknown;
+      is_current?: unknown;
+      authenticated?: unknown;
+    }>;
     model?: unknown;
     provider?: unknown;
   };
 
-  const providers = (Array.isArray(payload.providers) ? payload.providers : []).map(
-    (entry) => {
-      const id = String(entry?.id ?? "");
+  // Hermes identifies a provider by `slug` and lists its models as plain
+  // strings, with per-model capabilities in a sibling map keyed by model id.
+  // An older shape used `id` and `{id}` objects. Read both: a picker that
+  // renders every provider and model as "" is the one surface that lies
+  // about the runtime, and it is exactly what the old mapping produced.
+  const providers = (Array.isArray(payload.providers) ? payload.providers : [])
+    .map((entry) => {
+      const id = String(entry?.slug ?? entry?.id ?? "");
+      const capabilities =
+        entry?.capabilities && typeof entry.capabilities === "object"
+          ? (entry.capabilities as Record<string, Record<string, unknown> | undefined>)
+          : {};
+      const models = Array.isArray(entry?.models)
+        ? (entry.models as Array<unknown>)
+            .map((model) => {
+              const modelId =
+                typeof model === "string"
+                  ? model
+                  : String((model as Record<string, unknown>)?.id ?? "");
+              const inline =
+                typeof model === "object" && model !== null
+                  ? (model as Record<string, unknown>)
+                  : {};
+              return {
+                id: modelId,
+                supportsReasoning: Boolean(
+                  (inline.capabilities as Record<string, unknown> | undefined)
+                    ?.reasoning ??
+                    inline.supports_reasoning ??
+                    capabilities[modelId]?.reasoning,
+                ),
+              };
+            })
+            .filter((model) => model.id)
+        : [];
       return {
         id,
         name: String(entry?.name ?? id),
@@ -95,18 +135,11 @@ export async function GET(request: NextRequest) {
         // providers cannot explain why they are missing; one that shows them
         // as off-machine tells the truth about what the choice costs.
         onDevice: LOCAL_PROVIDERS.has(id.toLowerCase()),
-        models: Array.isArray(entry?.models)
-          ? (entry.models as Array<Record<string, unknown>>).map((model) => ({
-              id: String(model?.id ?? ""),
-              supportsReasoning: Boolean(
-                (model?.capabilities as Record<string, unknown> | undefined)
-                  ?.reasoning ?? model?.supports_reasoning,
-              ),
-            }))
-          : [],
+        isCurrent: Boolean(entry?.is_current),
+        models,
       };
-    },
-  );
+    })
+    .filter((provider) => provider.id);
 
   return Response.json({
     configured: true,

--- a/hushh-webapp/app/api/hermes/status/route.ts
+++ b/hushh-webapp/app/api/hermes/status/route.ts
@@ -49,11 +49,21 @@ export async function GET(request: NextRequest) {
       );
     }
     const payload = await response.json().catch(() => ({}));
+    // The gateway reports its configured model at the top level (`model`,
+    // `provider`); readiness only carries a status per check. Older builds
+    // nested the name under readiness. Read every shape rather than showing a
+    // connected agent with no model, which is what the header did before.
+    const model =
+      payload?.model ||
+      payload?.readiness?.model?.configured_model ||
+      payload?.readiness?.checks?.model?.configured_model ||
+      null;
     return withRequestIdJson(
       requestId,
       {
         connected: true,
-        model: payload?.readiness?.model?.configured_model || payload?.model || null,
+        model,
+        provider: payload?.provider ?? null,
         busy: Boolean(payload?.gateway_busy),
         activeAgents: payload?.active_agents ?? null,
         version: payload?.version ?? null,

--- a/hushh-webapp/components/agent/hermes-chat-panel.tsx
+++ b/hushh-webapp/components/agent/hermes-chat-panel.tsx
@@ -12,6 +12,9 @@ import {
 import { fetchPuppyStatus, type PuppyStatus } from "@/lib/services/puppy-one-service";
 import { cn } from "@/lib/utils";
 
+/** Per-viewer browser preference for the on-device pill ("1" or "0"). */
+const ON_DEVICE_STORAGE_KEY = "hussh.puppy.on_device";
+
 /**
  * Chat with Puppy One, the agent running on the owner's own machine.
  *
@@ -37,7 +40,31 @@ export function HermesChatPanel({ className }: { className?: string }) {
   const [turns, setTurns] = useState<PuppyTurn[]>([]);
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
-  const [onDevice, setOnDevice] = useState(true);
+  // The on-device pill is a per-viewer preference, so it survives a reload:
+  // a toggle that silently reset to "on-device" on every mount told the user
+  // one thing and sent the turn somewhere else. Storage can be unavailable
+  // (private window, blocked site data), so every access is guarded and the
+  // default stays on-device.
+  const [onDevice, setOnDeviceState] = useState(true);
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(ON_DEVICE_STORAGE_KEY);
+      if (stored === "0") setOnDeviceState(false);
+    } catch {
+      /* storage unavailable: keep the on-device default */
+    }
+  }, []);
+  const setOnDevice = useCallback((update: boolean | ((value: boolean) => boolean)) => {
+    setOnDeviceState((value) => {
+      const next = typeof update === "function" ? update(value) : update;
+      try {
+        window.localStorage.setItem(ON_DEVICE_STORAGE_KEY, next ? "1" : "0");
+      } catch {
+        /* storage unavailable: the choice still applies to this session */
+      }
+      return next;
+    });
+  }, []);
   const [error, setError] = useState("");
   const sessionRef = useRef<string>("");
   const endRef = useRef<HTMLDivElement | null>(null);
@@ -80,7 +107,7 @@ export function HermesChatPanel({ className }: { className?: string }) {
         },
       ]);
     },
-    [],
+    [setOnDevice],
   );
 
   const appendDelta = useCallback((assistantId: string, delta: string) => {


### PR DESCRIPTION
## Summary

Second UAT redeploy (run 33679466015, SHA 4321411b6) failed at the managed Vertex readiness probe: `gemini-3.1-pro-preview` rejects `thinking_level MINIMAL` (400 INVALID_ARGUMENT, reproduced live in `hushh-gemini-bridge`; LOW and no thinking config both return 200). The memory chain's 3.1 Pro preview pin arrived with #6388, so the probe had never exercised that model before; the runtime memory path already uses LOW for it, only the probe sends MINIMAL for every text model.

- **Model contract:** `generation_config_kwargs` maps `thinking_level MINIMAL` to `LOW` for `gemini-3.1-pro-preview` (enum, object, and dict forms); every other level passes through. Guard: `test_31_pro_preview_maps_minimal_thinking_to_low`.
- **Governance:** `docs/reference/ai/puppy-one-on-device.md` referenced `scripts/hussh-one-cron/`, a directory that lives in the Hermes fork rather than this repo, so the docs path lint turned the Governance job red. Reworded to name the fork without a backticked repo path.
- **Admin release SOP:** a short lessons block (deploy-surface local proof, a lane's Gemini project is not its deploy project, prove a run's conclusion rather than its watcher, the serving worktree never switches branches).
- **Also carried (shared branch):** commit cc86efb9a "fix(puppy): the status and toggles on /one/puppy read what the Hermes gateway actually sends" was committed to `feat/adk-orchestration-runtime` by the parallel Puppy One session (12 files: Hermes model/status routes, chat panel, tests, docs). Signed off, included here because the branch is shared; called out so the review covers it.

## Verification

- `scripts/ci/orchestrate.sh protocol` (1868 passed) and `governance` locally; `./bin/hushh docs verify` passes.
- Live: `gemini-3.1-pro-preview` in `hushh-gemini-bridge` with `thinkingLevel: LOW` returns 200; MINIMAL returns the 400 the probe hit.

Tracked on the Hussh Action Items board (#6412).