### PR TITLE
Kai: wire voice navigation for portfolio detail screens + news

### DIFF
--- a/consent-protocol/contracts/kai/kai-action-gateway.vnext.json
+++ b/consent-protocol/contracts/kai/kai-action-gateway.vnext.json
@@ -38,6 +38,8 @@
     "hushh-webapp/components/consent/consent-center-page.voice-action-contract.json",
     "hushh-webapp/components/kai/analysis-controls.voice-action-contract.json",
     "hushh-webapp/components/kai/kai-command-bar-global.voice-action-contract.json",
+    "hushh-webapp/components/kai/kai-market-news-page.voice-action-contract.json",
+    "hushh-webapp/components/kai/kai-portfolio-detail-page.voice-action-contract.json",
     "hushh-webapp/components/kai/views/dashboard-master-view.voice-action-contract.json",
     "hushh-webapp/components/kai/views/kai-market-preview-view.voice-action-contract.json",
     "hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json",
@@ -947,6 +949,50 @@
           "active_personas": [
             "investor",
             "ria"
+          ]
+        }
+      },
+      "orchestration": {
+        "instruction_id": null,
+        "context_policy": null,
+        "trust_boundary": null,
+        "delegation_policy": null
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "kai_news",
+      "surface_title": "Kai Market News",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md"
+      ],
+      "contract_file": "hushh-webapp/components/kai/kai-market-news-page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor"
+          ]
+        }
+      },
+      "orchestration": {
+        "instruction_id": null,
+        "context_policy": null,
+        "trust_boundary": null,
+        "delegation_policy": null
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "kai_portfolio_detail",
+      "surface_title": "Kai Portfolio Detail",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md"
+      ],
+      "contract_file": "hushh-webapp/components/kai/kai-portfolio-detail-page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor"
           ]
         }
       },
@@ -21256,20 +21302,527 @@
       }
     },
     {
+      "action_id": "route.kai_news",
+      "surface_id": "kai_news",
+      "label": "Open Market News",
+      "aliases": [
+        "open market news",
+        "show market news",
+        "show news"
+      ],
+      "search_keywords": [
+        "news",
+        "market news"
+      ],
+      "meaning": "Navigates to the market news feed.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/news"
+        ],
+        "screens": [
+          "kai_news"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Market route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/news"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-market-news-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/news"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_news",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_news",
+            "label": "Open Market News",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/news",
+              "screen": "kai_news"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "route.kai_portfolio_holdings",
+      "surface_id": "kai_portfolio_detail",
+      "label": "Show Holdings",
+      "aliases": [
+        "show my holdings",
+        "show holdings",
+        "open holdings"
+      ],
+      "search_keywords": [
+        "holdings",
+        "positions",
+        "portfolio"
+      ],
+      "meaning": "Navigates to the portfolio holdings breakdown -- every position held, not the general portfolio dashboard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/holdings"
+        ],
+        "screens": [
+          "kai_portfolio_holdings"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/holdings"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/portfolio/holdings"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_portfolio_holdings",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_portfolio_holdings",
+            "label": "Show Holdings",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/portfolio/holdings",
+              "screen": "kai_portfolio_holdings"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "route.kai_portfolio_allocation",
+      "surface_id": "kai_portfolio_detail",
+      "label": "Show Allocation",
+      "aliases": [
+        "show my allocation",
+        "show allocation",
+        "open allocation"
+      ],
+      "search_keywords": [
+        "allocation",
+        "portfolio"
+      ],
+      "meaning": "Navigates to the portfolio allocation breakdown.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/allocation"
+        ],
+        "screens": [
+          "kai_portfolio_allocation"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/allocation"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/portfolio/allocation"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_portfolio_allocation",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_portfolio_allocation",
+            "label": "Show Allocation",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/portfolio/allocation",
+              "screen": "kai_portfolio_allocation"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "route.kai_portfolio_performance",
+      "surface_id": "kai_portfolio_detail",
+      "label": "Show Performance",
+      "aliases": [
+        "show my performance",
+        "show performance",
+        "open performance"
+      ],
+      "search_keywords": [
+        "performance",
+        "returns",
+        "portfolio"
+      ],
+      "meaning": "Navigates to the portfolio performance breakdown.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/performance"
+        ],
+        "screens": [
+          "kai_portfolio_performance"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/performance"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/portfolio/performance"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_portfolio_performance",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_portfolio_performance",
+            "label": "Show Performance",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/portfolio/performance",
+              "screen": "kai_portfolio_performance"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "route.kai_portfolio_sources",
+      "surface_id": "kai_portfolio_detail",
+      "label": "Show Connected Sources",
+      "aliases": [
+        "show my sources",
+        "show connected sources",
+        "open sources"
+      ],
+      "search_keywords": [
+        "sources",
+        "connected accounts",
+        "portfolio"
+      ],
+      "meaning": "Navigates to the portfolio's connected data sources.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/sources"
+        ],
+        "screens": [
+          "kai_portfolio_sources"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/sources"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/portfolio/sources"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_portfolio_sources",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_portfolio_sources",
+            "label": "Show Connected Sources",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/portfolio/sources",
+              "screen": "kai_portfolio_sources"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
       "action_id": "route.kai_dashboard",
       "surface_id": "kai_portfolio_dashboard",
       "label": "Open Portfolio Dashboard",
       "aliases": [
         "open portfolio dashboard",
         "open portfolio",
-        "go to holdings"
+        "show my portfolio"
       ],
       "search_keywords": [
         "portfolio",
-        "dashboard",
-        "holdings"
+        "dashboard"
       ],
-      "meaning": "Navigates to portfolio dashboard for source/holdings context.",
+      "meaning": "Navigates to portfolio dashboard, the overview above holdings/allocation/performance/sources.",
       "speaker_persona": "kai",
       "delegate_agent_id": null,
       "reachability": {

--- a/consent-protocol/contracts/kai/one-route-orchestration-index.v1.json
+++ b/consent-protocol/contracts/kai/one-route-orchestration-index.v1.json
@@ -2401,7 +2401,7 @@
       "route_pattern": "/one/kai/news",
       "page_file": "app/one/kai/news/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.news",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2431,8 +2431,10 @@
       },
       "canonical_screen": "kai_market_news",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_news"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -2616,7 +2618,7 @@
       "route_pattern": "/one/kai/portfolio/allocation",
       "page_file": "app/one/kai/portfolio/allocation/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio.allocation",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2646,8 +2648,10 @@
       },
       "canonical_screen": "kai_portfolio_allocation",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_portfolio_allocation"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -2659,7 +2663,7 @@
       "route_pattern": "/one/kai/portfolio/holdings",
       "page_file": "app/one/kai/portfolio/holdings/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio.holdings",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2689,8 +2693,10 @@
       },
       "canonical_screen": "kai_portfolio_holdings",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_portfolio_holdings"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -2702,7 +2708,7 @@
       "route_pattern": "/one/kai/portfolio/performance",
       "page_file": "app/one/kai/portfolio/performance/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio.performance",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2732,8 +2738,10 @@
       },
       "canonical_screen": "kai_portfolio_performance",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_portfolio_performance"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -2745,7 +2753,7 @@
       "route_pattern": "/one/kai/portfolio/sources",
       "page_file": "app/one/kai/portfolio/sources/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio.sources",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2775,8 +2783,10 @@
       },
       "canonical_screen": "kai_portfolio_sources",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_portfolio_sources"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -2866,7 +2866,9 @@
       "route_mode": "standard",
       "semantic_routes": [],
       "voice": {
-        "action_ids": [],
+        "action_ids": [
+          "route.kai_news"
+        ],
         "delegate_agent_ids": [],
         "playbook_id": "route.one.kai.news"
       }
@@ -2985,7 +2987,9 @@
       "route_mode": "standard",
       "semantic_routes": [],
       "voice": {
-        "action_ids": [],
+        "action_ids": [
+          "route.kai_portfolio_allocation"
+        ],
         "delegate_agent_ids": [],
         "playbook_id": "route.one.kai.portfolio.allocation"
       }
@@ -3009,7 +3013,9 @@
       "route_mode": "standard",
       "semantic_routes": [],
       "voice": {
-        "action_ids": [],
+        "action_ids": [
+          "route.kai_portfolio_holdings"
+        ],
         "delegate_agent_ids": [],
         "playbook_id": "route.one.kai.portfolio.holdings"
       }
@@ -3033,7 +3039,9 @@
       "route_mode": "standard",
       "semantic_routes": [],
       "voice": {
-        "action_ids": [],
+        "action_ids": [
+          "route.kai_portfolio_performance"
+        ],
         "delegate_agent_ids": [],
         "playbook_id": "route.one.kai.portfolio.performance"
       }
@@ -3057,7 +3065,9 @@
       "route_mode": "standard",
       "semantic_routes": [],
       "voice": {
-        "action_ids": [],
+        "action_ids": [
+          "route.kai_portfolio_sources"
+        ],
         "delegate_agent_ids": [],
         "playbook_id": "route.one.kai.portfolio.sources"
       }
@@ -5464,13 +5474,13 @@
   "schema_version": "hushh.runtime_topology_index.v1",
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
-    "action_gateway": "184d7f92be53c724c9d0295275134c0d06f39d20107de1b2c57cb48c14c3cdf2",
+    "action_gateway": "2e2739dbeb59933b3695634d50d1cfdd0071c1feadf8328d0a7ee00745fe9b32",
     "agent_registry": "287f0c25daedf444e9211e88fc1dd5f07f72d4ff7aeb5e1321d6e5ed836607db",
     "cache_manifest": "c7a177decdb319d8a8b673ae16f6acdad5aedee5fc98329d2d58470e1726b4e8",
     "data_plane": "76399599594d347d840307b338dd681728ecaa9583990e32275f6199d3ce2290",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "057058e172a5de1d044caf02d9cbd6fcf55f2639c910e16b39d9b8d89ded0458",
-    "route_index": "6c3d3e817278bb59041defda781f265c4bc8edfdabefbdaeed795f41d65e1daf",
+    "route_index": "e6408b8d2cc074a7ea1c5ae916ffee357ce41d8007d4631002bb46c87e460399",
     "route_layout": "b66933c7083fd755f1a8e4a16262996fc7ae6124a4c550725bfdc7144332355f",
     "surface_map": "dca7d7fc80136e013091555d1c5c39884da5d98898f44274423c5eab490d0cd3",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
@@ -5478,7 +5488,7 @@
   },
   "summary": {
     "a2a_scope_gated_agents": 5,
-    "actions": 206,
+    "actions": 211,
     "agents": 20,
     "aliases": 3,
     "decision_required": 2,

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -38,6 +38,8 @@
     "hushh-webapp/components/consent/consent-center-page.voice-action-contract.json",
     "hushh-webapp/components/kai/analysis-controls.voice-action-contract.json",
     "hushh-webapp/components/kai/kai-command-bar-global.voice-action-contract.json",
+    "hushh-webapp/components/kai/kai-market-news-page.voice-action-contract.json",
+    "hushh-webapp/components/kai/kai-portfolio-detail-page.voice-action-contract.json",
     "hushh-webapp/components/kai/views/dashboard-master-view.voice-action-contract.json",
     "hushh-webapp/components/kai/views/kai-market-preview-view.voice-action-contract.json",
     "hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json",
@@ -947,6 +949,50 @@
           "active_personas": [
             "investor",
             "ria"
+          ]
+        }
+      },
+      "orchestration": {
+        "instruction_id": null,
+        "context_policy": null,
+        "trust_boundary": null,
+        "delegation_policy": null
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "kai_news",
+      "surface_title": "Kai Market News",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md"
+      ],
+      "contract_file": "hushh-webapp/components/kai/kai-market-news-page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor"
+          ]
+        }
+      },
+      "orchestration": {
+        "instruction_id": null,
+        "context_policy": null,
+        "trust_boundary": null,
+        "delegation_policy": null
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "kai_portfolio_detail",
+      "surface_title": "Kai Portfolio Detail",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md"
+      ],
+      "contract_file": "hushh-webapp/components/kai/kai-portfolio-detail-page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor"
           ]
         }
       },
@@ -21256,20 +21302,527 @@
       }
     },
     {
+      "action_id": "route.kai_news",
+      "surface_id": "kai_news",
+      "label": "Open Market News",
+      "aliases": [
+        "open market news",
+        "show market news",
+        "show news"
+      ],
+      "search_keywords": [
+        "news",
+        "market news"
+      ],
+      "meaning": "Navigates to the market news feed.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/news"
+        ],
+        "screens": [
+          "kai_news"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Market route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/news"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-market-news-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/news"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_news",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_news",
+            "label": "Open Market News",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/news",
+              "screen": "kai_news"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "route.kai_portfolio_holdings",
+      "surface_id": "kai_portfolio_detail",
+      "label": "Show Holdings",
+      "aliases": [
+        "show my holdings",
+        "show holdings",
+        "open holdings"
+      ],
+      "search_keywords": [
+        "holdings",
+        "positions",
+        "portfolio"
+      ],
+      "meaning": "Navigates to the portfolio holdings breakdown -- every position held, not the general portfolio dashboard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/holdings"
+        ],
+        "screens": [
+          "kai_portfolio_holdings"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/holdings"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/portfolio/holdings"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_portfolio_holdings",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_portfolio_holdings",
+            "label": "Show Holdings",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/portfolio/holdings",
+              "screen": "kai_portfolio_holdings"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "route.kai_portfolio_allocation",
+      "surface_id": "kai_portfolio_detail",
+      "label": "Show Allocation",
+      "aliases": [
+        "show my allocation",
+        "show allocation",
+        "open allocation"
+      ],
+      "search_keywords": [
+        "allocation",
+        "portfolio"
+      ],
+      "meaning": "Navigates to the portfolio allocation breakdown.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/allocation"
+        ],
+        "screens": [
+          "kai_portfolio_allocation"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/allocation"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/portfolio/allocation"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_portfolio_allocation",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_portfolio_allocation",
+            "label": "Show Allocation",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/portfolio/allocation",
+              "screen": "kai_portfolio_allocation"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "route.kai_portfolio_performance",
+      "surface_id": "kai_portfolio_detail",
+      "label": "Show Performance",
+      "aliases": [
+        "show my performance",
+        "show performance",
+        "open performance"
+      ],
+      "search_keywords": [
+        "performance",
+        "returns",
+        "portfolio"
+      ],
+      "meaning": "Navigates to the portfolio performance breakdown.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/performance"
+        ],
+        "screens": [
+          "kai_portfolio_performance"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/performance"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/portfolio/performance"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_portfolio_performance",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_portfolio_performance",
+            "label": "Show Performance",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/portfolio/performance",
+              "screen": "kai_portfolio_performance"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "route.kai_portfolio_sources",
+      "surface_id": "kai_portfolio_detail",
+      "label": "Show Connected Sources",
+      "aliases": [
+        "show my sources",
+        "show connected sources",
+        "open sources"
+      ],
+      "search_keywords": [
+        "sources",
+        "connected accounts",
+        "portfolio"
+      ],
+      "meaning": "Navigates to the portfolio's connected data sources.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/sources"
+        ],
+        "screens": [
+          "kai_portfolio_sources"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/sources"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/portfolio/sources"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_portfolio_sources",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_portfolio_sources",
+            "label": "Show Connected Sources",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/portfolio/sources",
+              "screen": "kai_portfolio_sources"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
       "action_id": "route.kai_dashboard",
       "surface_id": "kai_portfolio_dashboard",
       "label": "Open Portfolio Dashboard",
       "aliases": [
         "open portfolio dashboard",
         "open portfolio",
-        "go to holdings"
+        "show my portfolio"
       ],
       "search_keywords": [
         "portfolio",
-        "dashboard",
-        "holdings"
+        "dashboard"
       ],
-      "meaning": "Navigates to portfolio dashboard for source/holdings context.",
+      "meaning": "Navigates to portfolio dashboard, the overview above holdings/allocation/performance/sources.",
       "speaker_persona": "kai",
       "delegate_agent_id": null,
       "reachability": {

--- a/contracts/kai/one-route-orchestration-index.v1.json
+++ b/contracts/kai/one-route-orchestration-index.v1.json
@@ -2401,7 +2401,7 @@
       "route_pattern": "/one/kai/news",
       "page_file": "app/one/kai/news/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.news",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2431,8 +2431,10 @@
       },
       "canonical_screen": "kai_market_news",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_news"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -2616,7 +2618,7 @@
       "route_pattern": "/one/kai/portfolio/allocation",
       "page_file": "app/one/kai/portfolio/allocation/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio.allocation",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2646,8 +2648,10 @@
       },
       "canonical_screen": "kai_portfolio_allocation",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_portfolio_allocation"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -2659,7 +2663,7 @@
       "route_pattern": "/one/kai/portfolio/holdings",
       "page_file": "app/one/kai/portfolio/holdings/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio.holdings",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2689,8 +2693,10 @@
       },
       "canonical_screen": "kai_portfolio_holdings",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_portfolio_holdings"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -2702,7 +2708,7 @@
       "route_pattern": "/one/kai/portfolio/performance",
       "page_file": "app/one/kai/portfolio/performance/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio.performance",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2732,8 +2738,10 @@
       },
       "canonical_screen": "kai_portfolio_performance",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_portfolio_performance"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -2745,7 +2753,7 @@
       "route_pattern": "/one/kai/portfolio/sources",
       "page_file": "app/one/kai/portfolio/sources/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio.sources",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2775,8 +2783,10 @@
       },
       "canonical_screen": "kai_portfolio_sources",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_portfolio_sources"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []

--- a/hushh-webapp/components/kai/kai-market-news-page.voice-action-contract.json
+++ b/hushh-webapp/components/kai/kai-market-news-page.voice-action-contract.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "kai.local_action_contract.v1",
+  "surface_id": "kai_news",
+  "surface_title": "Kai Market News",
+  "docs_references": [
+    "docs/reference/kai/kai-action-gateway-vnext.md"
+  ],
+  "defaults": {
+    "reachability": {
+      "active_personas": [
+        "investor"
+      ]
+    }
+  },
+  "actions": [
+    {
+      "action_id": "route.kai_news",
+      "label": "Open Market News",
+      "meaning": "Navigates to the market news feed.",
+      "aliases": [
+        "open market news",
+        "show market news",
+        "show news"
+      ],
+      "search_keywords": [
+        "news",
+        "market news"
+      ],
+      "reachability": {
+        "routes": [
+          "/one/kai/news"
+        ],
+        "screens": [
+          "kai_news"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Market route must be active"
+        ]
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/news"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "components/kai/kai-market-news-page.tsx"
+      ],
+      "speaker_persona": "kai"
+    }
+  ]
+}

--- a/hushh-webapp/components/kai/kai-portfolio-detail-page.voice-action-contract.json
+++ b/hushh-webapp/components/kai/kai-portfolio-detail-page.voice-action-contract.json
@@ -1,0 +1,180 @@
+{
+  "schema_version": "kai.local_action_contract.v1",
+  "surface_id": "kai_portfolio_detail",
+  "surface_title": "Kai Portfolio Detail",
+  "docs_references": [
+    "docs/reference/kai/kai-action-gateway-vnext.md"
+  ],
+  "defaults": {
+    "reachability": {
+      "active_personas": [
+        "investor"
+      ]
+    }
+  },
+  "actions": [
+    {
+      "action_id": "route.kai_portfolio_holdings",
+      "label": "Show Holdings",
+      "meaning": "Navigates to the portfolio holdings breakdown -- every position held, not the general portfolio dashboard.",
+      "aliases": [
+        "show my holdings",
+        "show holdings",
+        "open holdings"
+      ],
+      "search_keywords": [
+        "holdings",
+        "positions",
+        "portfolio"
+      ],
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/holdings"
+        ],
+        "screens": [
+          "kai_portfolio_holdings"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ]
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/holdings"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "speaker_persona": "kai"
+    },
+    {
+      "action_id": "route.kai_portfolio_allocation",
+      "label": "Show Allocation",
+      "meaning": "Navigates to the portfolio allocation breakdown.",
+      "aliases": [
+        "show my allocation",
+        "show allocation",
+        "open allocation"
+      ],
+      "search_keywords": [
+        "allocation",
+        "portfolio"
+      ],
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/allocation"
+        ],
+        "screens": [
+          "kai_portfolio_allocation"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ]
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/allocation"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "speaker_persona": "kai"
+    },
+    {
+      "action_id": "route.kai_portfolio_performance",
+      "label": "Show Performance",
+      "meaning": "Navigates to the portfolio performance breakdown.",
+      "aliases": [
+        "show my performance",
+        "show performance",
+        "open performance"
+      ],
+      "search_keywords": [
+        "performance",
+        "returns",
+        "portfolio"
+      ],
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/performance"
+        ],
+        "screens": [
+          "kai_portfolio_performance"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ]
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/performance"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "speaker_persona": "kai"
+    },
+    {
+      "action_id": "route.kai_portfolio_sources",
+      "label": "Show Connected Sources",
+      "meaning": "Navigates to the portfolio's connected data sources.",
+      "aliases": [
+        "show my sources",
+        "show connected sources",
+        "open sources"
+      ],
+      "search_keywords": [
+        "sources",
+        "connected accounts",
+        "portfolio"
+      ],
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/sources"
+        ],
+        "screens": [
+          "kai_portfolio_sources"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ]
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/sources"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "speaker_persona": "kai"
+    }
+  ]
+}

--- a/hushh-webapp/components/kai/views/dashboard-master-view.voice-action-contract.json
+++ b/hushh-webapp/components/kai/views/dashboard-master-view.voice-action-contract.json
@@ -16,16 +16,15 @@
     {
       "action_id": "route.kai_dashboard",
       "label": "Open Portfolio Dashboard",
-      "meaning": "Navigates to portfolio dashboard for source/holdings context.",
+      "meaning": "Navigates to portfolio dashboard, the overview above holdings/allocation/performance/sources.",
       "aliases": [
         "open portfolio dashboard",
         "open portfolio",
-        "go to holdings"
+        "show my portfolio"
       ],
       "search_keywords": [
         "portfolio",
-        "dashboard",
-        "holdings"
+        "dashboard"
       ],
       "reachability": {
         "routes": [

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -38,6 +38,8 @@
     "hushh-webapp/components/consent/consent-center-page.voice-action-contract.json",
     "hushh-webapp/components/kai/analysis-controls.voice-action-contract.json",
     "hushh-webapp/components/kai/kai-command-bar-global.voice-action-contract.json",
+    "hushh-webapp/components/kai/kai-market-news-page.voice-action-contract.json",
+    "hushh-webapp/components/kai/kai-portfolio-detail-page.voice-action-contract.json",
     "hushh-webapp/components/kai/views/dashboard-master-view.voice-action-contract.json",
     "hushh-webapp/components/kai/views/kai-market-preview-view.voice-action-contract.json",
     "hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json",
@@ -947,6 +949,50 @@
           "active_personas": [
             "investor",
             "ria"
+          ]
+        }
+      },
+      "orchestration": {
+        "instruction_id": null,
+        "context_policy": null,
+        "trust_boundary": null,
+        "delegation_policy": null
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "kai_news",
+      "surface_title": "Kai Market News",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md"
+      ],
+      "contract_file": "hushh-webapp/components/kai/kai-market-news-page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor"
+          ]
+        }
+      },
+      "orchestration": {
+        "instruction_id": null,
+        "context_policy": null,
+        "trust_boundary": null,
+        "delegation_policy": null
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "kai_portfolio_detail",
+      "surface_title": "Kai Portfolio Detail",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md"
+      ],
+      "contract_file": "hushh-webapp/components/kai/kai-portfolio-detail-page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor"
           ]
         }
       },
@@ -21256,20 +21302,527 @@
       }
     },
     {
+      "action_id": "route.kai_news",
+      "surface_id": "kai_news",
+      "label": "Open Market News",
+      "aliases": [
+        "open market news",
+        "show market news",
+        "show news"
+      ],
+      "search_keywords": [
+        "news",
+        "market news"
+      ],
+      "meaning": "Navigates to the market news feed.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/news"
+        ],
+        "screens": [
+          "kai_news"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Market route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/news"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-market-news-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/news"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_news",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_news",
+            "label": "Open Market News",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/news",
+              "screen": "kai_news"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "route.kai_portfolio_holdings",
+      "surface_id": "kai_portfolio_detail",
+      "label": "Show Holdings",
+      "aliases": [
+        "show my holdings",
+        "show holdings",
+        "open holdings"
+      ],
+      "search_keywords": [
+        "holdings",
+        "positions",
+        "portfolio"
+      ],
+      "meaning": "Navigates to the portfolio holdings breakdown -- every position held, not the general portfolio dashboard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/holdings"
+        ],
+        "screens": [
+          "kai_portfolio_holdings"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/holdings"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/portfolio/holdings"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_portfolio_holdings",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_portfolio_holdings",
+            "label": "Show Holdings",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/portfolio/holdings",
+              "screen": "kai_portfolio_holdings"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "route.kai_portfolio_allocation",
+      "surface_id": "kai_portfolio_detail",
+      "label": "Show Allocation",
+      "aliases": [
+        "show my allocation",
+        "show allocation",
+        "open allocation"
+      ],
+      "search_keywords": [
+        "allocation",
+        "portfolio"
+      ],
+      "meaning": "Navigates to the portfolio allocation breakdown.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/allocation"
+        ],
+        "screens": [
+          "kai_portfolio_allocation"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/allocation"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/portfolio/allocation"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_portfolio_allocation",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_portfolio_allocation",
+            "label": "Show Allocation",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/portfolio/allocation",
+              "screen": "kai_portfolio_allocation"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "route.kai_portfolio_performance",
+      "surface_id": "kai_portfolio_detail",
+      "label": "Show Performance",
+      "aliases": [
+        "show my performance",
+        "show performance",
+        "open performance"
+      ],
+      "search_keywords": [
+        "performance",
+        "returns",
+        "portfolio"
+      ],
+      "meaning": "Navigates to the portfolio performance breakdown.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/performance"
+        ],
+        "screens": [
+          "kai_portfolio_performance"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/performance"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/portfolio/performance"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_portfolio_performance",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_portfolio_performance",
+            "label": "Show Performance",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/portfolio/performance",
+              "screen": "kai_portfolio_performance"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "route.kai_portfolio_sources",
+      "surface_id": "kai_portfolio_detail",
+      "label": "Show Connected Sources",
+      "aliases": [
+        "show my sources",
+        "show connected sources",
+        "open sources"
+      ],
+      "search_keywords": [
+        "sources",
+        "connected accounts",
+        "portfolio"
+      ],
+      "meaning": "Navigates to the portfolio's connected data sources.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/kai/portfolio/sources"
+        ],
+        "screens": [
+          "kai_portfolio_sources"
+        ],
+        "hidden_navigable": true,
+        "navigation_prerequisites": [
+          "Portfolio route must be active"
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/kai/portfolio/sources"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "components/kai/kai-portfolio-detail-page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/kai/portfolio/sources"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.route.kai_portfolio_sources",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "route.kai_portfolio_sources",
+            "label": "Show Connected Sources",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/kai/portfolio/sources",
+              "screen": "kai_portfolio_sources"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
       "action_id": "route.kai_dashboard",
       "surface_id": "kai_portfolio_dashboard",
       "label": "Open Portfolio Dashboard",
       "aliases": [
         "open portfolio dashboard",
         "open portfolio",
-        "go to holdings"
+        "show my portfolio"
       ],
       "search_keywords": [
         "portfolio",
-        "dashboard",
-        "holdings"
+        "dashboard"
       ],
-      "meaning": "Navigates to portfolio dashboard for source/holdings context.",
+      "meaning": "Navigates to portfolio dashboard, the overview above holdings/allocation/performance/sources.",
       "speaker_persona": "kai",
       "delegate_agent_id": null,
       "reachability": {

--- a/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
+++ b/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
@@ -2401,7 +2401,7 @@
       "route_pattern": "/one/kai/news",
       "page_file": "app/one/kai/news/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.news",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2431,8 +2431,10 @@
       },
       "canonical_screen": "kai_market_news",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_news"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -2616,7 +2618,7 @@
       "route_pattern": "/one/kai/portfolio/allocation",
       "page_file": "app/one/kai/portfolio/allocation/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio.allocation",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2646,8 +2648,10 @@
       },
       "canonical_screen": "kai_portfolio_allocation",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_portfolio_allocation"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -2659,7 +2663,7 @@
       "route_pattern": "/one/kai/portfolio/holdings",
       "page_file": "app/one/kai/portfolio/holdings/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio.holdings",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2689,8 +2693,10 @@
       },
       "canonical_screen": "kai_portfolio_holdings",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_portfolio_holdings"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -2702,7 +2708,7 @@
       "route_pattern": "/one/kai/portfolio/performance",
       "page_file": "app/one/kai/portfolio/performance/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio.performance",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2732,8 +2738,10 @@
       },
       "canonical_screen": "kai_portfolio_performance",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_portfolio_performance"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -2745,7 +2753,7 @@
       "route_pattern": "/one/kai/portfolio/sources",
       "page_file": "app/one/kai/portfolio/sources/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
+      "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio.sources",
       "context_policy": "minimal",
       "voice_playbook": {
@@ -2775,8 +2783,10 @@
       },
       "canonical_screen": "kai_portfolio_sources",
       "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "action_ids": [
+        "route.kai_portfolio_sources"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []


### PR DESCRIPTION
## Summary

Part of #6429 (Finance voice navigation; Gmail/Calendar out of scope, pending an update from whoever owns those). Finance has real, live screens that carried zero voice action -- adds `route.*` navigation for them. Scope is navigation only, per the ticket: Finance doesn't have much beyond the already-wired actions (`analysis.start` etc.), so this closes a coverage gap rather than adding new in-screen behavior.

## What this does

Five new navigation actions for screens that had none:
- `route.kai_portfolio_holdings` -> `/one/kai/portfolio/holdings`
- `route.kai_portfolio_allocation` -> `/one/kai/portfolio/allocation`
- `route.kai_portfolio_performance` -> `/one/kai/portfolio/performance`
- `route.kai_portfolio_sources` -> `/one/kai/portfolio/sources`
- `route.kai_news` -> `/one/kai/news`

Confirmed `investments`, `optimize`, and `funding-trade` are retired compatibility redirects (bounce to Portfolio / setup), not live screens -- no action needed for those.

Also drops `"go to holdings"` from `route.kai_dashboard`'s aliases -- it now competes with the new, more specific holdings action for the same phrase, so keeping both risked inconsistent routing depending on which the model matched.

Regenerates the governed artifacts the contract additions require: the action gateway (3 mirrors), route orchestration index, and runtime topology index.

## Test plan

- [x] `npx vitest run __tests__/voice/kai-action-gateway.test.ts` -- 13 passed
- [x] `npm run verify:voice-gateway` / `verify:surface-map` -- clean
- [x] `python -m pytest consent-protocol/tests/test_one_adk_agent_tree.py` (dead-end reachability + full suite) -- 213 passed, 1 pre-existing unrelated failure (`test_normalizes_screen_names`, reproduces on clean `upstream/main`)
- [x] `tsc --noEmit` -- clean