### PR TITLE
refactor(models): remove the model knobs that never chose anything

### DIFF
--- a/consent-protocol/.env.example
+++ b/consent-protocol/.env.example
@@ -231,7 +231,6 @@ KAI_GMAIL_RECEIPTS_DAILY_SYNC_HOURS=24
 KAI_GMAIL_RECEIPTS_MAX_MESSAGES_PER_SYNC=300
 GMAIL_RECEIPT_HTTP_TIMEOUT_SECONDS=25
 GMAIL_RECEIPT_LLM_FALLBACK_ENABLED=false
-GMAIL_RECEIPT_LLM_MODEL=gemini-2.5-flash-lite
 
 # One mailbox KYC intake (hosted lane; optional for local development)
 # Keep service-account JSON blank unless a dedicated One mailbox credential is

--- a/consent-protocol/api/routes/kai/portfolio.py
+++ b/consent-protocol/api/routes/kai/portfolio.py
@@ -23,7 +23,6 @@ import io
 import json
 import logging
 import math
-import os
 import re
 import time
 from collections import Counter
@@ -56,11 +55,11 @@ from api.routes.kai.import_run_manager import (
     PortfolioImportRunRecord,
 )
 from hushh_mcp.constants import (
+    GEMINI_MODEL,
     KAI_LLM_TEMPERATURE,
     KAI_LLM_THINKING_ENABLED,
     KAI_PORTFOLIO_IMPORT_ENABLE_THINKING,
     KAI_PORTFOLIO_IMPORT_MAX_OUTPUT_TOKENS,
-    KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL,
     KAI_PORTFOLIO_IMPORT_THINKING_LEVEL,
 )
 from hushh_mcp.kai_import import (
@@ -139,12 +138,12 @@ _HOLDING_KEY_HINTS = frozenset(
 
 
 def _resolve_portfolio_import_model() -> str:
-    """Resolve operator override while keeping the documented Flash default."""
-    for key in ("KAI_PORTFOLIO_IMPORT_MODEL", "KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL"):
-        candidate = os.getenv(key, "").strip()
-        if candidate:
-            return candidate
-    return KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL
+    """Portfolio import runs the fleet text model, like every other text agent.
+
+    It used to consult two environment keys that no lane set, in front of a constant
+    that was already equal to the fleet model: three names for one answer.
+    """
+    return GEMINI_MODEL
 
 
 _POSITIONS_PAGE_KEYWORDS = (

--- a/consent-protocol/hushh_mcp/constants.py
+++ b/consent-protocol/hushh_mcp/constants.py
@@ -387,13 +387,11 @@ def fleet_text_model_from_env(environ: "Mapping[str, str] | None" = None) -> str
 
 GEMINI_MODEL = fleet_text_model_from_env()
 
-# Vertex AI model (for Google Cloud deployments)
-GEMINI_MODEL_VERTEX = GEMINI_MODEL
 
 # ==================== Kai Portfolio Import Defaults ====================
 
-# Portfolio import extraction is prompt-first and optimized for lower latency.
-KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL = GEMINI_MODEL
+# Portfolio import extraction is prompt-first and optimized for lower latency. The
+# model itself is the fleet model; only these sampling settings are import-specific.
 KAI_PORTFOLIO_IMPORT_ENABLE_THINKING = True
 KAI_PORTFOLIO_IMPORT_THINKING_LEVEL = "LOW"
 KAI_PORTFOLIO_IMPORT_MAX_OUTPUT_TOKENS = 32768
@@ -430,8 +428,6 @@ __all__ = [
     "DEFAULT_CONSENT_TOKEN_EXPIRY_MS",
     "DEFAULT_TRUST_LINK_EXPIRY_MS",
     "GEMINI_MODEL",
-    "GEMINI_MODEL_VERTEX",
-    "KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL",
     "KAI_PORTFOLIO_IMPORT_ENABLE_THINKING",
     "KAI_PORTFOLIO_IMPORT_THINKING_LEVEL",
     "KAI_PORTFOLIO_IMPORT_MAX_OUTPUT_TOKENS",

--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -210,10 +210,9 @@ ONE_LIVE_VOICE_OPTIONS: dict[str, str] = {
 # send_client_content behavior. A BYOK key must never silently fall back to
 # Hussh's managed Vertex identity.
 _BYOK_LIVE_MODEL = (os.getenv("HUSHH_GEMINI_BYOK_LIVE_MODEL") or "").strip()
-# All worker agents resolve the same authored Gemini text generation.
-_SPECIALIST_MODEL = (
-    os.getenv("AGENT_ONE_SPECIALIST_MODEL") or _KAI_MANIFEST.model_config_for_runtime().name
-).strip()
+# All worker agents resolve the same authored Gemini text generation, through the
+# manifest alias rather than a private environment knob no lane ever set.
+_SPECIALIST_MODEL = _KAI_MANIFEST.model_config_for_runtime().name.strip()
 
 
 # The Live compatibility registry lives in runtime_providers so the deploy

--- a/consent-protocol/hushh_mcp/services/gmail_receipts_service.py
+++ b/consent-protocol/hushh_mcp/services/gmail_receipts_service.py
@@ -875,7 +875,7 @@ class GmailReceiptsService:
         return _to_bool(os.getenv("GMAIL_RECEIPT_LLM_FALLBACK_ENABLED"), False)
 
     def _llm_model(self) -> str:
-        return _clean_text(os.getenv("GMAIL_RECEIPT_LLM_MODEL"), str(GEMINI_MODEL))
+        return str(GEMINI_MODEL)
 
     def _build_state_token(self, *, user_id: str, redirect_uri: str) -> str:
         payload = {

--- a/consent-protocol/hushh_mcp/services/portfolio_import_service.py
+++ b/consent-protocol/hushh_mcp/services/portfolio_import_service.py
@@ -2094,7 +2094,7 @@ Statement text (first 12000 chars):
 
         from google.genai import types
 
-        from hushh_mcp.constants import GEMINI_MODEL_VERTEX
+        from hushh_mcp.constants import GEMINI_MODEL
 
         portfolio = ComprehensivePortfolio()
 
@@ -2104,7 +2104,7 @@ Statement text (first 12000 chars):
         except Exception as exc:
             logger.error("Vertex AI init failed: %s", type(exc).__name__)
             raise ValueError("Could not initialize managed Gemini client") from exc
-        model_to_use = GEMINI_MODEL_VERTEX
+        model_to_use = GEMINI_MODEL
 
         # Encode PDF as base64
         pdf_base64 = base64.b64encode(pdf_bytes).decode("utf-8")

--- a/consent-protocol/hushh_mcp/services/receipt_memory_service.py
+++ b/consent-protocol/hushh_mcp/services/receipt_memory_service.py
@@ -710,7 +710,7 @@ class ReceiptMemoryEnrichmentService:
         return raw not in {"0", "false", "off", "disabled", "no"}
 
     def _model(self) -> str:
-        return _clean_text(os.getenv("KAI_RECEIPT_MEMORY_LLM_MODEL"), str(GEMINI_MODEL))
+        return str(GEMINI_MODEL)
 
     def _timeout_seconds(self) -> float:
         raw = _clean_text(os.getenv("KAI_RECEIPT_MEMORY_LLM_TIMEOUT_SECONDS"), "8")

--- a/consent-protocol/tests/test_fleet_text_model_switch.py
+++ b/consent-protocol/tests/test_fleet_text_model_switch.py
@@ -39,8 +39,10 @@ def test_switch_moves_the_fleet_default() -> None:
     assert fleet_text_model_from_env({}) == FLEET_TEXT_MODEL_DEFAULT
     assert fleet_text_model_from_env({"HUSSH_GEMINI_TEXT_MODEL": "   "}) == FLEET_TEXT_MODEL_DEFAULT
     assert GEMINI_MODEL == fleet_text_model_from_env()
-    assert constants.GEMINI_MODEL_VERTEX == GEMINI_MODEL
-    assert constants.KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL == GEMINI_MODEL
+    # There is exactly one name for the fleet text model. GEMINI_MODEL_VERTEX and
+    # KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL were aliases of this value and are gone.
+    assert not hasattr(constants, "GEMINI_MODEL_VERTEX")
+    assert not hasattr(constants, "KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL")
 
 
 def test_alias_resolves_to_the_switched_model(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/consent-protocol/tests/test_kai_stream_contract.py
+++ b/consent-protocol/tests/test_kai_stream_contract.py
@@ -162,13 +162,17 @@ def test_portfolio_statement_import_compat_stream_does_not_use_multipart_request
     assert "request=_AlwaysConnectedImportStreamRequest()" in portfolio_source
 
 
-def test_portfolio_import_defaults_to_gemini_37_flash_with_env_override():
-    constants_source = (_ROOT / "hushh_mcp/constants.py").read_text(encoding="utf-8")
+def test_portfolio_import_runs_the_fleet_model_with_no_private_knob():
+    """Portfolio import has no model of its own.
+
+    It used to consult KAI_PORTFOLIO_IMPORT_MODEL and KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL,
+    neither of which any lane set, in front of a constant already equal to the fleet
+    model. One answer, one name.
+    """
     portfolio_source = (_ROOT / "api/routes/kai/portfolio.py").read_text(encoding="utf-8")
 
-    assert "KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL = GEMINI_MODEL" in constants_source
-    assert '"KAI_PORTFOLIO_IMPORT_MODEL"' in portfolio_source
-    assert '"KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL"' in portfolio_source
+    assert "KAI_PORTFOLIO_IMPORT_MODEL" not in portfolio_source
+    assert "return GEMINI_MODEL" in portfolio_source
     assert "extraction_model = _resolve_portfolio_import_model()" in portfolio_source
 
 

--- a/docs/reference/one/gemini-runtime-configuration.md
+++ b/docs/reference/one/gemini-runtime-configuration.md
@@ -41,6 +41,25 @@ allowlist changes. Every text agent, including the memory chain and the summary 
 case, and never `gemini-3.1-pro-preview`). Only the Live head keeps an explicit pin.
 `tests/test_fleet_text_model_switch.py` refuses any manifest that pins a Flash generation.
 
+### Knobs removed as valueless (2026-09-02)
+
+There is one name for the fleet text model and one way to override it. These were
+removed because each was either an alias of `GEMINI_MODEL` or an environment key no
+lane set, and every one of them implied a choice that did not exist:
+
+| Removed | Why |
+|---|---|
+| `GEMINI_MODEL_VERTEX` | Always equal to `GEMINI_MODEL`; the name implied a separate Vertex model. |
+| `KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL` | Same value again, under a third name. |
+| `KAI_PORTFOLIO_IMPORT_MODEL` (env) | Read by the portfolio route, set by no lane. |
+| `AGENT_ONE_SPECIALIST_MODEL` (env) | Set by no lane, and it froze the specialist model at import. |
+| `GMAIL_RECEIPT_LLM_MODEL` (env) | Pinned `gemini-2.5-flash-lite` in the local env, quietly outside the Flash-only rule. |
+| `KAI_RECEIPT_MEMORY_LLM_MODEL` (env) | Read by the receipt memory service, set by no lane. |
+
+Removing them is behaviour-preserving in every deployed lane, because no lane set any of
+them. Locally, Gmail receipt extraction moves off the pinned 2.5 generation and onto the
+fleet model like everything else.
+
 ### Who chooses the model (2026-09-02)
 
 The environment names a default, never the only possibility. A turn resolves its model


### PR DESCRIPTION
## Why

Follow-on to #6426. Six names implied a model choice that did not exist. Each was either an alias of `GEMINI_MODEL` or an environment key **no lane sets**, so each was a place a reader could reasonably look for the answer and find a decoy.

| Removed | What it actually was |
|---|---|
| `GEMINI_MODEL_VERTEX` | Always equal to `GEMINI_MODEL`; the name implied Vertex ran something else. |
| `KAI_PORTFOLIO_IMPORT_PRIMARY_MODEL` | The same value under a third name. |
| `KAI_PORTFOLIO_IMPORT_MODEL` (env) | Read by the portfolio route, set by no lane. |
| `AGENT_ONE_SPECIALIST_MODEL` (env) | Set by no lane, and it froze the specialist model at import. |
| `GMAIL_RECEIPT_LLM_MODEL` (env) | Pinned `gemini-2.5-flash-lite` in the local env, quietly outside the Flash-only rule. |
| `KAI_RECEIPT_MEMORY_LLM_MODEL` (env) | Read by the receipt memory service, set by no lane. |

Verified before removal: each name was grepped across `hushh_mcp`, `api`, `db`, `deploy/`, `.github/workflows/`, `.env`, and `.env.example`. Five other candidates my first scan flagged (`APP_REVIEW_MODE`, `HUSHH_PROD_PHONE_TEST_ENABLED`, `HUSSH_GEMINI_TEXT_MODEL`, `ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED`, `ONE_EMAIL_WEBHOOK_AUTH_ENABLED`) turned out to be read through indirect patterns and were **kept**.

## Behaviour

Unchanged in every deployed lane, because no lane set any of them. Locally, Gmail receipt extraction moves off the pinned 2.5 generation and onto the fleet model like everything else. **This is a small cost change on that path** (2.5 Flash Lite to the fleet Flash model); if receipts were deliberately on a cheaper model, say so and I will give that path an explicit, documented pin rather than a silent one.

Also removed: the old `payment_cards` era names appear only in `docs/reference/one/wallet.md`, which is the before/after naming map and their correct home, so nothing was removed there.

## Verification

`scripts/ci/orchestrate.sh protocol` (1868 passed, mypy clean over 115 source files) and `governance` green locally; `./bin/hushh docs verify` passes. The two tests that asserted the aliases now assert their **absence**, so they cannot quietly return.

Tracked on the Hussh Action Items board (#6412).