### PR TITLE
RIA: actually enforce ria_onboarding_complete and consent_center_available

### DIFF
--- a/consent-protocol/contracts/kai/kai-action-gateway.vnext.json
+++ b/consent-protocol/contracts/kai/kai-action-gateway.vnext.json
@@ -961,7 +961,7 @@
     },
     {
       "schema_version": "kai.local_action_contract.v1",
-      "surface_id": "kai_news",
+      "surface_id": "kai_market_news",
       "surface_title": "Kai Market News",
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md"
@@ -11851,7 +11851,9 @@
           "profile_preferences"
         ],
         "hidden_navigable": true,
-        "navigation_prerequisites": [],
+        "navigation_prerequisites": [
+          "profile route must be active"
+        ],
         "active_personas": [
           "investor",
           "ria"
@@ -21303,7 +21305,7 @@
     },
     {
       "action_id": "route.kai_news",
-      "surface_id": "kai_news",
+      "surface_id": "kai_market_news",
       "label": "Open Market News",
       "aliases": [
         "open market news",
@@ -21322,7 +21324,7 @@
           "/one/kai/news"
         ],
         "screens": [
-          "kai_news"
+          "kai_market_news"
         ],
         "hidden_navigable": true,
         "navigation_prerequisites": [
@@ -21378,7 +21380,7 @@
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/kai/news",
-              "screen": "kai_news"
+              "screen": "kai_market_news"
             }
           }
         ],

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5474,7 +5474,7 @@
   "schema_version": "hushh.runtime_topology_index.v1",
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
-    "action_gateway": "2e2739dbeb59933b3695634d50d1cfdd0071c1feadf8328d0a7ee00745fe9b32",
+    "action_gateway": "5605ad3933dedb8b04d83cde1604f0ff520f74b9278c98c9683e306c6b4ba4a8",
     "agent_registry": "bbb216914b5071e301b0a923fcd61695c9260691f56097a482510b1229ff6112",
     "cache_manifest": "c7a177decdb319d8a8b673ae16f6acdad5aedee5fc98329d2d58470e1726b4e8",
     "data_plane": "76399599594d347d840307b338dd681728ecaa9583990e32275f6199d3ce2290",

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -961,7 +961,7 @@
     },
     {
       "schema_version": "kai.local_action_contract.v1",
-      "surface_id": "kai_news",
+      "surface_id": "kai_market_news",
       "surface_title": "Kai Market News",
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md"
@@ -11851,7 +11851,9 @@
           "profile_preferences"
         ],
         "hidden_navigable": true,
-        "navigation_prerequisites": [],
+        "navigation_prerequisites": [
+          "profile route must be active"
+        ],
         "active_personas": [
           "investor",
           "ria"
@@ -21303,7 +21305,7 @@
     },
     {
       "action_id": "route.kai_news",
-      "surface_id": "kai_news",
+      "surface_id": "kai_market_news",
       "label": "Open Market News",
       "aliases": [
         "open market news",
@@ -21322,7 +21324,7 @@
           "/one/kai/news"
         ],
         "screens": [
-          "kai_news"
+          "kai_market_news"
         ],
         "hidden_navigable": true,
         "navigation_prerequisites": [
@@ -21378,7 +21380,7 @@
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/kai/news",
-              "screen": "kai_news"
+              "screen": "kai_market_news"
             }
           }
         ],

--- a/hushh-webapp/__tests__/lib/ria/ria-profile-view-model.test.ts
+++ b/hushh-webapp/__tests__/lib/ria/ria-profile-view-model.test.ts
@@ -77,10 +77,16 @@ describe("ria-profile-view-model", () => {
     expect(props.advisoryAccessReady).toBe(false);
   });
 
-  it("treats active/verified as advisory access ready", () => {
+  it("treats active/verified/finra_verified as advisory access ready", () => {
     expect(isRiaAdvisoryAccessReady(baseStatus({ advisory_status: "active" }))).toBe(
       true,
     );
+    expect(
+      isRiaAdvisoryAccessReady(baseStatus({ advisory_status: "verified" })),
+    ).toBe(true);
+    expect(
+      isRiaAdvisoryAccessReady(baseStatus({ advisory_status: "finra_verified" })),
+    ).toBe(true);
     expect(
       isRiaAdvisoryAccessReady(baseStatus({ advisory_status: "submitted" })),
     ).toBe(false);

--- a/hushh-webapp/__tests__/voice/capability-guard-coverage.test.ts
+++ b/hushh-webapp/__tests__/voice/capability-guard-coverage.test.ts
@@ -74,6 +74,7 @@ const PASSING_STATE: AppRuntimeState = {
     available: ["investor", "ria"],
     ria_switch_available: true,
     ria_setup_available: true,
+    ria_onboarding_complete: true,
   },
   voice: { available: true, tts_playing: false },
 };
@@ -129,19 +130,49 @@ const FAILING_OVERRIDE: Record<
         available: ["investor"],
         ria_switch_available: false,
         ria_setup_available: false,
+        ria_onboarding_complete: true,
+      },
+    },
+  },
+  // #6437: both were registered as "projection" but checked nowhere until
+  // this same change wired them in evaluateKaiActionAvailability, gated on
+  // whether RIA onboarding has actually settled to a verified status (not
+  // merely whether a persona/onboarding record exists). Deliberately
+  // changes nothing about `persona.active`/`available` here -- the fixture
+  // base (route.kai_analysis) requires the investor persona, and flipping
+  // persona fields too would make the earlier persona-reachability check
+  // block first, proving nothing about this guard specifically.
+  ria_onboarding_complete: {
+    state: {
+      persona: {
+        active: "investor",
+        primary_nav: "investor",
+        available: ["investor", "ria"],
+        ria_switch_available: true,
+        ria_setup_available: true,
+        ria_onboarding_complete: false,
+      },
+    },
+  },
+  consent_center_available: {
+    state: {
+      persona: {
+        active: "investor",
+        primary_nav: "investor",
+        available: ["investor", "ria"],
+        ria_switch_available: true,
+        ria_setup_available: true,
+        ria_onboarding_complete: false,
       },
     },
   },
 };
 
 // Registered as "projection" (client-checkable) but with no known way to
-// make them block today -- see #6437. Kept as .todo rather than omitted so
-// the gap stays visible in test output instead of silently disappearing,
-// and so fixing #6437 has an exact test to un-skip.
-const KNOWN_UNENFORCED_PROJECTION_GUARDS = new Set([
-  "consent_center_available",
-  "ria_onboarding_complete",
-]);
+// make them block today. Kept as .todo rather than omitted so the gap stays
+// visible in test output instead of silently disappearing, and so fixing
+// the linked issue has an exact test to un-skip.
+const KNOWN_UNENFORCED_PROJECTION_GUARDS = new Set<string>([]);
 
 // Registered as "projection" but confirmed, separately from #6437, to be
 // either unused by any live action today (active_persona_investor/_ria --

--- a/hushh-webapp/app/one/profile/page.voice-action-contract.json
+++ b/hushh-webapp/app/one/profile/page.voice-action-contract.json
@@ -290,7 +290,9 @@
           "profile_preferences"
         ],
         "hidden_navigable": true,
-        "navigation_prerequisites": []
+        "navigation_prerequisites": [
+          "profile route must be active"
+        ]
       },
       "guard_ids": [],
       "risk_level": "low",

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -125,6 +125,7 @@ import {
 } from "@/lib/agent/agent-chat-history-cache";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { usePersonaState } from "@/lib/persona/persona-context";
+import { isRiaAdvisoryAccessReady } from "@/lib/ria/ria-profile-view-model";
 import { CacheService, CACHE_KEYS } from "@/lib/services/cache-service";
 import { AppBackgroundTaskService } from "@/lib/services/app-background-task-service";
 import { toDurationBucket, trackEvent } from "@/lib/observability/client";
@@ -1308,8 +1309,10 @@ export function AgentChatWorkspace({
     personaTransitionTarget,
     riaSetupAvailable,
     riaSwitchAvailable,
+    riaOnboardingStatus,
     switchPersona,
   } = usePersonaState();
+  const riaOnboardingComplete = isRiaAdvisoryAccessReady(riaOnboardingStatus);
   const analysisParams = useKaiSession((state) => state.analysisParams);
   const busyOperations = useKaiSession((state) => state.busyOperations);
   const setAnalysisParams = useKaiSession((state) => state.setAnalysisParams);
@@ -1635,6 +1638,7 @@ export function AgentChatWorkspace({
         transition_target: personaTransitionTarget,
         ria_switch_available: riaSwitchAvailable,
         ria_setup_available: riaSetupAvailable,
+        ria_onboarding_complete: riaOnboardingComplete,
       },
       voice: {
         available: false,
@@ -1681,6 +1685,7 @@ export function AgentChatWorkspace({
     primaryNavPersona,
     riaSetupAvailable,
     riaSwitchAvailable,
+    riaOnboardingComplete,
     runningImportTask,
     routeInfo.screen,
     routeInfo.subview,

--- a/hushh-webapp/components/kai/kai-command-bar-global.tsx
+++ b/hushh-webapp/components/kai/kai-command-bar-global.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { KaiSearchBar } from "@/components/kai/kai-search-bar";
 import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { usePersonaState } from "@/lib/persona/persona-context";
+import { isRiaAdvisoryAccessReady } from "@/lib/ria/ria-profile-view-model";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
 import { CacheService, CACHE_KEYS } from "@/lib/services/cache-service";
 import { useVault } from "@/lib/vault/vault-context";
@@ -64,8 +65,10 @@ export function KaiCommandBarGlobal() {
     personaTransitionTarget,
     riaSetupAvailable,
     riaSwitchAvailable,
+    riaOnboardingStatus,
     switchPersona,
   } = usePersonaState();
+  const riaOnboardingComplete = isRiaAdvisoryAccessReady(riaOnboardingStatus);
   const { isVaultUnlocked, vaultOwnerToken, tokenExpiresAt } = useVault();
   const setAnalysisParams = useKaiSession((s) => s.setAnalysisParams);
   const busyOperations = useKaiSession((s) => s.busyOperations);
@@ -272,6 +275,7 @@ export function KaiCommandBarGlobal() {
         transition_target: personaTransitionTarget || null,
         ria_switch_available: riaSwitchAvailable,
         ria_setup_available: riaSetupAvailable,
+        ria_onboarding_complete: riaOnboardingComplete,
       },
       voice: {
         available: false,
@@ -300,6 +304,7 @@ export function KaiCommandBarGlobal() {
       primaryNavPersona,
       riaSetupAvailable,
       riaSwitchAvailable,
+      riaOnboardingComplete,
     ]
   );
 

--- a/hushh-webapp/components/kai/kai-market-news-page.voice-action-contract.json
+++ b/hushh-webapp/components/kai/kai-market-news-page.voice-action-contract.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "kai.local_action_contract.v1",
-  "surface_id": "kai_news",
+  "surface_id": "kai_market_news",
   "surface_title": "Kai Market News",
   "docs_references": [
     "docs/reference/kai/kai-action-gateway-vnext.md"
@@ -31,7 +31,7 @@
           "/one/kai/news"
         ],
         "screens": [
-          "kai_news"
+          "kai_market_news"
         ],
         "hidden_navigable": true,
         "navigation_prerequisites": [

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -961,7 +961,7 @@
     },
     {
       "schema_version": "kai.local_action_contract.v1",
-      "surface_id": "kai_news",
+      "surface_id": "kai_market_news",
       "surface_title": "Kai Market News",
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md"
@@ -11851,7 +11851,9 @@
           "profile_preferences"
         ],
         "hidden_navigable": true,
-        "navigation_prerequisites": [],
+        "navigation_prerequisites": [
+          "profile route must be active"
+        ],
         "active_personas": [
           "investor",
           "ria"
@@ -21303,7 +21305,7 @@
     },
     {
       "action_id": "route.kai_news",
-      "surface_id": "kai_news",
+      "surface_id": "kai_market_news",
       "label": "Open Market News",
       "aliases": [
         "open market news",
@@ -21322,7 +21324,7 @@
           "/one/kai/news"
         ],
         "screens": [
-          "kai_news"
+          "kai_market_news"
         ],
         "hidden_navigable": true,
         "navigation_prerequisites": [
@@ -21378,7 +21380,7 @@
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/kai/news",
-              "screen": "kai_news"
+              "screen": "kai_market_news"
             }
           }
         ],

--- a/hushh-webapp/lib/agent/agent-runtime-context.tsx
+++ b/hushh-webapp/lib/agent/agent-runtime-context.tsx
@@ -27,6 +27,7 @@ import { usePathname, useSearchParams } from "next/navigation";
 import { useAuth } from "@/hooks/use-auth";
 import { useVault } from "@/lib/vault/vault-context";
 import { usePersonaState } from "@/lib/persona/persona-context";
+import { isRiaAdvisoryAccessReady } from "@/lib/ria/ria-profile-view-model";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
 import { CacheService, CACHE_KEYS } from "@/lib/services/cache-service";
 import {
@@ -185,7 +186,9 @@ export function AgentRuntimeStateProvider({ children }: { children: ReactNode })
     personaTransitionTarget,
     riaSetupAvailable,
     riaSwitchAvailable,
+    riaOnboardingStatus,
   } = usePersonaState();
+  const riaOnboardingComplete = isRiaAdvisoryAccessReady(riaOnboardingStatus);
   const analysisParams = useKaiSession((state) => state.analysisParams);
   const busyOperations = useKaiSession((state) => state.busyOperations);
 
@@ -370,6 +373,7 @@ export function AgentRuntimeStateProvider({ children }: { children: ReactNode })
         transition_target: personaTransitionTarget,
         ria_switch_available: riaSwitchAvailable,
         ria_setup_available: riaSetupAvailable,
+        ria_onboarding_complete: riaOnboardingComplete,
       },
       voice: {
         available: voiceActive,
@@ -382,6 +386,7 @@ export function AgentRuntimeStateProvider({ children }: { children: ReactNode })
       activeAnalysisTicker,
       activePersona,
       availablePersonas,
+      riaOnboardingComplete,
       busyOperations,
       hasPortfolioData,
       isVaultUnlocked,

--- a/hushh-webapp/lib/ria/ria-profile-view-model.ts
+++ b/hushh-webapp/lib/ria/ria-profile-view-model.ts
@@ -42,7 +42,7 @@ export function isRiaAdvisoryAccessReady(
     status?.verification_status ||
     ""
   ).toLowerCase();
-  return value === "active" || value === "verified";
+  return value === "active" || value === "verified" || value === "finra_verified";
 }
 
 // Map the server-backed onboarding status onto the props OnboardingStepReview

--- a/hushh-webapp/lib/voice/kai-action-gateway.ts
+++ b/hushh-webapp/lib/voice/kai-action-gateway.ts
@@ -1029,6 +1029,27 @@ export function evaluateKaiActionAvailability(input: {
             : null,
       };
     }
+    // #6437: registered in capability-guard-coverage.v1.json as
+    // "projection" (client-checkable) since these were authored, but never
+    // actually wired here -- both gated real, voice-executable RIA
+    // client-workspace actions with nothing enforcing them. An onboarding
+    // *record* existing (ria_persona_available, checked above) is not the
+    // same as onboarding being *complete*; see isRiaAdvisoryAccessReady.
+    if (
+      (guardId === "ria_onboarding_complete" ||
+        guardId === "consent_center_available") &&
+      appRuntimeState?.persona?.ria_onboarding_complete !== true
+    ) {
+      return {
+        status: "blocked",
+        reason: "Finish RIA verification before using this action.",
+        target_persona: "ria",
+        blocked_guidance:
+          appRuntimeState?.persona?.ria_setup_available === true
+            ? "Complete RIA setup to unlock this."
+            : null,
+      };
+    }
   }
 
   return {

--- a/hushh-webapp/lib/voice/voice-types.ts
+++ b/hushh-webapp/lib/voice/voice-types.ts
@@ -157,6 +157,14 @@ export type AppRuntimeState = {
     transition_target?: Persona | null;
     ria_switch_available: boolean;
     ria_setup_available: boolean;
+    /**
+     * Whether the RIA advisor's onboarding has actually settled to a
+     * verified status (active/verified/finra_verified) -- not merely
+     * whether a persona/onboarding record exists. Gates
+     * ria_onboarding_complete and consent_center_available in
+     * evaluateKaiActionAvailability; see #6437.
+     */
+    ria_onboarding_complete: boolean;
   };
   voice: {
     available: boolean;


### PR DESCRIPTION
## Summary

Closes #6437. Both guard_ids were registered in \`capability-guard-coverage.v1.json\` as \`"kind": "projection"\` but checked nowhere -- not \`evaluateKaiActionAvailability\`, not the backend -- while gating real, voice-executable RIA client-workspace actions (opening a client's workspace tabs, requesting relationship access). An onboarding persona/record *existing* (already covered separately by \`ria_persona_available\`) is not the same as onboarding being *complete*.

## What this does

- Adds \`AppRuntimeState.persona.ria_onboarding_complete\`, derived from \`riaOnboardingStatus\` via \`isRiaAdvisoryAccessReady\` (active / verified / finra_verified) at all three places \`AppRuntimeState\` is actually constructed (the main provider in \`agent-runtime-context.tsx\`, plus the two narrower constructions in \`agent-chat-workspace.tsx\` and \`kai-command-bar-global.tsx\`).
- Both guard_ids now branch on that field in \`evaluateKaiActionAvailability\`.
- \`isRiaAdvisoryAccessReady\` itself was missing \`finra_verified\` -- the same gap #6291 fixed in two sibling copies of this same check earlier this week. Fixed here too, since this guard now depends on it being correct.
- Un-skips the two \`capability-guard-coverage.test.ts\` cases that were carrying this as a visible \`.todo()\` (from #6438).

## Also fixed (surfaced by running the full suite while verifying this)

Two smaller, unrelated drifts:
- \`route.kai_news\` declared screen \`kai_news\` instead of the canonical \`kai_market_news\` (from the Finance nav PR) -- \`route-orchestration-index.test.ts\` already covered this, it just hadn't run as part of that PR's verification.
- \`help.open_examples\` had \`hidden_navigable: true\` with empty \`navigation_prerequisites\` (from the One product-explainer PR) -- \`investor-kai-action-registry.test.ts\` already covered this too.

## Test plan

- [x] \`npx vitest run __tests__/voice __tests__/app/ria __tests__/components/ria __tests__/lib/ria\` -- 588 passed
- [x] \`npm run verify:voice-gateway\` / \`verify:surface-map\` -- clean
- [x] \`python -m pytest consent-protocol/tests/test_one_adk_agent_tree.py\` -- 213 passed, 1 pre-existing unrelated failure (\`test_normalizes_screen_names\`)
- [x] \`tsc --noEmit\` / \`eslint\` on touched files -- clean