### PR TITLE
Voice: test guard_id registration vs. actual enforcement

### DIFF
--- a/.claude/skills/wire-voice-action/SKILL.md
+++ b/.claude/skills/wire-voice-action/SKILL.md
@@ -122,26 +122,58 @@ yes, then calls again with `confirmed: true`. `guard_ids` entries named
 descriptive strings only, not enforced anywhere. Do not rely on adding one to
 get confirmation behavior; it does nothing on its own.
 
-## Step 3 — guard_ids: only these do anything, client-side
+## Step 3 — guard_ids: registered is not the same as enforced
 
+Every `guard_id` you write must be a key in
+`contracts/kai/capability-guard-coverage.v1.json` — `generate-kai-action-gateway.mjs`
+(`build:voice-gateway`, already in CI) hard-fails the build otherwise, so a
+typo'd or made-up guard string is caught immediately. That file also
+classifies each guard as `"kind": "projection"` (should be checkable
+client-side, no server round trip needed) or `"kind": "server_only"`
+(the client can never know; don't try).
+
+**Registration is not enforcement — verify separately, don't assume.**
 `evaluateKaiActionAvailability` (`hushh-webapp/lib/voice/kai-action-gateway.ts`)
-enforces exactly this closed set: `auth_signed_in` / `auth_required`,
-`vault_unlocked`, `portfolio_required`, `analysis_idle_required`,
-`active_analysis_required`, `gmail_connected`, `gmail_configured`,
-`ria_persona_available`. Anything else you write into `guard_ids` compiles,
-looks correct, and **does nothing** — it's not an error, there's no lint for
-it, the action just isn't actually gated by it. Reuse one of these if it
-fits; if it doesn't, you're adding a new guard, which means a new `if` branch
-in that function, not a new string in the JSON.
+is the actual client-side enforcer, and it only branches on a subset of the
+guards the registry calls "projection": confirmed wired today are
+`auth_signed_in` / `auth_required`, `vault_unlocked`, `portfolio_required`,
+`analysis_idle_required`, `active_analysis_required`, `gmail_connected`,
+`gmail_configured`, `ria_persona_available`. **#6437**: two other
+registry-declared "projection" guards (`consent_center_available`,
+`ria_onboarding_complete`) turned out to be checked *nowhere* — not this
+function, not the backend — while gating real, voice-executable RIA actions.
+Registering a guard and believing it's therefore live is exactly the trap
+that produced that bug. `__tests__/voice/capability-guard-coverage.test.ts`
+now exercises every registered "projection" guard's actual blocking
+behavior (not just its presence as a string) and fails loudly — as a visible
+`.todo`, not a silent skip — for any guard that doesn't yet have a proven
+way to block. If you add a "projection" guard, add its passing/failing
+`AppRuntimeState` override to that test in the same change, or the test
+itself will tell you to.
 
-The backend does not re-check this same set — its own comment is explicit:
-*"the app re-checks guards before executing."* `run_app_action` enforces a
-different thing: `manual_only`/`unwired` refusal, voice-domain toggles,
-screen reachability (does the scope even claim this screen), delegate
-redirection, and turn-scoped already-completed/already-failed dedup. Treat
-client guards and backend guards as two separate lists that happen to share
-some vocabulary, not one shared enforcement point — a guard that only exists
-client-side is bypassable by anything that reaches `run_app_action` directly.
+For a `"server_only"` guard: there is no generic backend dispatch table
+keyed by the guard_id string or its declared `validator` name — that name in
+the registry is a label for where enforcement is expected to live, not a
+function to go find. You have to write the actual check into whatever
+backend code path the action reaches (the RIA/consent/relationship service
+methods, typically), the same way you'd add any other authorization check to
+that endpoint. Adding the guard_id to the JSON alone enforces nothing.
+
+`guard_ids` named `explicit_user_confirmation` / `manual_user_execution`
+specifically: read `_directive_flags` in `action_tools.py` before assuming
+these gate anything — as of this writing they feed the confirmation-card
+*display* decision (see Step 2), not a hard block on their own.
+
+The backend's `run_app_action` does not re-check the client's guard set
+either way — its own comment is explicit: *"the app re-checks guards before
+executing."* It enforces a different thing: `manual_only`/`unwired`
+refusal, voice-domain toggles, screen reachability (does the scope even
+claim this screen), delegate redirection, and turn-scoped
+already-completed/already-failed dedup. Client guards, the "server_only"
+domain checks, and the backend's own dispatch-time checks are three
+separate things that happen to share some vocabulary — a guard that only
+exists in one of them is bypassable by anything that reaches the others
+directly.
 
 ## Step 4 — regenerate + verify
 
@@ -150,7 +182,7 @@ Same three-artifact regeneration as navigation actions
 
 ```bash
 cd hushh-webapp
-npx vitest run __tests__/voice/kai-action-gateway.test.ts
+npx vitest run __tests__/voice/kai-action-gateway.test.ts __tests__/voice/capability-guard-coverage.test.ts
 cd ..
 consent-protocol/.venv/Scripts/python.exe -m pytest consent-protocol/tests/test_one_adk_agent_tree.py -q
 ```

--- a/hushh-webapp/__tests__/voice/capability-guard-coverage.test.ts
+++ b/hushh-webapp/__tests__/voice/capability-guard-coverage.test.ts
@@ -1,0 +1,223 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateKaiActionAvailability,
+  getKaiActionById,
+  type KaiActionDefinition,
+} from "@/lib/voice/kai-action-gateway";
+import type { AppRuntimeState } from "@/lib/voice/voice-types";
+import type { VoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
+
+/**
+ * contracts/kai/capability-guard-coverage.v1.json is the registry of every
+ * valid guard_id -- generate-kai-action-gateway.mjs already fails the build
+ * if a contract uses a guard_id that isn't a key in it. What that registry
+ * does NOT prove is that a "kind": "projection" guard (client-checkable) is
+ * actually checked anywhere. #6437 found two that were registered, used on
+ * real allow_direct/confirm_required RIA actions, and enforced nowhere --
+ * evaluateKaiActionAvailability's guard loop had no branch for either
+ * string, so the action just evaluated as available.
+ *
+ * This test proves each "projection" guard genuinely blocks by exercising
+ * evaluateKaiActionAvailability's real behavior, not by inspecting source
+ * text -- a guard could be present as a string in the function without ever
+ * being reachable, and that would still pass a source-text check.
+ */
+
+const coveragePath = resolve(
+  process.cwd(),
+  "contracts/kai/capability-guard-coverage.v1.json",
+);
+const coverage = JSON.parse(readFileSync(coveragePath, "utf8")) as {
+  guards: Record<string, { kind: string; predicate?: string; validator?: string }>;
+};
+
+const projectionGuardIds = Object.entries(coverage.guards)
+  .filter(([, entry]) => entry.kind === "projection")
+  .map(([guardId]) => guardId)
+  .sort();
+
+// A real, currently-unguarded, single-persona, wired allow_direct action --
+// cloned per test with only guard_ids replaced, so every other field stays
+// exactly as authored instead of a hand-built fixture drifting from the
+// real contract shape.
+const BASE_ACTION = getKaiActionById("route.kai_analysis");
+
+function withGuard(guardId: string): KaiActionDefinition {
+  if (!BASE_ACTION) {
+    throw new Error(
+      "route.kai_analysis is missing from the generated gateway -- fixture base no longer valid",
+    );
+  }
+  return { ...BASE_ACTION, guard_ids: [guardId] };
+}
+
+// Every condition satisfied -- signed in, vault unlocked, portfolio present,
+// no analysis running, both personas available, Gmail connected+configured.
+// Each test below flips exactly the one field its guard is documented to
+// gate, so a failure isolates to that guard rather than a shared fixture bug.
+const PASSING_STATE: AppRuntimeState = {
+  auth: { signed_in: true, user_id: "test-user" },
+  vault: { unlocked: true, token_available: true, token_valid: true },
+  route: { pathname: "/one/kai", screen: "kai_analysis" },
+  runtime: {
+    analysis_active: false,
+    import_active: false,
+    busy_operations: [],
+  },
+  portfolio: { has_portfolio_data: true },
+  persona: {
+    active: "investor",
+    primary_nav: "investor",
+    available: ["investor", "ria"],
+    ria_switch_available: true,
+    ria_setup_available: true,
+  },
+  voice: { available: true, tts_playing: false },
+};
+
+const PASSING_SURFACE_METADATA: VoiceSurfaceMetadata = {
+  screenMetadata: { gmail_connected: true, gmail_configured: true },
+};
+
+// One targeted failing override per confirmed-implemented guard, plus a
+// `passingOverride` only where PASSING_STATE's own default doesn't already
+// satisfy that guard (active_analysis_required needs analysis_active: true
+// to be satisfied, but analysis_idle_required needs the opposite -- they
+// can't share one default). A guard with no entry here has no known way to
+// make it block -- see the .todo block below instead of silently skipping.
+const FAILING_OVERRIDE: Record<
+  string,
+  {
+    state?: Partial<AppRuntimeState>;
+    surfaceMetadata?: VoiceSurfaceMetadata;
+    passingOverride?: Partial<AppRuntimeState>;
+  }
+> = {
+  auth_signed_in: { state: { auth: { signed_in: false, user_id: null } } },
+  auth_required: { state: { auth: { signed_in: false, user_id: null } } },
+  vault_unlocked: {
+    state: { vault: { unlocked: false, token_available: false, token_valid: false } },
+  },
+  portfolio_required: { state: { portfolio: { has_portfolio_data: false } } },
+  analysis_idle_required: {
+    state: {
+      runtime: { analysis_active: true, import_active: false, busy_operations: [] },
+    },
+  },
+  active_analysis_required: {
+    state: {
+      runtime: { analysis_active: false, import_active: false, busy_operations: [] },
+    },
+    passingOverride: {
+      runtime: { analysis_active: true, import_active: false, busy_operations: [] },
+    },
+  },
+  gmail_connected: {
+    surfaceMetadata: { screenMetadata: { gmail_connected: false, gmail_configured: true } },
+  },
+  gmail_configured: {
+    surfaceMetadata: { screenMetadata: { gmail_connected: true, gmail_configured: false } },
+  },
+  ria_persona_available: {
+    state: {
+      persona: {
+        active: "investor",
+        primary_nav: "investor",
+        available: ["investor"],
+        ria_switch_available: false,
+        ria_setup_available: false,
+      },
+    },
+  },
+};
+
+// Registered as "projection" (client-checkable) but with no known way to
+// make them block today -- see #6437. Kept as .todo rather than omitted so
+// the gap stays visible in test output instead of silently disappearing,
+// and so fixing #6437 has an exact test to un-skip.
+const KNOWN_UNENFORCED_PROJECTION_GUARDS = new Set([
+  "consent_center_available",
+  "ria_onboarding_complete",
+]);
+
+// Registered as "projection" but confirmed, separately from #6437, to be
+// either unused by any live action today (active_persona_investor/_ria --
+// no action currently declares them, so there is nothing to regress) or
+// structurally redundant (vault_owner_token is a required parameter on the
+// underlying backend calls regardless of any named guard check, so its
+// absence here does not open a bypass). Not bugs -- just not testable the
+// same way as a guard something actually depends on.
+const KNOWN_UNUSED_OR_REDUNDANT_PROJECTION_GUARDS = new Set([
+  "active_persona_investor",
+  "active_persona_ria",
+  "vault_owner_token",
+]);
+
+describe("capability-guard-coverage: every registered projection guard actually blocks", () => {
+  it("found a non-trivial set of projection guards to check (sanity)", () => {
+    expect(projectionGuardIds.length).toBeGreaterThan(5);
+  });
+
+  it("route.kai_analysis fixture base resolved from the generated gateway", () => {
+    expect(BASE_ACTION).not.toBeNull();
+  });
+
+  for (const guardId of projectionGuardIds) {
+    if (KNOWN_UNENFORCED_PROJECTION_GUARDS.has(guardId)) {
+      it.todo(`"${guardId}" is registered as projection but never enforced -- see #6437`);
+      continue;
+    }
+    if (KNOWN_UNUSED_OR_REDUNDANT_PROJECTION_GUARDS.has(guardId)) {
+      continue;
+    }
+
+    const override = FAILING_OVERRIDE[guardId];
+    if (!override) {
+      // A new "projection" guard landed in the coverage registry with no
+      // corresponding entry here. Fail loudly instead of silently passing --
+      // either add its failing-state override above, or if it's a known
+      // gap like the two above, add it to KNOWN_UNENFORCED_PROJECTION_GUARDS
+      // with a linked issue, but never let a new guard go unverified by
+      // default.
+      it(`"${guardId}" has a known failing-state override to test against`, () => {
+        expect(
+          override,
+          `"${guardId}" is a new "projection" guard with no test coverage in this file. ` +
+            `Add a FAILING_OVERRIDE entry (preferred) or add it to ` +
+            `KNOWN_UNENFORCED_PROJECTION_GUARDS with a linked issue if it's a known gap.`,
+        ).toBeDefined();
+      });
+      continue;
+    }
+
+    it(`"${guardId}" blocks when its documented condition is unmet`, () => {
+      const result = evaluateKaiActionAvailability({
+        action: withGuard(guardId),
+        appRuntimeState: { ...PASSING_STATE, ...override.state },
+        surfaceMetadata: override.surfaceMetadata ?? PASSING_SURFACE_METADATA,
+      });
+      expect(
+        result.status,
+        `guard "${guardId}" is registered as client-enforceable in ` +
+          `capability-guard-coverage.v1.json but evaluateKaiActionAvailability ` +
+          `returned "${result.status}" instead of blocking it`,
+      ).not.toBe("available");
+    });
+
+    it(`"${guardId}" allows the same action when its condition is satisfied`, () => {
+      const result = evaluateKaiActionAvailability({
+        action: withGuard(guardId),
+        appRuntimeState: { ...PASSING_STATE, ...override.passingOverride },
+        surfaceMetadata: PASSING_SURFACE_METADATA,
+      });
+      expect(
+        result.status,
+        `guard "${guardId}" blocked a fully-passing state -- either the ` +
+          `guard or this test's PASSING_STATE fixture is wrong`,
+      ).toBe("available");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds \`__tests__/voice/capability-guard-coverage.test.ts\`. Every \`guard_id\` already has to be registered in \`contracts/kai/capability-guard-coverage.v1.json\` or the build fails -- but registration was never proof of enforcement. This test proves it behaviorally: for every \`"kind": "projection"\` guard in that registry, it exercises \`evaluateKaiActionAvailability\` with a real gateway action in a state that should fail the guard and asserts it actually blocks (and a passing state that actually allows) -- not just that the guard string exists somewhere in source.

## What it found

Two registered "projection" guards -- \`consent_center_available\`, \`ria_onboarding_complete\` -- were checked **nowhere**: not this function, not the backend. Both gate real, voice-executable (\`allow_direct\`/\`confirm_required\`) RIA client-workspace actions (opening a client's workspace tabs, requesting relationship access). Filed as #6437. Kept as visible \`it.todo()\`s in this PR referencing the issue, rather than silently excluded, so the gap stays in test output and fixing #6437 has an exact test to un-skip.

Three other registered guards (\`active_persona_investor\`, \`active_persona_ria\`, \`vault_owner_token\`) were separately confirmed to be either unused by any live action today or structurally redundant (the latter is a required parameter on the underlying backend calls regardless of any named guard check) -- documented in the test as such, not bugs.

## Also included

Corrects \`wire-voice-action\`'s Step 3, which claimed a narrower "8 guards, everything else inert" picture based on incomplete research written before this investigation -- it didn't know about the coverage registry, the projection/server_only split, or that registration alone doesn't guarantee enforcement. Now points at this test as the mechanism that catches that class of drift going forward.

## Test plan

- [x] \`npx vitest run __tests__/voice/capability-guard-coverage.test.ts __tests__/voice/kai-action-gateway.test.ts\` -- 31 passed, 2 todo (the #6437 gap)
- [x] \`tsc --noEmit\` / \`eslint\` on the new test file -- clean
- [x] A new "projection" guard added to the registry without a corresponding test override now fails loudly by design (verified by temporarily adding a fake entry locally)