### PR TITLE
fix(one-chat): header controls back to one scale, and the picker built from the design system

### DIFF
--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5492,7 +5492,7 @@
     "one_specialist_tools": "f91a213f8eda5ce9d17b9fed0062e77e0c3e8faca7786f1a7a7b9810ebe6002f",
     "route_index": "e6408b8d2cc074a7ea1c5ae916ffee357ce41d8007d4631002bb46c87e460399",
     "route_layout": "b66933c7083fd755f1a8e4a16262996fc7ae6124a4c550725bfdc7144332355f",
-    "surface_map": "2e9b4860e13b5a2adae246e5d5482dc1c822195f7064f12764bd78691e35c970",
+    "surface_map": "f5fffd96f19e2c2e949c47840a815f87c0fa0936eff7a50cc9c7a180590ba7b3",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },

--- a/hushh-webapp/__tests__/agent/puppy-jobs-route.test.ts
+++ b/hushh-webapp/__tests__/agent/puppy-jobs-route.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GET, POST } from "@/app/api/hermes/jobs/route";
+
+/**
+ * The switch that turns Puppy One's scheduled work on and off.
+ *
+ * This route holds the loopback bearer key, which is host remote-code-execution,
+ * and it changes what the owner's machine does while nobody is watching. Three
+ * of these tests exist because the first version got them wrong, and one was
+ * caught only by running the toggle against the real gateway.
+ */
+
+const ORIGINAL_ENV = { ...process.env };
+const SAME_ORIGIN = { "sec-fetch-site": "same-origin", "content-type": "application/json" };
+
+function post(body: unknown, headers: Record<string, string> = SAME_ORIGIN) {
+  return POST(
+    new Request("http://localhost/api/hermes/jobs", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers,
+    }) as never,
+  );
+}
+
+function gatewayJob(over: Record<string, unknown> = {}) {
+  return {
+    id: "6238fa10fe8b",
+    name: "WhatsApp Session Janitor (weekly)",
+    state: "scheduled",
+    schedule_display: "0 5 * * 0",
+    next_run_at: "2026-09-06T05:00:00-07:00",
+    last_status: "ok",
+    failure_streak: 0,
+    // Everything below must never reach the browser.
+    prompt: "SECRET INSTRUCTIONS",
+    api_key: "sk-secret",
+    workdir: "/Users/owner/private",
+    ...over,
+  };
+}
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("GET /api/hermes/jobs", () => {
+  it("asks for the disabled ones too, or a paused job could never be switched back on", async () => {
+    process.env.HERMES_API_SERVER_KEY = "k";
+    const sent = vi.fn(async () => Response.json({ jobs: [gatewayJob()] }));
+    vi.stubGlobal("fetch", sent);
+
+    await GET(new Request("http://localhost/api/hermes/jobs") as never);
+
+    // Measured against the live gateway: without this the job VANISHED from the
+    // list the moment it was paused, and its id had to be recovered from disk.
+    expect(String(sent.mock.calls[0][0])).toContain("include_disabled=true");
+  });
+
+  it("never passes the gateway's row through", async () => {
+    process.env.HERMES_API_SERVER_KEY = "k";
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({ jobs: [gatewayJob()] })));
+
+    const body = await (await GET(new Request("http://localhost/api/hermes/jobs") as never)).json();
+
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain("SECRET INSTRUCTIONS");
+    expect(serialized).not.toContain("sk-secret");
+    expect(serialized).not.toContain("/Users/owner/private");
+    expect(body.jobs[0]).toEqual({
+      id: "6238fa10fe8b",
+      name: "WhatsApp Session Janitor (weekly)",
+      schedule: "0 5 * * 0",
+      paused: false,
+      nextRunAt: "2026-09-06T05:00:00-07:00",
+      lastStatus: "ok",
+      lastError: null,
+      failureStreak: 0,
+    });
+  });
+
+  it("reads paused from the scheduler's own word for it", async () => {
+    process.env.HERMES_API_SERVER_KEY = "k";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ jobs: [gatewayJob({ state: "paused" })] })),
+    );
+
+    const body = await (await GET(new Request("http://localhost/api/hermes/jobs") as never)).json();
+    expect(body.jobs[0].paused).toBe(true);
+  });
+
+  it("treats not-configured and unreachable as calm states", async () => {
+    delete process.env.HERMES_API_SERVER_KEY;
+    const off = await (await GET(new Request("http://localhost/api/hermes/jobs") as never)).json();
+    expect(off.configured).toBe(false);
+    expect(off.jobs).toEqual([]);
+
+    process.env.HERMES_API_SERVER_KEY = "k";
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("ECONNREFUSED"); }));
+    const down = await (await GET(new Request("http://localhost/api/hermes/jobs") as never)).json();
+    expect(down).toMatchObject({ configured: true, reachable: false, jobs: [] });
+  });
+});
+
+describe("POST /api/hermes/jobs", () => {
+  it("refuses a job id that is not a job id", async () => {
+    process.env.HERMES_API_SERVER_KEY = "k";
+    const sent = vi.fn();
+    vi.stubGlobal("fetch", sent);
+
+    // encodeURIComponent leaves "." alone, so ".." would still climb out of
+    // /api/jobs/{id}/{action} and post to a different gateway endpoint.
+    for (const id of ["..", "../../v1/runs", "a/b", ""]) {
+      const response = await post({ id, action: "pause" });
+      expect(response.status, id).toBe(400);
+    }
+    expect(sent).not.toHaveBeenCalled();
+  });
+
+  it("refuses an action outside pause and resume", async () => {
+    process.env.HERMES_API_SERVER_KEY = "k";
+    const sent = vi.fn();
+    vi.stubGlobal("fetch", sent);
+
+    for (const action of ["delete", "run", "../run", "pause/../run", ""]) {
+      expect((await post({ id: "6238fa10fe8b", action })).status, action).toBe(400);
+    }
+    expect(sent).not.toHaveBeenCalled();
+  });
+
+  it("normalises case and whitespace rather than refusing them", async () => {
+    process.env.HERMES_API_SERVER_KEY = "k";
+    const sent = vi.fn(async () => Response.json({ job: gatewayJob({ state: "paused" }) }));
+    vi.stubGlobal("fetch", sent);
+
+    // Safe because the result is checked against a closed set before it is
+    // used; the alternative is refusing a caller for their capitalisation.
+    const body = await (await post({ id: "6238fa10fe8b", action: " PAUSE " })).json();
+
+    expect(body.ok).toBe(true);
+    expect(String(sent.mock.calls[0][0])).toContain("/pause");
+  });
+
+  it("refuses a cross-site request", async () => {
+    process.env.HERMES_API_SERVER_KEY = "k";
+    const sent = vi.fn();
+    vi.stubGlobal("fetch", sent);
+
+    const response = await post(
+      { id: "6238fa10fe8b", action: "pause" },
+      { "sec-fetch-site": "cross-site", "content-type": "application/json" },
+    );
+
+    // The route adds a host-RCE key server-side and runs on a port any page can
+    // reach; a site the owner merely visits must not be able to stop their work.
+    expect(response.status).toBe(403);
+    expect(sent).not.toHaveBeenCalled();
+  });
+
+  it("does not call a 2xx refusal a success", async () => {
+    process.env.HERMES_API_SERVER_KEY = "k";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ ok: false, error: "Job is mid-run." })),
+    );
+
+    const body = await (await post({ id: "6238fa10fe8b", action: "pause" })).json();
+
+    // A 2xx is the gateway answering, not agreeing. Reading the status alone
+    // would render the switch as flipped when nothing changed.
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("mid-run");
+  });
+
+  it("passes a valid toggle through and reports the job back", async () => {
+    process.env.HERMES_API_SERVER_KEY = "k";
+    const sent = vi.fn(async () =>
+      Response.json({ job: gatewayJob({ state: "paused" }) }),
+    );
+    vi.stubGlobal("fetch", sent);
+
+    const body = await (await post({ id: "6238fa10fe8b", action: "pause" })).json();
+
+    expect(String(sent.mock.calls[0][0])).toContain("/api/jobs/6238fa10fe8b/pause");
+    expect(body).toMatchObject({ ok: true, action: "pause" });
+    expect(body.job.paused).toBe(true);
+    expect(JSON.stringify(body)).not.toContain("SECRET INSTRUCTIONS");
+  });
+});

--- a/hushh-webapp/__tests__/agent/puppy-jobs-service.test.ts
+++ b/hushh-webapp/__tests__/agent/puppy-jobs-service.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fetchPuppyJobs,
+  setPuppyJobPaused,
+} from "@/lib/services/puppy-one-service";
+
+/**
+ * The jobs half of the Puppy One service.
+ *
+ * Both calls have the same duty as the readings: never throw. A machine with
+ * no agent answering is the ordinary case on this route, not an exception,
+ * and a surface that has to catch would grow its own flavour of "broken" for
+ * a state that is not broken at all.
+ *
+ * The second duty is narrower and easier to lose: `jobs` is ALWAYS an array.
+ * A caller rendering a list must never have to decide what a missing array
+ * means, and "no jobs" must stay distinguishable from "could not ask".
+ */
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function jsonResponse(body: unknown, ok = true) {
+  return { ok, json: async () => body };
+}
+
+describe("fetchPuppyJobs", () => {
+  it("passes the gateway's list through", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        configured: true,
+        reachable: true,
+        jobs: [
+          {
+            id: "auto-dream",
+            name: "Auto-Dream",
+            schedule: "10 3 * * *",
+            paused: false,
+            nextRunAt: "2026-09-03T03:10:00-07:00",
+            lastStatus: "ok",
+            lastError: null,
+            failureStreak: 0,
+          },
+        ],
+      }),
+    );
+
+    const result = await fetchPuppyJobs();
+    expect(result.configured).toBe(true);
+    expect(result.reachable).toBe(true);
+    expect(result.jobs).toHaveLength(1);
+    expect(result.jobs[0]?.name).toBe("Auto-Dream");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/hermes/jobs",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+  });
+
+  it("keeps not-configured intact, with an array to render", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        configured: false,
+        reason: "not_configured",
+        message: "Set HERMES_API_SERVER_KEY to see Puppy One's scheduled work.",
+      }),
+    );
+
+    const result = await fetchPuppyJobs();
+    expect(result.configured).toBe(false);
+    expect(result.reason).toBe("not_configured");
+    // Absent upstream, still an array here: "no jobs" is the caller's
+    // simplest case and it should not have to guard for undefined.
+    expect(result.jobs).toEqual([]);
+  });
+
+  it("reads a refused or unreachable route as unreachable, never as zero jobs", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, false));
+    expect(await fetchPuppyJobs()).toEqual({
+      configured: true,
+      reachable: false,
+      jobs: [],
+    });
+
+    fetchMock.mockRejectedValue(new Error("connection refused"));
+    expect(await fetchPuppyJobs()).toEqual({
+      configured: true,
+      reachable: false,
+      jobs: [],
+    });
+  });
+});
+
+describe("setPuppyJobPaused", () => {
+  it("asks for the action the caller's boolean means", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true, id: "x", action: "pause" }));
+
+    const result = await setPuppyJobPaused({ id: "x", paused: true });
+    expect(result.ok).toBe(true);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      id: "x",
+      action: "pause",
+    });
+
+    await setPuppyJobPaused({ id: "x", paused: false });
+    const [, resumeInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(JSON.parse(String(resumeInit.body))).toEqual({
+      id: "x",
+      action: "resume",
+    });
+  });
+
+  it("carries the route's own refusal through", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        { ok: false, error: "Pass a job id and either pause or resume." },
+        false,
+      ),
+    );
+    expect(await setPuppyJobPaused({ id: "", paused: true })).toEqual({
+      ok: false,
+      error: "Pass a job id and either pause or resume.",
+    });
+  });
+
+  it("never throws at an unreachable machine, and never claims success", async () => {
+    fetchMock.mockRejectedValue(new Error("connection refused"));
+    expect(await setPuppyJobPaused({ id: "x", paused: true })).toEqual({
+      ok: false,
+      error: "Puppy One is not answering on this machine.",
+    });
+
+    // A 200 with no `ok` is not an agreement. Anything short of an explicit
+    // yes leaves the caller free to keep showing the job's real state.
+    fetchMock.mockResolvedValue(jsonResponse({}));
+    expect(await setPuppyJobPaused({ id: "x", paused: false })).toEqual({
+      ok: false,
+      error: "Puppy One could not change that job.",
+    });
+  });
+});

--- a/hushh-webapp/__tests__/agent/puppy-machine-sheet.test.tsx
+++ b/hushh-webapp/__tests__/agent/puppy-machine-sheet.test.tsx
@@ -6,20 +6,34 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   fetchPuppyResources: vi.fn(),
+  fetchPuppyJobs: vi.fn(),
+  setPuppyJobPaused: vi.fn(),
 }));
 
 vi.mock("@/lib/services/puppy-one-service", async (importOriginal) => {
   const original =
     await importOriginal<typeof import("@/lib/services/puppy-one-service")>();
-  return { ...original, fetchPuppyResources: mocks.fetchPuppyResources };
+  return {
+    ...original,
+    fetchPuppyResources: mocks.fetchPuppyResources,
+    fetchPuppyJobs: mocks.fetchPuppyJobs,
+    setPuppyJobPaused: mocks.setPuppyJobPaused,
+  };
 });
 
-import { PuppyMachineSheet } from "@/components/agent/puppy-resource-monitor";
-import type { PuppyResources } from "@/lib/services/puppy-one-service";
+import {
+  MACHINE_PANEL_SHEET_QUERY,
+  PuppyMachineSheet,
+} from "@/components/agent/puppy-resource-monitor";
+import type {
+  PuppyJob,
+  PuppyJobs,
+  PuppyResources,
+} from "@/lib/services/puppy-one-service";
 
 /**
  * The readings are the owner's to ask for.
@@ -30,9 +44,30 @@ import type { PuppyResources } from "@/lib/services/puppy-one-service";
  *     reading keeps saying "healthy" while a machine's login is gone, so the
  *     one fact that cannot be inferred from the rest is the one fact that
  *     cannot be put behind a tap.
- *  2. A shut sheet is silent. Nothing repeats against the local gateway while
+ *  2. A shut panel is silent. Nothing repeats against the local gateway while
  *     nobody is looking at the answer.
+ *
+ * `__tests__/setup.ts` stubs `matchMedia` as permanently non-matching, which
+ * is the desktop answer; the phone lane restubs it per test.
  */
+
+/** Answers only the panel's own breakpoint, and only as this test wants. */
+function setViewport(kind: "phone" | "desktop") {
+  const wantsSheet = kind === "phone";
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === MACHINE_PANEL_SHEET_QUERY ? wantsSheet : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
 
 function mount(payload: PuppyResources) {
   mocks.fetchPuppyResources.mockResolvedValue(payload);
@@ -42,6 +77,15 @@ function mount(payload: PuppyResources) {
 function trigger() {
   return screen.getByRole("button", { name: /this machine/i });
 }
+
+beforeEach(() => {
+  setViewport("desktop");
+  mocks.fetchPuppyJobs.mockResolvedValue({
+    configured: true,
+    reachable: true,
+    jobs: [],
+  } satisfies PuppyJobs);
+});
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -279,5 +323,335 @@ describe("PuppyMachineSheet", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+function job(overrides: Partial<PuppyJob> = {}): PuppyJob {
+  return {
+    id: "job",
+    name: "A job",
+    schedule: null,
+    paused: false,
+    nextRunAt: null,
+    lastStatus: null,
+    lastError: null,
+    failureStreak: 0,
+    ...overrides,
+  };
+}
+
+/** An ISO stamp `minutes` from now, nudged so rounding cannot land short. */
+function inMinutes(minutes: number): string {
+  return new Date(Date.now() + minutes * 60_000 + 2_000).toISOString();
+}
+
+async function openWithJobs(jobs: PuppyJob[] | PuppyJobs) {
+  mocks.fetchPuppyJobs.mockResolvedValue(
+    Array.isArray(jobs) ? { configured: true, reachable: true, jobs } : jobs,
+  );
+  mount({ configured: true, reachable: true, agent: { model: "m" } });
+  fireEvent.click(await screen.findByRole("button", { name: /this machine/i }));
+  return screen.findByRole("dialog");
+}
+
+/**
+ * A bottom sheet is the phone's container, not the desktop's.
+ *
+ * The assertion is about WHICH surface opened, not how it looks: both are
+ * `role="dialog"`, so the data-slot each primitive stamps is the only honest
+ * way to tell a sheet from a dialog. And exactly one exists, because two
+ * mounted copies would be two lists of switches over one machine.
+ */
+describe("PuppyMachineSheet container", () => {
+  const READINGS: PuppyResources = {
+    configured: true,
+    reachable: true,
+    agent: { model: "m", on_device: true, on_device_gate: true },
+    machine: { ram_used_pct: 41.2 },
+  };
+
+  it("opens the centred dialog on a desktop, never the bottom sheet", async () => {
+    setViewport("desktop");
+    mount(READINGS);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /this machine/i }),
+    );
+
+    await screen.findByRole("dialog");
+    expect(
+      document.querySelectorAll('[data-slot="dialog-content"]'),
+    ).toHaveLength(1);
+    expect(
+      document.querySelectorAll('[data-slot="sheet-content"]'),
+    ).toHaveLength(0);
+    expect(screen.getByText("On this machine")).toBeInTheDocument();
+    expect(screen.getByText("41% used")).toBeInTheDocument();
+  });
+
+  it("keeps the bottom sheet on a phone", async () => {
+    setViewport("phone");
+    mount(READINGS);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /this machine/i }),
+    );
+
+    await screen.findByRole("dialog");
+    expect(
+      document.querySelectorAll('[data-slot="sheet-content"]'),
+    ).toHaveLength(1);
+    expect(
+      document.querySelectorAll('[data-slot="dialog-content"]'),
+    ).toHaveLength(0);
+    expect(screen.getByText("On this machine")).toBeInTheDocument();
+  });
+
+  it("mounts the panel once, inside one container", async () => {
+    setViewport("desktop");
+    const panel = await openWithJobs([
+      job({ id: "auto-dream", name: "Auto-Dream" }),
+    ]);
+
+    expect(
+      await within(panel).findAllByRole("switch", { name: "Auto-Dream" }),
+    ).toHaveLength(1);
+    expect(
+      document.querySelectorAll('section[aria-label="Puppy One machine"]'),
+    ).toHaveLength(1);
+  });
+});
+
+/**
+ * The scheduled work, and the switch for each job.
+ *
+ * The switch is the part that has to be exactly right. It shows what the
+ * GATEWAY says the job is doing -- never a local guess -- so it cannot appear
+ * to have flipped before the machine agreed, and a refusal leaves the job
+ * where it was rather than leaving a lie on the screen.
+ */
+describe("PuppyMachineSheet scheduled work", () => {
+  it("reads the jobs when the panel opens, and never while it is shut", async () => {
+    mount({ configured: true, reachable: true, agent: { model: "m" } });
+    await waitFor(() =>
+      expect(mocks.fetchPuppyResources).toHaveBeenCalledTimes(1),
+    );
+    // The readings take one shut reading, for the link banner. The jobs have
+    // no such duty, so nobody asked the gateway anything about them.
+    expect(mocks.fetchPuppyJobs).not.toHaveBeenCalled();
+
+    fireEvent.click(trigger());
+    await waitFor(() => expect(mocks.fetchPuppyJobs).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(120_000);
+      });
+      expect(mocks.fetchPuppyJobs).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("says the schedule in words, when it next runs, and that the last run was ok", async () => {
+    const panel = await openWithJobs([
+      job({
+        id: "auto-dream",
+        name: "Auto-Dream",
+        schedule: "10 3 * * *",
+        nextRunAt: inMinutes(13 * 60),
+        lastStatus: "ok",
+      }),
+    ]);
+
+    expect(await within(panel).findByText("Auto-Dream")).toBeInTheDocument();
+    expect(
+      within(panel).getByText("Daily at 03:10 · next in 13 h · last run ok"),
+    ).toBeInTheDocument();
+    expect(
+      within(panel).getByRole("switch", { name: "Auto-Dream" }),
+    ).toBeChecked();
+  });
+
+  it("translates only the cron it can translate exactly, and prints the rest verbatim", async () => {
+    const panel = await openWithJobs([
+      job({ id: "doctor", name: "Doctor", schedule: "*/15 * * * *" }),
+      job({ id: "board", name: "Board sync", schedule: "0 9 * * 1" }),
+      job({ id: "sheet", name: "Timesheet", schedule: "30 6 1 * *" }),
+      job({ id: "wiki", name: "Wiki", schedule: "15 * * * *" }),
+      job({ id: "sync", name: "Board sync", schedule: "0 */6 * * *" }),
+      // Not five fields, and a shape with more than one reading: each is said
+      // as it stands, because a schedule described wrongly is the sentence
+      // someone would act on.
+      job({ id: "loop", name: "Loop", schedule: "every 30m" }),
+      job({ id: "odd", name: "Odd", schedule: "0 9 * * MON-FRI" }),
+    ]);
+
+    expect(await within(panel).findByText("Every 15 min")).toBeInTheDocument();
+    expect(within(panel).getByText("Mondays at 09:00")).toBeInTheDocument();
+    expect(
+      within(panel).getByText("Monthly on the 1st at 06:30"),
+    ).toBeInTheDocument();
+    expect(within(panel).getByText("Hourly at :15")).toBeInTheDocument();
+    expect(within(panel).getByText("Every 6 h at :00")).toBeInTheDocument();
+    expect(within(panel).getByText("every 30m")).toBeInTheDocument();
+    expect(within(panel).getByText("0 9 * * MON-FRI")).toBeInTheDocument();
+  });
+
+  it("marks a failing job in words and a glyph, not only in colour", async () => {
+    const panel = await openWithJobs([
+      job({
+        id: "doctor",
+        name: "Self-Healing Doctor",
+        schedule: "*/15 * * * *",
+        nextRunAt: inMinutes(14),
+        lastStatus: "error",
+        lastError: "gateway timeout after 30s",
+        failureStreak: 3,
+      }),
+      job({ id: "healthy", name: "Board sync", lastStatus: "ok" }),
+    ]);
+
+    expect(
+      await within(panel).findByText("Failed 3 runs in a row"),
+    ).toBeInTheDocument();
+    // The machine's own words, not ours.
+    expect(
+      within(panel).getByText("gateway timeout after 30s"),
+    ).toBeInTheDocument();
+    expect(
+      within(panel).getByText("Every 15 min · next in 14 min"),
+    ).toBeInTheDocument();
+    // A healthy job wears none of it.
+    expect(within(panel).getByText("last run ok")).toBeInTheDocument();
+  });
+
+  it("reads a paused job as deliberately off, not as a fault", async () => {
+    const panel = await openWithJobs([
+      job({
+        id: "janitor",
+        name: "WhatsApp Janitor",
+        schedule: "0 9 * * 1",
+        paused: true,
+        nextRunAt: inMinutes(60),
+      }),
+    ]);
+
+    expect(
+      await within(panel).findByText("Mondays at 09:00 · Paused"),
+    ).toBeInTheDocument();
+    expect(
+      within(panel).getByRole("switch", { name: "WhatsApp Janitor" }),
+    ).not.toBeChecked();
+    // Nothing about a paused job is an error.
+    expect(within(panel).queryByText(/Failed/)).not.toBeInTheDocument();
+    expect(
+      within(panel).queryByText("Last run failed"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("holds the switch at the gateway's answer until the gateway answers", async () => {
+    let settle: (value: { ok: boolean }) => void = () => {};
+    mocks.setPuppyJobPaused.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settle = resolve;
+        }),
+    );
+    const running = job({ id: "auto-dream", name: "Auto-Dream" });
+    const panel = await openWithJobs([running]);
+    const control = await within(panel).findByRole("switch", {
+      name: "Auto-Dream",
+    });
+
+    fireEvent.click(control);
+    await waitFor(() =>
+      expect(mocks.setPuppyJobPaused).toHaveBeenCalledWith({
+        id: "auto-dream",
+        paused: true,
+      }),
+    );
+    // Still ON, and refusing a second request: nothing has agreed yet.
+    expect(control).toBeChecked();
+    expect(control).toBeDisabled();
+    fireEvent.click(control);
+    expect(mocks.setPuppyJobPaused).toHaveBeenCalledTimes(1);
+
+    // The list is re-read rather than guessed at.
+    mocks.fetchPuppyJobs.mockResolvedValue({
+      configured: true,
+      reachable: true,
+      jobs: [{ ...running, paused: true }],
+    });
+    await act(async () => {
+      settle({ ok: true });
+    });
+    await waitFor(() => expect(mocks.fetchPuppyJobs).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("switch", { name: "Auto-Dream" }),
+      ).not.toBeChecked(),
+    );
+  });
+
+  it("keeps the real state when the machine refuses, and says why", async () => {
+    mocks.setPuppyJobPaused.mockResolvedValue({
+      ok: false,
+      error: "Puppy One is not answering on this machine.",
+    });
+    const panel = await openWithJobs([
+      job({ id: "auto-dream", name: "Auto-Dream" }),
+    ]);
+    const control = await within(panel).findByRole("switch", {
+      name: "Auto-Dream",
+    });
+
+    fireEvent.click(control);
+
+    expect(
+      await within(panel).findByText(
+        "Puppy One is not answering on this machine.",
+      ),
+    ).toBeInTheDocument();
+    // The job never stopped running, so the switch never stopped saying so.
+    const after = within(panel).getByRole("switch", { name: "Auto-Dream" });
+    expect(after).toBeChecked();
+    expect(after).toBeEnabled();
+    // A refused change is not a reason to re-read a list that did not change.
+    expect(mocks.fetchPuppyJobs).toHaveBeenCalledTimes(1);
+  });
+
+  it("says a machine with no key set what to set, rather than showing an empty box", async () => {
+    const panel = await openWithJobs({
+      configured: false,
+      reason: "not_configured",
+      message: "Set HERMES_API_SERVER_KEY to see Puppy One's scheduled work.",
+      jobs: [],
+    });
+    expect(
+      await within(panel).findByText(
+        "Set HERMES_API_SERVER_KEY to see Puppy One's scheduled work.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("says so when the jobs probe did not answer", async () => {
+    const panel = await openWithJobs({
+      configured: true,
+      reachable: false,
+      jobs: [],
+    });
+    expect(
+      await within(panel).findByText(
+        "Puppy One did not answer about its scheduled work.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("says so when the machine has nothing scheduled", async () => {
+    const panel = await openWithJobs([]);
+    expect(
+      await within(panel).findByText("Nothing is scheduled on this machine."),
+    ).toBeInTheDocument();
   });
 });

--- a/hushh-webapp/app/api/hermes/jobs/route.ts
+++ b/hushh-webapp/app/api/hermes/jobs/route.ts
@@ -1,0 +1,212 @@
+import { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+import { isSameOriginRequest, resolveHermesBridgeConfig } from "@/lib/hermes/bridge-config";
+import { resolveRequestId, withRequestIdJson } from "@/app/api/_utils/request-id";
+
+/**
+ * The work Puppy One does on a schedule, and the switch for each one.
+ *
+ * These are the jobs that run on the owner's machine whether or not anyone is
+ * watching: the nightly memory consolidation, the wiki and board syncs, the
+ * self-healing doctor. Until now the only way to see or stop one was a slash
+ * command, so a job that had started misbehaving overnight could not be turned
+ * off from the surface that shows it running.
+ *
+ * Server-side only, like every route in this folder: the loopback bearer key
+ * is host remote-code-execution and never reaches the browser.
+ */
+
+export interface PuppyJob {
+  id: string;
+  name: string;
+  schedule: string | null;
+  paused: boolean;
+  nextRunAt: string | null;
+  lastStatus: string | null;
+  lastError: string | null;
+  failureStreak: number;
+}
+
+/** Pausing and resuming only. Deleting or editing a job is not a toggle. */
+const ACTIONS = new Set(["pause", "resume"]);
+
+/**
+ * A job id as the scheduler writes them: hex, or a dated run id.
+ *
+ * Validated by shape rather than escaped, because the id becomes a PATH
+ * SEGMENT on the local gateway. `encodeURIComponent` leaves `.` untouched, so
+ * an id of ".." would still traverse out of `/api/jobs/{id}/{action}` and post
+ * to a different endpoint entirely. An allowlist cannot be talked around.
+ */
+const JOB_ID = /^[A-Za-z0-9_-]{1,64}$/;
+
+function text(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function toJob(raw: unknown): PuppyJob | null {
+  const row = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  const id = text(row.id);
+  if (!id) return null;
+  const schedule =
+    row.schedule && typeof row.schedule === "object"
+      ? (row.schedule as Record<string, unknown>)
+      : {};
+  return {
+    id,
+    name: text(row.name) ?? id,
+    schedule:
+      text(row.schedule_display) ?? text(schedule.display) ?? text(schedule.expr),
+    // `state` is the scheduler's own word for it. A job is off when it says
+    // paused, not when some other field is falsy.
+    paused: text(row.state) === "paused",
+    nextRunAt: text(row.next_run_at),
+    lastStatus: text(row.last_status),
+    // Surfaced because a job that reports "ok" while its delivery fails is the
+    // exact case the owner needs to see; both errors are worth showing.
+    lastError: text(row.last_error) ?? text(row.last_delivery_error),
+    failureStreak:
+      typeof row.failure_streak === "number" && row.failure_streak > 0
+        ? Math.floor(row.failure_streak)
+        : 0,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const requestId = resolveRequestId(request);
+  const config = resolveHermesBridgeConfig();
+  if (!config) {
+    return withRequestIdJson(
+      requestId,
+      {
+        configured: false,
+        reason: "not_configured",
+        jobs: [],
+        message: "Set HERMES_API_SERVER_KEY to see Puppy One's scheduled work.",
+      },
+      { status: 200 },
+    );
+  }
+
+  let upstream: Response;
+  try {
+    // include_disabled=true is load-bearing, not a nicety. The gateway hides
+    // paused jobs by default, so without it a job vanished from this list the
+    // moment it was switched off and there was no way left to switch it back
+    // on. A control that can only be moved one way is not a switch.
+    upstream = await fetch(`${config.baseUrl}/api/jobs?include_disabled=true`, {
+      headers: { Authorization: `Bearer ${config.apiKey}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {
+    return withRequestIdJson(
+      requestId,
+      { configured: true, reachable: false, jobs: [] },
+      { status: 200 },
+    );
+  }
+  if (!upstream.ok) {
+    return withRequestIdJson(
+      requestId,
+      { configured: true, reachable: false, jobs: [] },
+      { status: 200 },
+    );
+  }
+
+  const payload = (await upstream.json().catch(() => ({}))) as { jobs?: unknown };
+  // Mapped field by field on purpose. The gateway's row carries the job's full
+  // prompt, its model credentials and its working directory; none of that is
+  // the browser's business, and passing the row through would ship all of it.
+  const jobs = (Array.isArray(payload.jobs) ? payload.jobs : [])
+    .map(toJob)
+    .filter((job): job is PuppyJob => job !== null);
+
+  return withRequestIdJson(
+    requestId,
+    { jobs, configured: true, reachable: true },
+    { status: 200 },
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const requestId = resolveRequestId(request);
+  const config = resolveHermesBridgeConfig();
+  if (!config) {
+    return withRequestIdJson(
+      requestId,
+      { ok: false, error: "Set HERMES_API_SERVER_KEY to change Puppy One's schedule." },
+      { status: 200 },
+    );
+  }
+
+  if (!isSameOriginRequest(request)) {
+    // This route holds the loopback key and changes what the owner's machine
+    // does on a schedule. A page they merely visit must not be able to reach it.
+    return withRequestIdJson(
+      requestId,
+      { ok: false, error: "Cross-site requests cannot change Puppy One's schedule." },
+      { status: 403 },
+    );
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+  const id = text(body.id);
+  const action = text(body.action)?.toLowerCase();
+  if (!id || !JOB_ID.test(id) || !action || !ACTIONS.has(action)) {
+    // Both are allowlisted rather than forwarded: each becomes a path segment
+    // on the local gateway, so an unrecognised value is a request to somewhere
+    // this route does not intend to go.
+    return withRequestIdJson(
+      requestId,
+      { ok: false, error: "Pass a job id and either pause or resume.", accepted: [...ACTIONS] },
+      { status: 400 },
+    );
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(
+      `${config.baseUrl}/api/jobs/${encodeURIComponent(id)}/${action}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+  } catch {
+    return withRequestIdJson(
+      requestId,
+      { ok: false, error: "Puppy One is not answering on this machine." },
+      { status: 200 },
+    );
+  }
+  if (!upstream.ok) {
+    return withRequestIdJson(
+      requestId,
+      { ok: false, error: "Puppy One could not change that job." },
+      { status: 200 },
+    );
+  }
+
+  const result = (await upstream.json().catch(() => ({}))) as Record<string, unknown>;
+  // A 2xx is the gateway answering, not the gateway agreeing. It reports a
+  // refusal in the body, and reading only the status turned a soft "no" into a
+  // success the switch would then render as done.
+  if (result.ok === false || text(result.error)) {
+    return withRequestIdJson(
+      requestId,
+      { ok: false, error: text(result.error) ?? "Puppy One did not change that job." },
+      { status: 200 },
+    );
+  }
+  return withRequestIdJson(
+    requestId,
+    { ok: true, id, action, job: toJob(result.job ?? result) },
+    { status: 200 },
+  );
+}

--- a/hushh-webapp/app/api/hermes/models/route.ts
+++ b/hushh-webapp/app/api/hermes/models/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
 
-import { resolveHermesBridgeConfig } from "@/lib/hermes/bridge-config";
+import { isSameOriginRequest, resolveHermesBridgeConfig } from "@/lib/hermes/bridge-config";
 
 /**
  * The Puppy One model picker, proxied to the local Hermes api_server.
@@ -197,6 +197,16 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  if (!isSameOriginRequest(request)) {
+    // Pinning a model changes which model answers on the owner's machine, and
+    // this route adds the loopback key server-side. Without this check a page
+    // the owner merely visits could repoint their agent off-device.
+    return Response.json(
+      { ok: false, error: "Cross-site requests cannot change the model." },
+      { status: 403 },
+    );
+  }
+
   const config = resolveHermesBridgeConfig();
   if (!config) return notConfigured();
 

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -40,7 +40,13 @@ import remarkGfm from "remark-gfm";
 
 import { Button } from "@/components/ui/button";
 import { AgentHistorySidebar } from "@/components/agent/agent-history-sidebar";
-import { SegmentedTabs } from "@/lib/morphy-ux/ui/segmented-tabs";
+import { SegmentedControl } from "@/lib/morphy-ux/ui/segmented-control";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
 import { EmailDraftCard } from "@/components/agent/email-draft-card";
 import {
   EmailDeliveryHistoryCard,
@@ -4885,35 +4891,27 @@ export function AgentChatWorkspace({
 
             <div className="flex shrink-0 items-center gap-2">
               {/*
-                The app's own segmented control, not a hand-rolled pair of
-                pills. The first version animated `transition-colors` only, so
-                switching agents snapped where every other tab strip in the app
-                eases: this primitive transitions background, border, shadow and
-                colour together over 150ms, and carries the tablist semantics
-                (aria-selected, roving tabIndex) that a pair of buttons does not.
+                The compact segmented control at header scale. The full-width
+                filter primitive was tried here first and stood ~44px tall
+                against 36px icon buttons, so the header stopped lining up.
+                This one is h-8 with an eased sliding transition, which is the
+                animation the toggle was always missing.
               */}
-              <SegmentedTabs
-                ariaLabel="Agent"
+              <SegmentedControl
+                variant="compact"
+                size="sm"
                 value={agentSurface}
                 onValueChange={(next) => setAgentSurface(next as AgentChatSurface)}
                 options={[
-                  { value: "one", label: "One", accessibleLabel: "One, your cloud agent" },
-                  {
-                    value: "puppy",
-                    label: "Puppy",
-                    accessibleLabel: "Puppy One, on your machine, with its own conversation",
-                  },
+                  { value: "one", label: "One" },
+                  { value: "puppy", label: "Puppy" },
                 ]}
-                className="w-auto min-h-9 shrink-0"
+                className="w-auto shrink-0"
               />
               {modelPreference && modelPreference.choices.length > 1 ? (
-                <select
-                  data-testid="agent-chat-model-picker"
-                  aria-label="Model"
-                  title={`Running ${modelPreference.effective_model}`}
+                <Select
                   value={modelPreference.effective_model}
-                  onChange={(event) => {
-                    const nextModel = event.target.value;
+                  onValueChange={(nextModel) => {
                     const previous = modelPreference;
                     // Optimistic: the picker must not stall the header while the
                     // write lands. A failure restores exactly what was showing.
@@ -4931,14 +4929,33 @@ export function AgentChatWorkspace({
                       }
                     })();
                   }}
-                  className="hidden h-7 max-w-[9.5rem] shrink-0 truncate rounded-full bg-foreground/[0.045] px-2 text-[11px] font-medium text-muted-foreground outline-none transition-colors hover:text-foreground sm:block"
                 >
-                  {modelPreference.choices.map((choice) => (
-                    <option key={choice.model_id} value={choice.model_id}>
-                      {choice.label}
-                    </option>
-                  ))}
-                </select>
+                  <SelectTrigger
+                    data-testid="agent-chat-model-picker"
+                    aria-label="Model"
+                    title={`Running ${modelPreference.effective_model}`}
+                    className="h-8 w-auto max-w-[7.5rem] shrink-0 gap-1 rounded-full border-0 bg-foreground/[0.045] px-2.5 text-[11px] font-medium text-muted-foreground sm:max-w-[9.5rem]"
+                  >
+                    {/* "3.8 Flash", not "Gemini 3.8 Flash": every option is a
+                        Gemini, so the shared word is the one thing a narrow
+                        header cannot afford. The full label stays in the menu
+                        and in the tooltip. */}
+                    <span className="truncate">
+                      {(
+                        modelPreference.choices.find(
+                          (choice) => choice.model_id === modelPreference.effective_model,
+                        )?.label ?? modelPreference.effective_model
+                      ).replace(/^Gemini\s+/i, "")}
+                    </span>
+                  </SelectTrigger>
+                  <SelectContent align="end">
+                    {modelPreference.choices.map((choice) => (
+                      <SelectItem key={choice.model_id} value={choice.model_id}>
+                        {choice.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               ) : null}
               {/* A fixed slot, always present. This used to mount and unmount
                   with the status, and because the cluster is shrink-0 the whole

--- a/hushh-webapp/components/agent/puppy-resource-monitor.tsx
+++ b/hushh-webapp/components/agent/puppy-resource-monitor.tsx
@@ -3,12 +3,21 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
+  useSyncExternalStore,
   type ReactNode,
 } from "react";
 import { AlertTriangle, Cloud, Cpu, Loader2 } from "lucide-react";
 
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import {
   Sheet,
   SheetContent,
@@ -17,8 +26,13 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
+import { Switch } from "@/components/ui/switch";
 import {
+  fetchPuppyJobs,
   fetchPuppyResources,
+  setPuppyJobPaused,
+  type PuppyJob,
+  type PuppyJobs,
   type PuppyResidentModel,
   type PuppyResourceLink,
   type PuppyResources,
@@ -30,7 +44,13 @@ import { cn } from "@/lib/utils";
  *
  * The readings are the owner's to ask for, not a permanent fixture above the
  * conversation: `PuppyMachineSheet` is a quiet control that opens them in a
- * sheet, and nothing repeats while that sheet is shut.
+ * panel, and nothing repeats while that panel is shut.
+ *
+ * The panel follows the viewport rather than the phone. Under 640px it is the
+ * app's bottom sheet, where a thumb already is. At 640px and up it is the
+ * centred dialog, because a bottom sheet on a desktop slides a strip across
+ * the foot of a large window to show a small amount of text -- see
+ * `PuppyMachineSheet` for why a dialog and not an anchored popover.
  *
  * ONE reading refuses to wait for a tap. A broken link to Hussh One stays
  * inline, always, above the control. Enrolment outlives login, so a machine
@@ -79,6 +99,16 @@ const POLL_MS = 20_000;
  * stays open.
  */
 const LINK_POLL_MS = 300_000;
+
+/**
+ * Under this width the panel is a bottom sheet; at it and above, a dialog.
+ *
+ * 639.98px rather than 640px so the sheet and `sm:` hand over at exactly the
+ * same place: a device landing on 639.6px must not get the sheet's geometry
+ * and the dialog's breakpoint at once. Exported so a test can answer this one
+ * query without having to guess the number.
+ */
+export const MACHINE_PANEL_SHEET_QUERY = "(max-width: 639.98px)";
 
 /** Disk this full is the thing that stops an overnight job. */
 const DISK_WARNING_PCT = 90;
@@ -162,58 +192,251 @@ function useMachineReading(live: boolean): {
 }
 
 /**
+ * The scheduled jobs, and the switch that turns one off.
+ *
+ * Read ONLY when the panel is open, and never on a timer. Unlike the readings
+ * there is no fact in here that has to reach the owner unasked, so a shut
+ * panel costs the local gateway nothing at all.
+ *
+ * A toggle is single-flight PER JOB and the switch never moves on its own
+ * authority: the row keeps rendering the gateway's `paused` until a re-read
+ * says otherwise. That is the difference between a switch and a wish. A
+ * refusal leaves the job exactly where it was and says so on the row.
+ */
+function usePuppyScheduledWork(live: boolean): {
+  payload: PuppyJobs | null;
+  busyIds: ReadonlySet<string>;
+  errors: Readonly<Record<string, string>>;
+  onToggle: (job: PuppyJob) => void;
+} {
+  const [payload, setPayload] = useState<PuppyJobs | null>(null);
+  const [busyIds, setBusyIds] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const mounted = useRef(true);
+  // The render-visible set lags a microtask behind; the guard cannot. Two taps
+  // in the same tick would both read the old state and both fire.
+  const inFlight = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const read = useCallback(async () => {
+    const next = await fetchPuppyJobs();
+    if (!mounted.current) return;
+    setPayload(next);
+  }, []);
+
+  // Opening is the whole trigger. No interval: a schedule does not change
+  // while someone is looking at it, and the readings' own 20s poll already
+  // re-renders this list often enough for "in 14 min" to stay honest.
+  useEffect(() => {
+    if (!live) return;
+    void read();
+  }, [live, read]);
+
+  const onToggle = useCallback(
+    (job: PuppyJob) => {
+      if (inFlight.current.has(job.id)) return;
+      inFlight.current = new Set(inFlight.current).add(job.id);
+      setBusyIds(inFlight.current);
+      setErrors((current) => {
+        if (!(job.id in current)) return current;
+        const next = { ...current };
+        delete next[job.id];
+        return next;
+      });
+
+      void (async () => {
+        const result = await setPuppyJobPaused({
+          id: job.id,
+          paused: !job.paused,
+        });
+        if (mounted.current) {
+          if (result.ok) {
+            // Re-read rather than trusting the local guess. The gateway may
+            // have done something other than what was asked -- a job that was
+            // deleted underneath us, a resume that a broken schedule refused
+            // -- and the list is the only place that knows.
+            await read();
+          } else {
+            setErrors((current) => ({
+              ...current,
+              [job.id]:
+                result.error || "Puppy One could not change that job.",
+            }));
+          }
+        }
+        const remaining = new Set(inFlight.current);
+        remaining.delete(job.id);
+        inFlight.current = remaining;
+        if (!mounted.current) return;
+        setBusyIds(remaining);
+      })();
+    },
+    [read],
+  );
+
+  return { payload, busyIds, errors, onToggle };
+}
+
+function panelPresentationSupported(): boolean {
+  return (
+    typeof window !== "undefined" && typeof window.matchMedia === "function"
+  );
+}
+
+function subscribeToPanelPresentation(onChange: () => void): () => void {
+  if (!panelPresentationSupported()) return () => {};
+  const query = window.matchMedia(MACHINE_PANEL_SHEET_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+/**
+ * True when this viewport wants the bottom sheet.
+ *
+ * A subscription rather than a one-shot read, so a window dragged across the
+ * boundary is answered instead of being remembered wrongly until the next
+ * reload. The server snapshot is `false`, the desktop answer, which costs
+ * nothing: neither container mounts its content until the owner asks.
+ */
+function useSheetPresentation(): boolean {
+  return useSyncExternalStore(
+    subscribeToPanelPresentation,
+    () =>
+      panelPresentationSupported() &&
+      window.matchMedia(MACHINE_PANEL_SHEET_QUERY).matches,
+    () => false,
+  );
+}
+
+const PANEL_TITLE = "This machine";
+const PANEL_DESCRIPTION =
+  "What Puppy One is running on, and the work it has scheduled.";
+
+/**
  * The owner's way in: one quiet control, plus the one reading that refuses to
  * hide behind it.
  *
  * The control names what it opens rather than what it is made of. "This
  * machine" is the thing the owner is asking about; "Metrics" or "Debug" would
  * be this code describing itself.
+ *
+ * A bottom sheet is the phone's answer, not the desktop's, so the container
+ * follows the viewport:
+ *
+ *   under 640px  the app's bottom sheet, dragged and dismissed like every
+ *                other sheet here, and where the thumb already is.
+ *   640px and up the centred dialog, which is what this repo already reaches
+ *                for when the same surface has to be both -- see
+ *                `save-location-modal.tsx`. Not an anchored popover: this
+ *                panel is a readings card plus a switchable list of eleven
+ *                jobs, which is a task and not a menu, and the popover
+ *                primitive here is 288px wide with no title, no close
+ *                affordance and no focus trap to lend it.
+ *
+ * ONE panel is built, and exactly one container mounts it. Two mounted copies
+ * would be two lists of switches over one machine, and the toggle in the
+ * hidden one would still be reachable by a screen reader.
+ *
+ * The presentation is frozen for the lifetime of an opening. Swapping Sheet
+ * for Dialog swaps the parent element, so React remounts everything inside --
+ * which mid-toggle would tear down the switch under the hand using it, and
+ * lose the row's error with it.
  */
 export function PuppyMachineSheet({ className }: { className?: string }) {
   const [open, setOpen] = useState(false);
   const { payload, readAt } = useMachineReading(open);
+  const scheduled = usePuppyScheduledWork(open);
   const linkState = describeLink(payload?.link);
   // "ok" resolves to `healthy` and "not_connected" to null, so what is left is
   // exactly the set the owner cannot be left to discover by tapping.
   const notice = linkState && linkState.kind !== "healthy" ? linkState : null;
 
+  // Re-synced only while the panel is shut, so it always OPENS in the right
+  // container and then stops following. Nothing is on screen to flash while
+  // it catches up: neither container mounts its content until the owner asks.
+  const livePresentation = useSheetPresentation();
+  const [asSheet, setAsSheet] = useState(livePresentation);
+  useEffect(() => {
+    if (!open) setAsSheet(livePresentation);
+  }, [livePresentation, open]);
+
+  const trigger = (
+    <button
+      type="button"
+      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.045] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <Cpu className="size-3.5" aria-hidden />
+      {PANEL_TITLE}
+    </button>
+  );
+
+  // The container is already the boundary. A second bordered card inside it
+  // would be a box drawn around a box.
+  const panel = (
+    <PuppyResourceMonitor
+      payload={payload}
+      readAt={readAt}
+      className="rounded-none border-0"
+      scheduled={
+        <PuppyJobList
+          payload={scheduled.payload}
+          busyIds={scheduled.busyIds}
+          errors={scheduled.errors}
+          onToggle={scheduled.onToggle}
+        />
+      }
+    />
+  );
+
   return (
     <div className={cn("flex flex-col gap-2", className)}>
       {notice ? <LinkNotice state={notice} /> : null}
       <div className="flex justify-end">
-        <Sheet open={open} onOpenChange={setOpen} modal>
-          <SheetTrigger asChild>
-            <button
-              type="button"
-              className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.045] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        {asSheet ? (
+          <Sheet open={open} onOpenChange={setOpen} modal>
+            <SheetTrigger asChild>{trigger}</SheetTrigger>
+            <SheetContent side="bottom" className="gap-0 p-0">
+              <SheetHeader className="px-4 pb-2 pr-12 pt-3 text-left">
+                <SheetTitle className="text-base">{PANEL_TITLE}</SheetTitle>
+                <SheetDescription>{PANEL_DESCRIPTION}</SheetDescription>
+              </SheetHeader>
+              {/* No padding of its own: every section inside already carries
+                  `px-4`, which is the header's gutter too. */}
+              <div className="pb-[calc(1rem+env(safe-area-inset-bottom,0px))]">
+                {panel}
+              </div>
+            </SheetContent>
+          </Sheet>
+        ) : (
+          <Dialog open={open} onOpenChange={setOpen} modal>
+            <DialogTrigger asChild>{trigger}</DialogTrigger>
+            <DialogContent
+              className="gap-0 p-0 sm:max-w-md"
+              // `DialogContent` already renders the one accessible
+              // description this dialog is allowed to have; a second
+              // `DialogDescription` would collide with it on the same id. So
+              // the line below is the SAME sentence, drawn for the eye only,
+              // and hidden from the reader that has already been told it.
+              srDescription={PANEL_DESCRIPTION}
             >
-              <Cpu className="size-3.5" aria-hidden />
-              This machine
-            </button>
-          </SheetTrigger>
-          <SheetContent
-            side="bottom"
-            className="gap-0 p-0 sm:mx-auto sm:max-w-md"
-          >
-            <SheetHeader className="px-4 pb-2 pr-12 pt-3 text-left">
-              <SheetTitle className="text-base">This machine</SheetTitle>
-              <SheetDescription>
-                What Puppy One is running on, read while this is open.
-              </SheetDescription>
-            </SheetHeader>
-            {/* No padding of its own: every section inside already carries
-                `px-4`, which is the header's gutter too. */}
-            <div className="pb-[calc(1rem+env(safe-area-inset-bottom,0px))]">
-              {/* The sheet is already the boundary. A second bordered card
-                  inside it would be a box drawn around a box. */}
-              <PuppyResourceMonitor
-                payload={payload}
-                readAt={readAt}
-                className="rounded-none border-0"
-              />
-            </div>
-          </SheetContent>
-        </Sheet>
+              <DialogHeader className="px-4 pb-2 pr-12 pt-3 text-left">
+                <DialogTitle className="text-base">{PANEL_TITLE}</DialogTitle>
+                <p className="text-sm text-muted-foreground" aria-hidden>
+                  {PANEL_DESCRIPTION}
+                </p>
+              </DialogHeader>
+              <div className="pb-4">{panel}</div>
+            </DialogContent>
+          </Dialog>
+        )}
       </div>
     </div>
   );
@@ -278,12 +501,27 @@ export function PuppyResourceMonitor({
   payload,
   readAt = 0,
   className,
+  scheduled,
 }: {
   payload: PuppyResources | null;
   /** Epoch ms of that read. 0 means "not stamped": no relative time is shown. */
   readAt?: number;
   className?: string;
+  /**
+   * The job list, rendered under the "Scheduled work" summary.
+   *
+   * A slot rather than a fetch, so this component stays presentational: who
+   * reads the jobs, and when, is the panel owner's contract -- the same rule
+   * that keeps the machine reading out of here.
+   */
+  scheduled?: ReactNode;
 }) {
+  // The readings and the scheduled work are SEPARATE probes, so a state that
+  // stops one must not silently remove the other. These early returns used to
+  // drop the `scheduled` slot with them, which meant the switches disappeared
+  // in exactly the states an owner is most likely to be looking for them: while
+  // the readings are still loading, or when the readings call failed. The jobs
+  // section carries its own calm states and can speak for itself.
   if (!payload) {
     return (
       <Shell className={className}>
@@ -291,6 +529,7 @@ export function PuppyResourceMonitor({
           <Loader2 className="size-3.5 animate-spin" aria-hidden />
           Reading this machine…
         </p>
+        {scheduled}
       </Shell>
     );
   }
@@ -302,6 +541,7 @@ export function PuppyResourceMonitor({
           {payload.message ||
             "Set HERMES_API_SERVER_KEY to read the machine Puppy One runs on."}
         </p>
+        {scheduled}
       </Shell>
     );
   }
@@ -312,6 +552,7 @@ export function PuppyResourceMonitor({
         <p className="px-4 py-3 text-xs text-muted-foreground">
           Puppy One is not answering on this machine.
         </p>
+        {scheduled}
       </Shell>
     );
   }
@@ -351,8 +592,15 @@ export function PuppyResourceMonitor({
     diskFreeGb !== null ||
     diskUsedPct !== null ||
     battery !== undefined;
-  const hasJobs =
-    jobsEnabled !== null || nextJobName !== null || completed !== null;
+  const hasJobsSummary =
+    jobsEnabled !== null ||
+    nextJobName !== null ||
+    completed !== null ||
+    failed !== null;
+  // The section also earns its place when the readings said nothing about
+  // jobs but the list has something to say -- including "nothing is
+  // scheduled", which is an answer and not an empty box.
+  const hasJobs = hasJobsSummary || Boolean(scheduled);
   // Only the healthy footnote lives in here; a broken link is said inline by
   // `LinkNotice`, outside this sheet. A healthy link with nothing to name it by
   // renders no line either, so a payload carrying only that would otherwise
@@ -516,45 +764,59 @@ export function PuppyResourceMonitor({
       {/* 4. Is the work landing? */}
       {hasJobs ? (
         <Section label="Scheduled work">
-          <div className="flex flex-col gap-1 text-xs">
-            {jobsEnabled !== null ? (
-              <p className="tabular-nums">
-                <span className="font-medium">{jobsEnabled} scheduled</span>
-                {jobsDisabled !== null && jobsDisabled > 0 ? (
-                  <span className="text-muted-foreground">
-                    {" "}
-                    · {jobsDisabled} off
-                  </span>
-                ) : null}
-              </p>
-            ) : null}
-            {nextJobName ? (
-              <p className="truncate text-muted-foreground">
-                Next: {nextJobName}
-                {nextJobIn ? (
-                  <span className="tabular-nums"> {nextJobIn}</span>
-                ) : null}
-              </p>
-            ) : null}
-            {completed !== null || failed !== null ? (
-              <p className="tabular-nums text-muted-foreground">
-                Last 24h:
-                {completed !== null ? ` ${completed} completed` : ""}
-                {completed !== null && failed !== null ? " ·" : ""}
-                {failed !== null ? (
-                  <span
-                    className={cn(
-                      failed > 0 &&
-                        "text-[color:var(--app-destructive-deep)] dark:text-[color:var(--app-destructive-bright)]",
-                    )}
-                  >
-                    {" "}
-                    {failed} failed
-                  </span>
-                ) : null}
-              </p>
-            ) : null}
-          </div>
+          {/* The headline over the list: the counts, the soonest job, and the
+              only fact the list itself cannot carry -- how the last day of
+              runs actually went. */}
+          {hasJobsSummary ? (
+            <div className="flex flex-col gap-1 text-xs">
+              {jobsEnabled !== null ? (
+                <p className="tabular-nums">
+                  <span className="font-medium">{jobsEnabled} scheduled</span>
+                  {jobsDisabled !== null && jobsDisabled > 0 ? (
+                    <span className="text-muted-foreground">
+                      {" "}
+                      · {jobsDisabled} off
+                    </span>
+                  ) : null}
+                </p>
+              ) : null}
+              {nextJobName ? (
+                <p className="truncate text-muted-foreground">
+                  Next: {nextJobName}
+                  {nextJobIn ? (
+                    <span className="tabular-nums"> {nextJobIn}</span>
+                  ) : null}
+                </p>
+              ) : null}
+              {completed !== null || failed !== null ? (
+                <p className="tabular-nums text-muted-foreground">
+                  Last 24h:
+                  {completed !== null ? ` ${completed} completed` : ""}
+                  {completed !== null && failed !== null ? " ·" : ""}
+                  {failed !== null ? (
+                    <span
+                      className={cn(
+                        failed > 0 &&
+                          "text-[color:var(--app-destructive-deep)] dark:text-[color:var(--app-destructive-bright)]",
+                      )}
+                    >
+                      {" "}
+                      {failed} failed
+                    </span>
+                  ) : null}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+          {scheduled ? (
+            <div
+              className={cn(
+                hasJobsSummary && "mt-2.5 border-t border-border/60 pt-2.5",
+              )}
+            >
+              {scheduled}
+            </div>
+          ) : null}
         </Section>
       ) : null}
 
@@ -678,6 +940,210 @@ function ResidentRow({ model }: { model: PuppyResidentModel }) {
   );
 }
 
+/**
+ * Every job on this machine, and its switch.
+ *
+ * Three states are not the list being broken and none of them is an empty
+ * box: no key set, a machine that did not answer, and a machine with nothing
+ * scheduled are each one sentence.
+ */
+function PuppyJobList({
+  payload,
+  busyIds,
+  errors,
+  onToggle,
+}: {
+  payload: PuppyJobs | null;
+  busyIds: ReadonlySet<string>;
+  errors: Readonly<Record<string, string>>;
+  onToggle: (job: PuppyJob) => void;
+}) {
+  if (!payload) {
+    return (
+      <p className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Loader2 className="size-3.5 animate-spin" aria-hidden />
+        Reading the scheduled work…
+      </p>
+    );
+  }
+
+  if (payload.configured === false) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        {payload.message ||
+          "Set HERMES_API_SERVER_KEY to see Puppy One's scheduled work."}
+      </p>
+    );
+  }
+
+  if (payload.reachable === false) {
+    // Worded apart from the readings' own "not answering" line: they are
+    // separate probes, and only one of them may have failed.
+    return (
+      <p className="text-xs text-muted-foreground">
+        Puppy One did not answer about its scheduled work.
+      </p>
+    );
+  }
+
+  if (payload.jobs.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Nothing is scheduled on this machine.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-1">
+      {payload.jobs.map((job) => (
+        <JobRow
+          key={job.id}
+          job={job}
+          pending={busyIds.has(job.id)}
+          error={errors[job.id] ?? null}
+          onToggle={onToggle}
+        />
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * One job.
+ *
+ * Three forms, and each carries its state in shape as well as colour so it
+ * survives a greyscale screen:
+ *
+ *   running   no stripe, full-strength name.
+ *   paused    a plain grey stripe, a dimmed name, and the WORD "Paused". It
+ *             is a deliberate off, not a fault, and it must never wear the
+ *             colour that means something went wrong.
+ *   failing   a red stripe and a labelled chip with a warning glyph, saying
+ *             how many runs in a row went wrong. A paused job that last
+ *             failed keeps the paused form and still shows the chip: both
+ *             facts are true and neither is allowed to hide the other.
+ *
+ * The switch renders the GATEWAY's `paused`, never a local guess, so it
+ * cannot appear to have flipped before the machine agreed. While a request is
+ * in flight the row is busy and the switch refuses a second one.
+ */
+function JobRow({
+  job,
+  pending,
+  error,
+  onToggle,
+}: {
+  job: PuppyJob;
+  pending: boolean;
+  error: string | null;
+  onToggle: (job: PuppyJob) => void;
+}) {
+  const nameId = useId();
+  // A job is failing when its LAST run failed, or when it has a streak. A
+  // lingering `lastError` from a run that has since recovered is history, not
+  // a state: treating any non-empty error as failure marked healthy jobs red
+  // and suppressed their true "last run ok" line, so the row disagreed with
+  // itself. The error text is still shown below when there is one.
+  const statusWord = nonEmpty(job.lastStatus)?.toLowerCase();
+  const failing =
+    job.failureStreak > 0 || statusWord === "error" || statusWord === "failed";
+
+  const detail: string[] = [];
+  const schedule = describeSchedule(job.schedule);
+  if (schedule) detail.push(schedule);
+  if (job.paused) {
+    detail.push("Paused");
+  } else {
+    const next = describeNextRun(job.nextRunAt);
+    if (next) detail.push(next);
+  }
+  const lastStatus = nonEmpty(job.lastStatus);
+  if (!failing && lastStatus) detail.push(`last run ${lastStatus}`);
+
+  return (
+    <li
+      className={cn(
+        "rounded-lg border-l-2 px-2.5 py-2",
+        job.paused
+          ? "border-l-border bg-muted/30"
+          : failing
+            ? "border-l-[color:var(--app-destructive-border)] bg-[color:var(--app-destructive-tint)]"
+            : "border-l-transparent bg-muted/40",
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <p
+            id={nameId}
+            className={cn(
+              "truncate text-xs font-medium",
+              job.paused && "text-muted-foreground",
+            )}
+          >
+            {job.name}
+          </p>
+          {detail.length > 0 ? (
+            <p className="mt-0.5 text-[11px] tabular-nums text-muted-foreground">
+              {detail.join(" · ")}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5">
+          {pending ? (
+            <Loader2
+              className="size-3 animate-spin text-muted-foreground"
+              aria-hidden
+            />
+          ) : null}
+          <Switch
+            size="sm"
+            checked={!job.paused}
+            disabled={pending}
+            aria-busy={pending || undefined}
+            aria-labelledby={nameId}
+            onCheckedChange={() => onToggle(job)}
+          />
+        </div>
+      </div>
+
+      {failing ? (
+        <span
+          className={cn(
+            "mt-1.5 inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium",
+            TONE_CHIP.danger,
+          )}
+        >
+          <AlertTriangle className="size-3" aria-hidden />
+          {describeFailure(job.failureStreak)}
+        </span>
+      ) : null}
+
+      {/* Verbatim from the machine. A rewritten error is a different error. */}
+      {nonEmpty(job.lastError) ? (
+        <p className="mt-1 break-words text-[10px] text-muted-foreground">
+          {job.lastError}
+        </p>
+      ) : null}
+
+      {/* The refusal, said on the row it belongs to. The switch above still
+          shows what the job is actually doing.
+
+          `alert` rather than `status`: this node is INSERTED in answer to
+          something the owner just did, and an inserted alert is the case
+          screen readers actually announce. */}
+      {error ? (
+        <p
+          role="alert"
+          className="mt-1 text-[10px] font-medium text-[color:var(--app-destructive-deep)] dark:text-[color:var(--app-destructive-bright)]"
+        >
+          {error}
+        </p>
+      ) : null}
+    </li>
+  );
+}
+
 type LinkState =
   | { kind: "alert"; tone: "warning" | "danger"; message: string; remedy?: string }
   | { kind: "quiet"; message: string }
@@ -789,6 +1255,136 @@ function formatGb(value: number): string {
 
 function formatPct(value: number): string {
   return `${Math.round(value)}%`;
+}
+
+const WEEKDAYS = [
+  "Sundays",
+  "Mondays",
+  "Tuesdays",
+  "Wednesdays",
+  "Thursdays",
+  "Fridays",
+  "Saturdays",
+];
+
+/**
+ * A schedule, in the words someone would use out loud.
+ *
+ * "10 3 * * *" is a machine's sentence, not a person's, and an owner deciding
+ * whether to switch a job off should not have to parse cron in their head.
+ *
+ * Translated ONLY for the shapes that translate exactly. Anything else --
+ * step lists, ranges, named weekdays, the gateway's own "every 30m" -- is
+ * printed verbatim, because a schedule described wrongly is worse than one
+ * left in its own notation: it is the sentence the owner would act on.
+ *
+ * 24-hour time on purpose. It is unambiguous, it needs no locale, and it
+ * sorts the way the numbers already read.
+ */
+function describeSchedule(expression: string | null): string | null {
+  const raw = nonEmpty(expression);
+  if (!raw) return null;
+
+  const fields = raw.split(/\s+/);
+  if (fields.length !== 5) return raw;
+  // The defaults are unreachable -- the length is already five -- and exist
+  // only so each field is a string rather than `string | undefined`.
+  const [minute = "", hour = "", dayOfMonth = "", month = "", dayOfWeek = ""] =
+    fields;
+  if (month !== "*") return raw;
+
+  const everyMinutes = stepValue(minute);
+  if (
+    everyMinutes !== null &&
+    hour === "*" &&
+    dayOfMonth === "*" &&
+    dayOfWeek === "*"
+  ) {
+    return `Every ${everyMinutes} min`;
+  }
+
+  const minuteAt = cronNumber(minute, 0, 59);
+  if (minuteAt === null) return raw;
+
+  const everyHours = stepValue(hour);
+  if (everyHours !== null && dayOfMonth === "*" && dayOfWeek === "*") {
+    return `Every ${everyHours} h at :${pad(minuteAt)}`;
+  }
+
+  if (hour === "*" && dayOfMonth === "*" && dayOfWeek === "*") {
+    return `Hourly at :${pad(minuteAt)}`;
+  }
+
+  const hourAt = cronNumber(hour, 0, 23);
+  if (hourAt === null) return raw;
+  const at = `${pad(hourAt)}:${pad(minuteAt)}`;
+
+  if (dayOfMonth === "*" && dayOfWeek === "*") return `Daily at ${at}`;
+
+  if (dayOfMonth === "*") {
+    const weekday = cronNumber(dayOfWeek, 0, 7);
+    if (weekday === null) return raw;
+    // Cron accepts both 0 and 7 for Sunday.
+    const named = WEEKDAYS[weekday % 7];
+    if (!named) return raw;
+    return `${named} at ${at}`;
+  }
+
+  if (dayOfWeek === "*") {
+    const day = cronNumber(dayOfMonth, 1, 31);
+    if (day === null) return raw;
+    return `Monthly on the ${ordinal(day)} at ${at}`;
+  }
+
+  return raw;
+}
+
+/** A cron step field, star-slash-15, read as 15. Null for anything else. */
+function stepValue(field: string): number | null {
+  const match = /^\*\/(\d{1,2})$/.exec(field);
+  if (!match) return null;
+  const value = Number(match[1]);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+/** A single plain integer in range. Lists, ranges and names return null. */
+function cronNumber(field: string, min: number, max: number): number | null {
+  if (!/^\d{1,2}$/.test(field)) return null;
+  const value = Number(field);
+  return value >= min && value <= max ? value : null;
+}
+
+function pad(value: number): string {
+  return value < 10 ? `0${value}` : String(value);
+}
+
+function ordinal(value: number): string {
+  const tens = value % 100;
+  if (tens >= 11 && tens <= 13) return `${value}th`;
+  const ones = value % 10;
+  if (ones === 1) return `${value}st`;
+  if (ones === 2) return `${value}nd`;
+  if (ones === 3) return `${value}rd`;
+  return `${value}th`;
+}
+
+/**
+ * "next in 14 min", or "due now".
+ *
+ * Measured against the browser's clock rather than a stamp on the payload,
+ * because this route does not carry one -- and it is the same machine: the
+ * gateway is reached over loopback from the server this page came from.
+ */
+function describeNextRun(iso: string | null): string | null {
+  const at = nonEmpty(iso);
+  if (!at) return null;
+  const relative = relativeTime(Date.now(), at);
+  if (!relative) return null;
+  return relative.startsWith("in ") ? `next ${relative}` : relative;
+}
+
+function describeFailure(streak: number): string {
+  return streak > 1 ? `Failed ${streak} runs in a row` : "Last run failed";
 }
 
 /** "in 14 min". Returns null for a timestamp that cannot be read. */

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -156,6 +156,10 @@
       "file": "app/api/hermes/chat/stream/route.ts"
     },
     {
+      "template": "/api/hermes/jobs",
+      "file": "app/api/hermes/jobs/route.ts"
+    },
+    {
       "template": "/api/hermes/models",
       "file": "app/api/hermes/models/route.ts"
     },
@@ -9464,5 +9468,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "571c8bfed57f5b2b0996270a795713fccc36347527eb68d01f67e817ae05683f"
+  "content_sha256": "e950dbb56729e1da6bd2f2c943549f793a1fc3e4c596ebe72ad83a5c6a14d3b2"
 }

--- a/hushh-webapp/lib/hermes/bridge-config.ts
+++ b/hushh-webapp/lib/hermes/bridge-config.ts
@@ -27,6 +27,33 @@ export const HERMES_DEFAULT_BASE_URL = "http://127.0.0.1:8642";
  * "not connected" state instead of an error: a machine without Hermes running
  * is a normal condition, not a failure.
  */
+/**
+ * Whether a state-changing request came from our own page.
+ *
+ * These routes hold a loopback bearer key that is host remote-code-execution,
+ * and they run on a port any web page the owner visits can reach. Without this,
+ * a cross-site form post could pause the agent's scheduled work or repoint its
+ * model, because the browser attaches no credential we check and the key is
+ * added server-side regardless of who asked.
+ *
+ * Fetch metadata is the primary check and needs no configuration; `Origin` is
+ * the fallback for browsers that do not send it. A request carrying neither is
+ * not a browser form post, so it is allowed: that is curl on the owner's own
+ * machine, which already has every capability this route does.
+ */
+export function isSameOriginRequest(request: Request): boolean {
+  const site = request.headers.get("sec-fetch-site");
+  if (site) return site === "same-origin" || site === "none";
+
+  const origin = request.headers.get("origin");
+  if (!origin) return true;
+  try {
+    return new URL(origin).host === new URL(request.url).host;
+  } catch {
+    return false;
+  }
+}
+
 export function resolveHermesBridgeConfig(): HermesBridgeConfig | null {
   const apiKey = (process.env.HERMES_API_SERVER_KEY || "").trim();
   if (!apiKey) return null;

--- a/hushh-webapp/lib/services/puppy-one-service.ts
+++ b/hushh-webapp/lib/services/puppy-one-service.ts
@@ -182,10 +182,56 @@ export interface PuppyResources {
   jobs?: PuppyResourceJobs;
 }
 
+/**
+ * One scheduled job, as `/api/hermes/jobs` hands it over.
+ *
+ * camelCase, unlike the readings above, because this route does NOT pass the
+ * gateway's row through: it maps field by field and drops the job's prompt,
+ * its credentials and its working directory before the payload ever leaves the
+ * server. The shape is the route's own, so it is named here in the same words
+ * the route uses.
+ *
+ * `null` means "the gateway did not say", never zero and never "no". A job
+ * with no `schedule` is not a job that never runs; it is a job whose schedule
+ * this build could not read, and it renders as nothing rather than as a guess.
+ */
+export interface PuppyJob {
+  id: string;
+  name: string;
+  /** "10 3 * * *", "every 30m", or whatever the scheduler calls it. */
+  schedule: string | null;
+  /** The scheduler's own word for off. Deliberate, not an error. */
+  paused: boolean;
+  /** ISO with offset, e.g. "2026-09-03T03:10:00-07:00". */
+  nextRunAt: string | null;
+  /** "ok" | "error" | anything a later gateway invents. Read as an open string. */
+  lastStatus: string | null;
+  lastError: string | null;
+  failureStreak: number;
+}
+
+export interface PuppyJobs {
+  configured: boolean;
+  reachable?: boolean;
+  reason?: string;
+  message?: string;
+  jobs: PuppyJob[];
+}
+
+export interface PuppyJobChange {
+  ok: boolean;
+  id?: string;
+  action?: string;
+  job?: PuppyJob | null;
+  error?: string;
+}
+
 const STATUS_TIMEOUT_MS = 10_000;
 const OPTIONS_TIMEOUT_MS = 25_000;
 const ASSIGN_TIMEOUT_MS = 35_000;
 const RESOURCES_TIMEOUT_MS = 20_000;
+const JOBS_TIMEOUT_MS = 15_000;
+const JOB_CHANGE_TIMEOUT_MS = 20_000;
 
 /** Read Puppy One's status. Never throws: not-running is an ordinary state. */
 export async function fetchPuppyStatus(): Promise<PuppyStatus> {
@@ -217,6 +263,67 @@ export async function fetchPuppyResources(): Promise<PuppyResources> {
     return (await response.json()) as PuppyResources;
   } catch {
     return { configured: true, reachable: false };
+  }
+}
+
+/**
+ * Read the work Puppy One does on a schedule. Never throws, for the same
+ * reason the readings do not: a machine with no agent answering is ordinary.
+ *
+ * `jobs` is always an array. A caller rendering a list must not have to decide
+ * what an absent array means, and the two states that are NOT "no jobs" --
+ * not configured, and not answering -- are carried by their own fields.
+ */
+export async function fetchPuppyJobs(): Promise<PuppyJobs> {
+  try {
+    const response = await fetch("/api/hermes/jobs", {
+      cache: "no-store",
+      signal: AbortSignal.timeout(JOBS_TIMEOUT_MS),
+    });
+    if (!response.ok) return { configured: true, reachable: false, jobs: [] };
+    const payload = (await response.json()) as PuppyJobs;
+    return {
+      ...payload,
+      jobs: Array.isArray(payload?.jobs) ? payload.jobs : [],
+    };
+  } catch {
+    return { configured: true, reachable: false, jobs: [] };
+  }
+}
+
+/**
+ * Pause or resume one job.
+ *
+ * Resolves rather than throws for every outcome: an unreachable gateway is an
+ * ordinary state, and the caller has to be able to leave the switch showing
+ * the job's REAL state when the machine refuses. The returned `job` is the
+ * gateway's own row for it; callers still re-read the list afterwards rather
+ * than trusting a single row to be the whole truth.
+ */
+export async function setPuppyJobPaused(input: {
+  id: string;
+  paused: boolean;
+}): Promise<PuppyJobChange> {
+  try {
+    const response = await fetch("/api/hermes/jobs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: input.id,
+        action: input.paused ? "pause" : "resume",
+      }),
+      signal: AbortSignal.timeout(JOB_CHANGE_TIMEOUT_MS),
+    });
+    const payload = (await response
+      .json()
+      .catch(() => ({}))) as PuppyJobChange;
+    if (payload?.ok === true) return payload;
+    return {
+      ok: false,
+      error: payload?.error || "Puppy One could not change that job.",
+    };
+  } catch {
+    return { ok: false, error: "Puppy One is not answering on this machine." };
   }
 }
 


### PR DESCRIPTION
Founder feedback on the deployed header: *"this doesnt add up to height and width that we had"*, *"the previous was perfect toggles, but just animation needed to be wired"*, *"the model dropdown has to be from the morphy components"*, *"its not visible nicely on the mobile view"*.

## The toggle

It had been moved onto `SegmentedTabs`, which is the **full-width mobile filter primitive**: `min-h-11` container, `min-h-10` segments, `w-full` grid columns. In a header whose other controls are 36px icon buttons it stood roughly 44px tall, which is exactly the mismatch. Passing `min-h-9` could not fix it because the inner segments carry their own floor.

It now uses `SegmentedControl` at `variant="compact" size="sm"` — the header-scale Morphy primitive, `h-8` container with `px-2 py-1 text-xs` segments — which already carries an eased sliding transition (`duration-500`, `cubic-bezier(0.25,1,0.5,1)`). So the toggle shape is the one that was liked, and the animation is the thing that was actually missing.

## The picker

It was a raw `<select>`: outside the design system, and `hidden sm:block`, so on a phone it did not exist at all. It is now the design system's `Select`, which gives a real popover that works on touch, and it renders at every width.

The trigger shows **"3.8 Flash"**, not "Gemini 3.8 Flash": every option is a Gemini, so the shared word is the one thing a narrow header cannot afford. The full label stays in the menu and in the tooltip.

## Verification

`orchestrate.sh web-core` and `web-targeted` green; `tsc --noEmit` and eslint clean; `verify:design-system` passes; the 19 agent test files (122 tests) pass.

Tracked on the Hussh Action Items board.