### PR TITLE
One: read and speak back any PKM domain summary

### DIFF
--- a/consent-protocol/hushh_mcp/one_adk/action_tools.py
+++ b/consent-protocol/hushh_mcp/one_adk/action_tools.py
@@ -52,6 +52,11 @@ from hushh_mcp.services.consent_lifecycle_service import (
     ConsentLifecycleError,
     ConsentLifecycleService,
 )
+from hushh_mcp.services.domain_contracts import (
+    CANONICAL_DOMAIN_REGISTRY,
+    get_canonical_domain_metadata,
+    normalize_domain_key,
+)
 from hushh_mcp.services.information_request_service import (
     InformationRequestError,
     InformationRequestService,
@@ -80,6 +85,7 @@ from hushh_mcp.services.person_profile_service import (
     PersonProfileNotFoundError,
     PersonProfileService,
 )
+from hushh_mcp.services.personal_knowledge_model_service import get_pkm_service
 from hushh_mcp.services.spoken_name_resolver import (
     UnresolvedPersonName,
     ambiguous_match_names,
@@ -1493,6 +1499,81 @@ async def list_my_connections(tool_context: ToolContext) -> dict[str, Any]:
         "connections",
         lambda: ConnectionsService().list_connections(user_id=user_id),
     )
+
+
+# Domains this tool will never read back over voice, even though they are
+# real PKM domains: runtime_secrets is BYOK model credential material, not
+# personal information -- there is no phrasing of "what do you know about my
+# X" that should ever resolve to it. Kept separate from the general domain
+# registry rather than filtered ad hoc, so a new sensitive domain has one
+# obvious place to be added.
+_VOICE_UNREADABLE_PKM_DOMAINS = frozenset({"runtime_secrets"})
+
+_PKM_READABLE_DOMAIN_KEYS = tuple(
+    entry.domain_key
+    for entry in CANONICAL_DOMAIN_REGISTRY
+    if entry.domain_key not in _VOICE_UNREADABLE_PKM_DOMAINS
+)
+
+
+async def read_my_pkm_domain_summary(domain: str, tool_context: ToolContext) -> dict[str, Any]:
+    """Read the person's own redacted PKM summary for one domain and report it.
+
+    Covers every general information domain (financial, health, travel,
+    subscriptions, professional, identity, and the rest of the canonical PKM
+    registry) through one tool rather than one per domain, since they are all
+    read the same way -- the discovery-only index, never decrypted holdings.
+    Live app data with its own service (Connect's actual connections list,
+    Location's circles) is deliberately out of scope here; use the
+    dedicated read tools for those instead.
+
+    The summary is whatever sanitized, non-sensitive metadata
+    update_domain_summary() has accumulated for that domain -- it may be
+    partial or empty even when the domain itself exists.
+    """
+    user_id, blocked = await _read_tool_user_id(tool_context)
+    if blocked is not None:
+        return blocked
+    if user_id is None:
+        raise AssertionError("_read_tool_user_id returned no user_id with blocked=None")
+
+    requested = normalize_domain_key(domain)
+    if requested not in _PKM_READABLE_DOMAIN_KEYS:
+        return {
+            "status": "failed",
+            "message": (
+                f'"{domain}" is not a domain I can read. Available domains: '
+                + ", ".join(_PKM_READABLE_DOMAIN_KEYS)
+                + "."
+            ),
+        }
+
+    label = (
+        get_canonical_domain_metadata(requested).display_name
+        if get_canonical_domain_metadata(requested)
+        else requested
+    )
+    # Not _read_tool_result: that helper's `call` is a zero-arg wrapper around
+    # a *synchronous* service call (every existing read tool's service method
+    # is sync), but get_index_v2 is genuinely async. Same shape and same
+    # failure-boundary reasoning as _read_tool_result -- an exception must
+    # never escape a live-session tool call -- just awaited instead of called.
+    try:
+        index = await get_pkm_service().get_index_v2(user_id)
+    except Exception:  # noqa: BLE001 - the model must be told something failed, not why internally
+        logger.exception("one_adk_read_tool_failed label=%s reason=unexpected", label)
+        return {
+            "status": "failed",
+            "message": f"Could not check {label} right now. Try again in a moment.",
+        }
+    available = list(index.available_domains) if index else []
+    if requested not in available:
+        return {"status": "ok", "result": {"has_data": False, "domain": requested, "summary": {}}}
+    summary = (index.domain_summaries or {}).get(requested) or {}
+    return {
+        "status": "ok",
+        "result": {"has_data": True, "domain": requested, "summary": dict(summary)},
+    }
 
 
 async def discover_person_information(

--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -69,6 +69,7 @@ from hushh_mcp.one_adk.action_tools import (
     list_pending_information_requests,
     list_pending_location_requests,
     propose_information_request,
+    read_my_pkm_domain_summary,
     run_app_action,
     set_preferred_model,
     start_app_goal,
@@ -589,6 +590,27 @@ ONE_IDENTITY_INSTRUCTION: str = (
     "show a raw scope identifier, or imply that a social connection grants access. End with "
     "a Markdown link using the returned profilePath so the person can select exact fields "
     "and confirm the consent request. Do not claim a request was sent from discovery alone.\n\n"
+    # Reading the person's own PKM data. One general read tool, not one per
+    # domain -- every domain listed here is read the same way (the
+    # discovery-only summary index, never decrypted holdings), so a new
+    # domain needs no new tool, just the domain key added below.
+    "For 'what do you know about my X' / 'tell me about my X' questions -- "
+    "portfolio or investments, health, travel, subscriptions, professional "
+    "background, identity, food preferences, RIA practice, wallet, "
+    "entertainment, shopping, social, location, or anything else about the "
+    "person themselves -- call read_my_pkm_domain_summary with the matching "
+    "domain key: identity, financial, subscriptions, health, travel, food, "
+    "professional, ria, source_library, wallet, entertainment, shopping, "
+    "social, location, or general. Map the person's own words to the "
+    "closest key yourself; if the tool reports the key was not recognised, "
+    "read back the domains it lists rather than guessing again blind. If "
+    "has_data is false, say plainly that nothing has been captured for that "
+    "area yet rather than implying an error. The summary is redacted, "
+    "sanitized metadata, not raw records -- speak only the fields it "
+    "actually returned, in plain language; never invent a figure, date, or "
+    "status it did not report. This is a different tool from the "
+    "Location/Connect read tools above: those read live app data with "
+    "their own services, this reads the general PKM domains only.\n\n"
     # Guide mode: some actions cannot be triggered by the app at all, only by
     # the person (run_app_action reports these as 'manual_only', e.g. picking
     # a file or connecting a third-party account). This is not a dead end.
@@ -1627,6 +1649,7 @@ def _one_roster_tools(*, specialist_model: Any | None = None) -> list:
         list_pending_location_requests,
         list_my_outgoing_location_requests,
         list_my_connections,
+        read_my_pkm_domain_summary,
         discover_person_information,
         list_available_models,
         list_pending_information_requests,

--- a/consent-protocol/tests/test_one_adk_agent_tree.py
+++ b/consent-protocol/tests/test_one_adk_agent_tree.py
@@ -46,6 +46,7 @@ from hushh_mcp.one_adk.action_tools import (
     list_my_outgoing_location_requests,
     list_pending_connection_requests,
     list_pending_location_requests,
+    read_my_pkm_domain_summary,
     run_app_action,
     start_app_goal,
 )
@@ -3727,6 +3728,109 @@ class TestBackendDirectConnectionReadTools:
         ):
             result = await list_pending_connection_requests(_tool_context(state))
         assert result == {"status": "failed", "message": "Try again shortly."}
+
+
+class _FakePkmIndex:
+    def __init__(self, available_domains, domain_summaries):
+        self.available_domains = available_domains
+        self.domain_summaries = domain_summaries
+
+
+class TestReadMyPkmDomainSummary:
+    """read_my_pkm_domain_summary -- the general PKM domain-summary read tool."""
+
+    def _authorized_state(self) -> dict:
+        return {STATE_USER_ID: "user_1", STATE_CONSENT_TOKEN: "token_1"}
+
+    def _auth_patch(self):
+        return patch(
+            "hushh_mcp.one_adk.action_tools.validate_token_with_db",
+            new=AsyncMock(return_value=(True, None, SimpleNamespace(user_id="user_1"))),
+        )
+
+    def _pkm_patch(self, index):
+        fake_service = SimpleNamespace(get_index_v2=AsyncMock(return_value=index))
+        return patch(
+            "hushh_mcp.one_adk.action_tools.get_pkm_service",
+            return_value=fake_service,
+        )
+
+    @pytest.mark.asyncio
+    async def test_reads_the_summary_for_a_domain_the_person_has_data_in(self):
+        state = self._authorized_state()
+        index = _FakePkmIndex(
+            available_domains=["financial", "identity"],
+            domain_summaries={"financial": {"holdings_count": 12, "portfolio_value_bucket": "100k-250k"}},
+        )
+        with self._auth_patch(), self._pkm_patch(index):
+            result = await read_my_pkm_domain_summary("financial", _tool_context(state))
+        assert result == {
+            "status": "ok",
+            "result": {
+                "has_data": True,
+                "domain": "financial",
+                "summary": {"holdings_count": 12, "portfolio_value_bucket": "100k-250k"},
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_reports_no_data_rather_than_erroring_for_a_domain_with_none_yet(self):
+        state = self._authorized_state()
+        index = _FakePkmIndex(available_domains=["identity"], domain_summaries={})
+        with self._auth_patch(), self._pkm_patch(index):
+            result = await read_my_pkm_domain_summary("financial", _tool_context(state))
+        assert result == {
+            "status": "ok",
+            "result": {"has_data": False, "domain": "financial", "summary": {}},
+        }
+
+    @pytest.mark.asyncio
+    async def test_normalizes_case_and_whitespace_on_the_spoken_domain(self):
+        state = self._authorized_state()
+        index = _FakePkmIndex(
+            available_domains=["health"], domain_summaries={"health": {"steps_tracked": True}}
+        )
+        with self._auth_patch(), self._pkm_patch(index):
+            result = await read_my_pkm_domain_summary("  Health  ", _tool_context(state))
+        assert result["result"]["domain"] == "health"
+        assert result["result"]["has_data"] is True
+
+    @pytest.mark.asyncio
+    async def test_rejects_an_unknown_domain_and_lists_the_real_ones(self):
+        state = self._authorized_state()
+        with self._auth_patch():
+            result = await read_my_pkm_domain_summary("crypto_wallets", _tool_context(state))
+        assert result["status"] == "failed"
+        assert "financial" in result["message"]
+        assert "health" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_never_reads_back_runtime_secrets_even_if_asked_by_that_exact_key(self):
+        # Credential-shaped domain: excluded regardless of what the model
+        # passes, not filtered after the fact -- see the module-level
+        # _VOICE_UNREADABLE_PKM_DOMAINS comment for why.
+        state = self._authorized_state()
+        with self._auth_patch():
+            result = await read_my_pkm_domain_summary("runtime_secrets", _tool_context(state))
+        assert result["status"] == "failed"
+        assert "runtime_secrets" not in result["message"].split("Available domains: ")[-1]
+
+    @pytest.mark.asyncio
+    async def test_a_db_hiccup_fails_clean_instead_of_killing_the_session(self):
+        state = self._authorized_state()
+        fake_service = SimpleNamespace(
+            get_index_v2=AsyncMock(side_effect=RuntimeError("connection pool exhausted"))
+        )
+        with (
+            self._auth_patch(),
+            patch(
+                "hushh_mcp.one_adk.action_tools.get_pkm_service",
+                return_value=fake_service,
+            ),
+        ):
+            result = await read_my_pkm_domain_summary("financial", _tool_context(state))
+        assert result["status"] == "failed"
+        assert "try again" in result["message"].lower()
 
 
 class TestSettledActionJourneys:

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5479,7 +5479,7 @@
     "cache_manifest": "c7a177decdb319d8a8b673ae16f6acdad5aedee5fc98329d2d58470e1726b4e8",
     "data_plane": "76399599594d347d840307b338dd681728ecaa9583990e32275f6199d3ce2290",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
-    "one_specialist_tools": "057058e172a5de1d044caf02d9cbd6fcf55f2639c910e16b39d9b8d89ded0458",
+    "one_specialist_tools": "ab90748ab570ede34a5b7a59822c6f4837196d51d830ce9e56bcb5c1ddc1ae93",
     "route_index": "e6408b8d2cc074a7ea1c5ae916ffee357ce41d8007d4631002bb46c87e460399",
     "route_layout": "b66933c7083fd755f1a8e4a16262996fc7ae6124a4c550725bfdc7144332355f",
     "surface_map": "dca7d7fc80136e013091555d1c5c39884da5d98898f44274423c5eab490d0cd3",


### PR DESCRIPTION
## Summary

Part of #6433 (voice agent can read and speak any data accessible to the user). Scoped to **PKM domain summaries** specifically -- financial, health, travel, subscriptions, professional, identity, and the rest of the canonical domain registry (~15 domains; \`runtime_secrets\` deliberately excluded, see below). **Live app data** with its own service (Connect's actual connections list, Location's circles) is structurally different and stays out of scope here -- tracked separately as #6441.

## What this does

- New tool \`read_my_pkm_domain_summary(domain, tool_context)\` in \`action_tools.py\`, registered directly on One's root agent (\`agent_tree.py\`) alongside the existing \`list_my_connections\` / \`list_my_location_circles\` read tools.
- **One general tool, not one per domain** -- every PKM domain is read the same way (\`get_index_v2\`'s discovery-only summary index, never decrypted holdings), so adding a new domain later needs no new tool, just its key added to the persona grounding text.
- Not routed through the action-gateway contract system: that system is for actions with a route/\`execution_target\`; this class of "answer a question from data" tool was never wired through it (matching \`list_my_connections\` etc., which aren't either).
- \`runtime_secrets\` is excluded at the source (\`_VOICE_UNREADABLE_PKM_DOMAINS\`), not filtered after the fact -- it's BYOK model credential material, not personal information, and no phrasing of "what do you know about my X" should ever resolve to it.
- Persona grounding text added telling One when to reach for this vs. the existing Location/Connect read tools, and how to handle an unrecognized domain (read back what the tool actually listed, never guess again blind) and a domain with no data yet (say so plainly, not an error).

## Why not \`_read_tool_result\`

That helper's \`call\` is a zero-arg wrapper around a *synchronous* service call (every existing read tool's service method is sync) -- but \`get_index_v2\` is genuinely async. Same shape, same never-let-an-exception-escape-a-live-session reasoning, just awaited instead of called rather than forcing an async path into a sync-only helper.

## Test plan

- [x] 6 new tests in \`test_one_adk_agent_tree.py\` (\`TestReadMyPkmDomainSummary\`): reads a populated domain, reports "no data yet" for an empty one (not an error), normalizes case/whitespace on the spoken domain, rejects an unknown domain with the real list, confirms \`runtime_secrets\` is never offered even if asked for by its exact key, and a DB hiccup fails clean instead of killing the session.
- [x] \`python -m pytest consent-protocol/tests/test_one_adk_agent_tree.py\` -- 219 passed, 1 pre-existing unrelated failure (\`test_normalizes_screen_names\`)
- [x] \`ruff check\` / \`mypy\` on all touched files -- clean