### PR TITLE
RIA: fix the Clients roster verification gate (dead-end CTA + off-brand yellow)

### DIFF
--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -1091,6 +1091,36 @@ describe("RiaOnboardingPage", () => {
     });
   });
 
+  it("keeps a draft/submitted/rejected advisor in the wizard instead of bouncing to profile", async () => {
+    // Regression: `exists: true` alone used to count as "established" and
+    // send the advisor straight to /ria/profile, even mid-verification. The
+    // Clients page's own gate still blocked them (not verified), so the
+    // "Complete verification" CTA became a dead end -- profile had nothing
+    // for them to finish. Only an actually-verified status may redirect.
+    for (const status of ["draft", "submitted", "rejected"]) {
+      mocks.routerReplace.mockClear();
+      mocks.usePersonaState.mockReturnValue({
+        refresh: mocks.refreshPersonaState,
+        riaCapability: "setup",
+        loading: false,
+        refreshing: false,
+        riaOnboardingStatus: {
+          exists: true,
+          advisory_status: status,
+          verification_status: status,
+        },
+      });
+
+      const { unmount } = render(<RiaOnboardingPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("onboarding-shell")).toBeTruthy();
+      });
+      expect(mocks.routerReplace).not.toHaveBeenCalledWith("/ria/profile");
+      unmount();
+    }
+  });
+
   it("keeps a switch advisor in the wizard when re-verifying via ?edit=license", async () => {
     mocks.useSearchParams.mockReturnValue(new URLSearchParams("edit=license"));
     mocks.usePersonaState.mockReturnValue({

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -157,7 +157,13 @@ function resolveRiaSubmitErrorMessage(
 }
 
 function isAdvisoryAccessReady(status?: string | null): boolean {
-  return status === "active" || status === "verified";
+  return status === "active" || status === "verified" || status === "finra_verified";
+}
+
+function isEstablishedAdvisor(
+  status: Pick<RiaOnboardingStatus, "advisory_status" | "verification_status"> | null | undefined,
+): boolean {
+  return isAdvisoryAccessReady(status?.advisory_status || status?.verification_status);
 }
 
 function shouldRepairVerifiedPrefill(draft: RiaOnboardingDraft): boolean {
@@ -263,7 +269,7 @@ export default function RiaOnboardingPage({
       if (hasEditIntent || setupMode || setupOrigin) return "wizard";
       if (
         riaCapability === "switch" ||
-        personaRiaOnboardingStatus?.exists === true
+        isEstablishedAdvisor(personaRiaOnboardingStatus)
       ) {
         return "established";
       }
@@ -465,7 +471,7 @@ export default function RiaOnboardingPage({
     }
     if (
       riaCapability === "switch" ||
-      personaRiaOnboardingStatus?.exists === true
+      isEstablishedAdvisor(personaRiaOnboardingStatus)
     ) {
       setEntryMode("established");
       return;

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -282,12 +282,12 @@ export function RiaVerificationGate({ children }: { children: ReactNode }) {
     return (
       <div className="mx-auto my-12 flex w-full max-w-xl flex-col items-center px-4 text-center sm:px-6">
         {/* Header Icon */}
-        <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-amber-500/30 bg-amber-500/15 text-amber-400">
+        <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-[color:var(--app-accent-border)] bg-[color:var(--app-accent-tint)] text-[color:var(--ria-gold,var(--app-accent))]">
           <ShieldAlert className="h-7 w-7" />
         </div>
 
         {/* Eyebrow */}
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--ria-gold,#d97706)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--ria-gold,var(--app-accent))]">
           {RIA_COPY.clients.verifyGate.eyebrow}
         </p>
 
@@ -308,7 +308,7 @@ export function RiaVerificationGate({ children }: { children: ReactNode }) {
 
         {/* Action CTA Button */}
         <Button
-          className="mt-6 h-11 rounded-full bg-[color:var(--ria-gold,#d97706)] px-8 text-sm font-semibold text-slate-950 shadow-lg shadow-amber-500/25 hover:bg-amber-400 active:scale-[0.98] transition-all cursor-pointer"
+          className="mt-6 h-11 rounded-full bg-[color:var(--ria-gold,var(--app-accent))] px-8 text-sm font-semibold text-[color:var(--app-accent-fg)] shadow-lg hover:bg-[color:var(--app-accent-hover)] active:scale-[0.98] transition-all cursor-pointer"
           onClick={() => router.push(ROUTES.RIA_ONBOARDING)}
           data-testid="ria-clients-verify-gate-cta"
         >


### PR DESCRIPTION
## Summary

Closes #6291. From a screenshot of the Clients roster's "Verification Required" gate: the CTA doesn't do what it says, and the whole gate is rendered in a yellow that doesn't exist anywhere else in the app.

## Bug 1: dead-end CTA

Clicking "Complete verification" landed on `/ria/profile` with nothing to do there -- not the onboarding wizard the button's own copy promises ("Finish verification in onboarding").

Root cause: the onboarding page's entry-mode gate decided "established advisor, redirect to profile" from `personaRiaOnboardingStatus?.exists === true` -- but an onboarding record *exists* the moment someone starts (draft/submitted/rejected all have `exists: true`), long before they're actually verified. The Clients page's own gate (`isRiaVerified`) correctly keeps blocking them since they're not verified -- so the two disagreed, and the CTA became a loop with no way out.

Fix: added `isEstablishedAdvisor()`, gated on the real status (`active` / `verified` / `finra_verified`, matching `isRiaVerified`'s set), and used it in place of the bare existence check in both the entry-mode `useState` initializer and its `useEffect`.

## Bug 2: off-brand yellow

The gate hardcoded literal Tailwind `amber-*` classes for the icon badge, eyebrow, and -- most visibly, since it's what triggered the report -- the button's `hover:bg-amber-400`, instead of the app's `--ria-gold`/`--app-accent` tokens the rest of the file already uses. Swapped every hardcoded amber class for the token-based equivalents already defined for this exact purpose (`--app-accent-tint`, `--app-accent-border`, `--app-accent-hover`, `--app-accent-fg`), so the gate now follows the app's actual accent (including the user's chosen accent preference) instead of always rendering gold.

## Test plan

- [x] Added a regression test: draft/submitted/rejected advisors stay in the wizard rather than bouncing to profile
- [x] `npx vitest run __tests__/app/ria/onboarding-page.test.tsx __tests__/components/ria/ria-verification-gate.test.tsx __tests__/components/ria/ria-profile-redirect-loop.test.tsx` -- 33 passed
- [x] `npx vitest run __tests__/app/ria __tests__/components/ria` (full RIA suite) -- 174 passed
- [x] `tsc --noEmit` / `eslint` on touched files -- clean