### PR TITLE
feat(puppy): remote link truth from One, heartbeat payload fixed both sides, production enrollment path, machine panel + job switches

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -246,7 +246,7 @@ jobs:
             --plaid-redirect-path "/kai/plaid/oauth/return" \
             --plaid-tx-history-days "730" \
             --one-location-read-only-state-enabled "false" \
-            --hushh-trusted-device-enabled "false" \
+            --hushh-trusted-device-enabled "${{ vars.HUSSH_TRUSTED_DEVICE_ENABLED || 'false' }}" \
             --hushh-tech-client-enabled "false" \
             --hushh-tech-allowed-consent-scopes "" \
             --one-location-nearby-presence-mode "${{ github.event.inputs.nearby_check_in_cohort && 'production' || '' }}" \

--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -436,36 +436,43 @@ async def trusted_device_seal_ack(
     return result
 
 
-class TrustedDeviceHeartbeatRequest(BaseModel):
-    """Runtime telemetry a live device reports. Every field is optional and
-    advisory; unknown fields are dropped by the service allow-list."""
+def _heartbeat_snapshot(body: Any) -> dict[str, Any]:
+    """Read the telemetry out of a heartbeat body, flat or wrapped.
 
-    machine_id: str | None = Field(default=None, max_length=120)
-    current_model: str | None = Field(default=None, max_length=120)
-    agent_version: str | None = Field(default=None, max_length=120)
-    busy: bool | None = None
-    active_sessions: int | None = Field(default=None, ge=0, le=10_000)
-    next_cron_at: int | None = Field(default=None, ge=0)
-    # Machine specs and power, so the owner sees the machine their agent runs
-    # on. Every one of these is on the service allow-list; before they were
-    # declared here, Pydantic dropped them at the route boundary and the
-    # service never saw them. Names only: brand and processor describe a
-    # machine, never identify one. Ranges are enforced again by the service,
-    # which drops rather than clamps.
-    brand: str | None = Field(default=None, max_length=120)
-    processor: str | None = Field(default=None, max_length=120)
-    ram_total_gb: float | None = Field(default=None, ge=0, le=4096)
-    ram_used_pct: float | None = Field(default=None, ge=0, le=100)
-    battery_pct: float | None = Field(default=None, ge=0, le=100)
-    battery_minutes_remaining: int | None = Field(default=None, ge=0, le=100_000)
-    battery_charging: bool | None = None
-    on_ac: bool | None = None
+    The route deliberately does NOT validate the body with a typed model. The
+    heartbeat is advisory telemetry whose one load-bearing effect is stamping
+    ``last_heartbeat_at``, and the service allow-list (``_safe_heartbeat``)
+    already keeps only known scalar fields, truncates text and drops
+    out-of-range numbers. A typed model with bounds in front of it turned one
+    over-long value into a 422 for the WHOLE beat: a 121-character model id
+    made every push fail, the device read as gone in One while it was healthy,
+    and the failure was silent because telemetry never raises on the device.
+    Sanitising per field costs that field; rejecting per request costs the
+    signal.
+
+    Two body shapes are read. Hermes builds from 2026-08-28 (when the
+    heartbeat first shipped) to 2026-09-03 posted the snapshot wrapped as
+    ``{"heartbeat": {...}}``; later builds post it flat. Top-level keys win
+    over the wrapped block on a shared key, and only one level is unwrapped.
+    A body that is not an object is an empty reading, which still stamps the
+    beat: liveness is the signal, the fields are extras.
+    """
+    if not isinstance(body, dict):
+        return {}
+    wrapped = body.get("heartbeat")
+    inner = (
+        {key: value for key, value in wrapped.items() if key != "heartbeat"}
+        if isinstance(wrapped, dict)
+        else {}
+    )
+    flat = {key: value for key, value in body.items() if key != "heartbeat"}
+    return {**inner, **flat}
 
 
 @router.post("/trusted-devices/{device_id}/heartbeat")
 async def trusted_device_heartbeat(
     device_id: str,
-    payload: TrustedDeviceHeartbeatRequest | None = None,
+    payload: Any = Body(default=None),
     firebase_uid: str = Depends(require_firebase_auth),
 ):
     """Liveness heartbeat from a running trusted device.
@@ -481,7 +488,7 @@ async def trusted_device_heartbeat(
     enforcement never consults it. Trust stays decided by status and
     is_trusted_device_active.
     """
-    snapshot = payload.model_dump(exclude_none=True) if payload is not None else {}
+    snapshot = _heartbeat_snapshot(payload)
     try:
         await run_in_threadpool(
             TrustedDeviceService().record_heartbeat,

--- a/consent-protocol/tests/test_trusted_device_heartbeat.py
+++ b/consent-protocol/tests/test_trusted_device_heartbeat.py
@@ -236,9 +236,7 @@ async def test_heartbeat_route_records_and_acknowledges(
     monkeypatch.setattr(account, "TrustedDeviceService", lambda: _Svc())
     monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
 
-    payload = account.TrustedDeviceHeartbeatRequest(
-        machine_id="gw-studio", current_model="gemini-3.6-flash", busy=False
-    )
+    payload = dict(machine_id="gw-studio", current_model="gemini-3.6-flash", busy=False)
     result = await account.trusted_device_heartbeat(
         device_id=DEVICE_ID, payload=payload, firebase_uid="u1"
     )
@@ -251,12 +249,13 @@ async def test_heartbeat_route_records_and_acknowledges(
 async def test_heartbeat_route_forwards_machine_specs_and_power(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The request model must declare every field the service allow-lists.
+    """The route forwards the whole body; the SERVICE decides what is kept.
 
-    Pydantic drops undeclared fields at the route boundary, so before these
-    were declared a device posting its brand, processor, RAM and battery had
-    them silently discarded and the service never saw them. The devices page
-    could then never show the machine the agent runs on.
+    A typed request model used to sit in front of the service, and twice it
+    cost the owner a reading: first by dropping undeclared machine-spec
+    fields, then by rejecting the entire beat with a 422 whenever one value
+    was over its bound. The route now forwards every key and the allow-list
+    in _safe_heartbeat keeps, truncates or drops per field.
     """
     from api.routes import account
 
@@ -272,7 +271,7 @@ async def test_heartbeat_route_forwards_machine_specs_and_power(
     monkeypatch.setattr(account, "TrustedDeviceService", lambda: _Svc())
     monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
 
-    payload = account.TrustedDeviceHeartbeatRequest.model_validate(
+    payload = dict(
         {
             "machine_id": "gw-studio",
             "current_model": "google/gemma-4-26b-a4b-qat",
@@ -302,5 +301,221 @@ async def test_heartbeat_route_forwards_machine_specs_and_power(
         assert key in snapshot, key
     assert snapshot["brand"] == "Apple"
     assert snapshot["ram_total_gb"] == 128
-    # Identifying fields are not declared, so they never reach the service.
-    assert "serial_number" not in snapshot
+    # The route forwards identifying fields too; the allow-list is what drops
+    # them, and it is the one place that decision is made.
+    assert "serial_number" not in _safe_heartbeat(snapshot)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_route_never_rejects_a_beat_for_one_bad_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An over-long or out-of-range value costs that field, never the beat.
+
+    LM Studio model ids can exceed 120 characters. With a bounded request
+    model every heartbeat from such a machine was a 422, post_heartbeat on the
+    device swallowed it, and One showed a healthy machine as gone. The route
+    forwards the body; the service truncates the text and drops the number
+    and the beat still stamps last_heartbeat_at.
+    """
+    from api.routes import account
+
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    seen: list[dict[str, Any]] = []
+
+    class _Svc:
+        def record_heartbeat(self, **kwargs: Any) -> None:
+            seen.append(kwargs)
+
+    monkeypatch.setattr(account, "TrustedDeviceService", lambda: _Svc())
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+
+    long_model = "lmstudio-community/" + ("x" * 130)
+    result = await account.trusted_device_heartbeat(
+        device_id=DEVICE_ID,
+        payload={"current_model": long_model, "ram_total_gb": 99_999, "busy": True},
+        firebase_uid="u1",
+    )
+    assert result["recorded"] is True
+    safe = _safe_heartbeat(seen[0]["snapshot"])
+    assert safe["current_model"] == long_model[:120]
+    assert safe["busy"] is True
+    assert "ram_total_gb" not in safe
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_route_treats_a_non_object_body_as_an_empty_beat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.routes import account
+
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    seen: list[dict[str, Any]] = []
+
+    class _Svc:
+        def record_heartbeat(self, **kwargs: Any) -> None:
+            seen.append(kwargs)
+
+    monkeypatch.setattr(account, "TrustedDeviceService", lambda: _Svc())
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+
+    for body in (None, "busy", 7, ["busy"], {"heartbeat": "not-an-object"}):
+        seen.clear()
+        result = await account.trusted_device_heartbeat(
+            device_id=DEVICE_ID, payload=body, firebase_uid="u1"
+        )
+        assert result["recorded"] is True, body
+        # The beat still lands (liveness), with nothing to say about the machine.
+        assert seen[0]["snapshot"] == {}, body
+
+
+# ---------------------------------------------------------------------------
+# Wrapped body: {"heartbeat": {...}}
+#
+# Hermes builds from 2026-08-28 (when the heartbeat first shipped) to
+# 2026-09-03 posted the telemetry wrapped under a "heartbeat" key. The typed
+# request model of the time dropped the wrapper at the route boundary and the
+# store wrote an empty snapshot (measured on UAT: last_heartbeat_at set,
+# heartbeat null). The route reads both shapes until every installed agent
+# has updated to the flat body.
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_snapshot_unwraps_a_nested_only_body() -> None:
+    from api.routes import account
+
+    payload = dict(
+        {
+            "heartbeat": {
+                "machine_id": "gw-studio",
+                "current_model": "gemini-3.6-flash",
+                "busy": True,
+                "ram_used_pct": 41.7,
+            }
+        }
+    )
+    assert account._heartbeat_snapshot(payload) == {
+        "machine_id": "gw-studio",
+        "current_model": "gemini-3.6-flash",
+        "busy": True,
+        "ram_used_pct": 41.7,
+    }
+
+
+def test_heartbeat_snapshot_flat_wins_over_nested_for_the_same_key() -> None:
+    from api.routes import account
+
+    payload = dict(
+        {
+            "machine_id": "flat-wins",
+            "busy": False,
+            "heartbeat": {
+                "machine_id": "nested-loses",
+                "busy": True,
+                "current_model": "only-in-nested",
+            },
+        }
+    )
+    snapshot = account._heartbeat_snapshot(payload)
+    assert snapshot["machine_id"] == "flat-wins"
+    assert snapshot["busy"] is False
+    # A key present only in the nested block still comes through.
+    assert snapshot["current_model"] == "only-in-nested"
+    # The wrapper key itself never appears in the snapshot.
+    assert "heartbeat" not in snapshot
+
+
+def test_heartbeat_snapshot_does_not_recurse_into_a_doubly_nested_body() -> None:
+    from api.routes import account
+
+    payload = dict(
+        {"heartbeat": {"machine_id": "one-level", "heartbeat": {"machine_id": "two-levels"}}}
+    )
+    assert account._heartbeat_snapshot(payload) == {"machine_id": "one-level"}
+
+
+def test_heartbeat_snapshot_returns_empty_for_a_missing_body() -> None:
+    from api.routes import account
+
+    assert account._heartbeat_snapshot(None) == {}
+
+
+def test_a_nested_body_cannot_smuggle_a_key_past_the_allow_list() -> None:
+    # The wrapper is unwrapped at the route, then the service allow-list runs
+    # on the flattened result exactly as it does for a flat body. The route
+    # forwards unknown keys; _safe_heartbeat is the one place they are dropped.
+    from api.routes import account
+
+    payload = dict(
+        {
+            "heartbeat": {
+                "machine_id": "gw-studio",
+                "vault_key": "super-secret",
+                "home_path": "/Users/someone/.hermes",
+                "serial_number": "must-not-pass",
+            }
+        }
+    )
+    flattened = account._heartbeat_snapshot(payload)
+    safe = _safe_heartbeat({**flattened, "vault_key": "still-not-allowed"})
+    assert safe == {"machine_id": "gw-studio"}
+
+
+def test_heartbeat_snapshot_does_not_recurse_or_raise_on_a_deep_wrapper() -> None:
+    # A wrapper nested a thousand deep used to be validated at every level by
+    # a self-referential model and could turn into a 500 in the error
+    # renderer. Now it is one level of unwrapping and nothing else.
+    from api.routes import account
+
+    body: dict[str, Any] = {"machine_id": "leaf"}
+    for _ in range(1000):
+        body = {"heartbeat": body}
+    snapshot = account._heartbeat_snapshot(body)
+    assert "machine_id" not in snapshot
+    assert snapshot == {}
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_route_records_a_wrapped_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.routes import account
+
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    seen: list[dict[str, Any]] = []
+
+    class _Svc:
+        def record_heartbeat(self, **kwargs: Any) -> None:
+            seen.append(kwargs)
+
+    monkeypatch.setattr(account, "TrustedDeviceService", lambda: _Svc())
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+
+    payload = dict(
+        {
+            "heartbeat": {
+                "machine_id": "gw-studio",
+                "current_model": "google/gemma-4-26b-a4b-qat",
+                "brand": "Apple",
+                "battery_pct": 88,
+            }
+        }
+    )
+    result = await account.trusted_device_heartbeat(
+        device_id=DEVICE_ID, payload=payload, firebase_uid="u1"
+    )
+    assert result["recorded"] is True
+    snapshot = seen[0]["snapshot"]
+    # Before the wrapper was accepted this snapshot was {} and the store wrote
+    # heartbeat null with last_heartbeat_at set.
+    assert snapshot["machine_id"] == "gw-studio"
+    assert snapshot["current_model"] == "google/gemma-4-26b-a4b-qat"
+    assert snapshot["brand"] == "Apple"
+    assert snapshot["battery_pct"] == 88
+    assert "heartbeat" not in snapshot

--- a/consent-protocol/tests/test_trusted_device_migration.py
+++ b/consent-protocol/tests/test_trusted_device_migration.py
@@ -64,6 +64,14 @@ def test_trusted_device_migration_is_release_ordered_and_metadata_only() -> None
             "created_at",
             "last_used_at",
             "revoked_at",
+            # Migration 176: sync channel and seal confirmation.
+            "last_synced_at",
+            "last_sync_cursor",
+            "sealed_at",
+            # Migration 189: liveness heartbeat, the only evidence the agent
+            # is actually running (last_synced_at cannot say that).
+            "last_heartbeat_at",
+            "heartbeat",
         },
         "trusted_device_challenges": {
             "challenge_id",

--- a/docs/reference/ai/puppy-one-on-device.md
+++ b/docs/reference/ai/puppy-one-on-device.md
@@ -246,7 +246,7 @@ in the fork at
 
 | Surface | Source of truth | State after the audit |
 | --- | --- | --- |
-| `/one/puppy` header dot and model name | `GET /api/hermes/status` reading the gateway's `/health/detailed` on loopback | Repaired. The gateway did not name its model in that payload and the route read a field that never existed, so a connected agent showed no model. The gateway now reports `model` and `provider` there and the route reads every shape. |
+| `/one/puppy` header dot and model name | Two authorities, in order. `GET /api/hermes/status` (the gateway's `/health/detailed` on loopback) when the bridge is connected; otherwise `trusted_devices.last_heartbeat_at` through `fetchPuppyLink`, One's own record of the device | Repaired twice. First, the gateway did not name its model in that payload and the route read a field that never existed, so a connected agent showed no model; the gateway now reports `model` and `provider` there and the route reads every shape. Second, on a deployed origin the loopback is a Cloud Run container and never the owner's Mac, so the dot said "not connected" to every deployed viewer; it now turns green with the device name when One has a fresh heartbeat, and says "last seen …" when it has a stale one. The bridge keeps the pill whenever it is connected. |
 | Model picker | `GET /api/hermes/models` reading the gateway's `/api/model/options` | Repaired. The gateway names a provider by `slug` and lists models as strings with a capabilities map; the route mapped `id` and `{id}` objects, so every provider and model rendered as an empty string. |
 | Model pin | `POST /api/hermes/models` to the gateway's `/api/model/set` | Repaired. That route existed only in the Hermes dashboard, never in the loopback API server, so every pin from One answered "could not change the model". The API server now serves it with the same expensive-model confirmation and next-session semantics. |
 | `on-device` / `any model` pill | Browser state, sent per turn as the provider pin | Now remembered per browser. It reset to on-device on every reload while the header kept the last choice. |
@@ -256,6 +256,58 @@ in the fork at
 | On-device gate | `hussh_one.on_device_only` in the Hermes config, read by the auxiliary client and the egress audit | On for the founder's machine; readable only on the device (`hermes_cli.hussh_one_egress_audit`, the health index). Not exposed to One. |
 | Vault while the screen is locked | `hussh_one.vault.lock_with_workstation`, default off | On-device config only. The always-on agent keeps its vault while the console is locked unless the owner opts in. |
 | Daily jobs, harness, learning loop | Versioned in the Hermes fork (its scripts/hussh-one-cron directory, not this repo); graded by `hermes puppy jobs`; ledger at `~/.hermes/evolution-ledger.jsonl` | On-device only. Nothing ships the health index, the doctor state, the ledger or the job audit off the machine. |
+
+## What a person sees when Puppy One is not here
+
+The bridge under `/api/hermes/*` reaches a gateway over loopback ON THE SERVER
+(`lib/hermes/bridge-config.ts` refuses any other host). On
+`uat.one.hushh.ai` and `one.hushh.ai` that loopback is the Cloud Run
+container, never the person's Mac, so the bridge is "not connected" for every
+deployed viewer, permanently, and it used to say so with a developer's hint
+about a server env key.
+
+The link now has two authorities, and each answers a different question. The
+backend heartbeat (`trusted_devices.last_heartbeat_at` and `heartbeat`, read
+through `fetchPuppyLink` in `lib/services/puppy-one-service.ts`) is the source
+of truth for **whether the person's machine is connected to their account**,
+for every viewer on every origin. The loopback bridge is the source of truth
+for **chat and controls only**: the composer, the model picker and the
+on-device pill stay gated on it, because those need a gateway the server can
+actually reach. The two never contradict each other on one surface, because
+a connected bridge keeps the header pill and the machine sheet's live reading,
+and the heartbeat speaks only when the bridge has nothing to say.
+
+`derivePuppyLink` is pure and uses the same `HEARTBEAT_FRESH_MS` window the
+devices page uses for "Active now", so the two surfaces cannot disagree about
+one machine.
+
+| State | Source of truth | What is shown | The way out |
+| --- | --- | --- | --- |
+| Local bridge connected | `GET /api/hermes/status` on loopback | Green pill with the model name, the composer, the model picker, the on-device pill, the live machine reading in the sheet | Nothing to do |
+| Live | An active trusted device with a heartbeat inside `HEARTBEAT_FRESH_MS` | Green pill "connected · {device}". Empty state: "Puppy One is connected to your account on {device} · {model} · seen {relative}. Chat here works from that machine." with a Trusted devices link; the composer placeholder says "Chat with Puppy One from {device}". The sheet shows the heartbeat snapshot under "As reported to Hussh One {relative}" (the configured model, busy and sessions, brand and processor, memory, battery). | Use the machine, or open Trusted devices |
+| Quiet | An active device exists, none has reported inside the window | Muted pill "last seen {relative}". Empty state: "Puppy One on {device} was last seen {relative}. It may be asleep or offline. On that machine, run /hussh-one status." A device that has never reported is "trusted but has not reported yet", with no claim that it is offline. | On that machine, `/hussh-one status` |
+| Unlinked | No trusted device rows at all | Muted pill "not connected". Empty state: "Puppy One isn't connected to your account yet. Install it on your Mac, then run /hussh-one connect." with the [Get Puppy One on GitHub](https://github.com/hushh-labs/hussh-one-hermes) anchor and the Trusted devices link; composer placeholder "Connect Puppy One to start". | Install from GitHub, then `/hussh-one connect` |
+| Revoked | Only revoked rows remain | Muted pill "not connected". Empty state: "Puppy One was unlinked from this account. On that machine, run /hussh-one connect." (`connect`, not `reconnect`: a revoked device is sealed and the agent's own remedy is a fresh connect; `reconnect` repairs an expired login on a still-trusted machine and refuses to run otherwise.) | On that machine, `/hussh-one connect` |
+| Unavailable | The device list could not be read (signed out, backend down, malformed payload) | Muted pill "not connected". Empty state: "Couldn't check your Puppy One link right now." A brief backend hiccup never reads as a broken machine. | Reload; nothing about the device is implied |
+| Developer hint | The bridge's own `message` ("Set HERMES_API_SERVER_KEY …") | Rendered ONLY when `window.location.hostname` is `localhost` or `127.0.0.1` (`lib/hermes/local-host.ts`), and then only as a second muted line under the state copy above | Set the key in the webapp's server env, same value as `API_SERVER_KEY` in `~/.hermes/.env` |
+
+One fact, one place. The strip above the chat speaks only for the DEVICE's
+own account of its session (`link.session` from the bridge), which knows
+about an expired token on a still-trusted machine, something One cannot see.
+One's record of the device is explained once, in the chat panel's empty state,
+with the way out; the strip never repeats it, so the same sentence and the same
+install link cannot appear twice on one screen. Both surfaces read One's record
+from one store with one poll (`subscribePuppyLink`, a read a minute against a
+ten-minute keepalive), so the pill and the sheet change in the same moment.
+
+Two things the link deliberately does not know. On a lane whose enrollment
+kill switch is off (`HUSSH_TRUSTED_DEVICE_ENABLED`, hard "false" on dev) the
+device list still answers, so "unlinked" shows the install copy even though
+`/hussh-one connect` would be refused there; the flag is a lane decision, not
+something the page should guess at. And the model in every copy is the one the
+device has CONFIGURED, as it reported it, not proof that it is loaded: nothing
+on the device fires a heartbeat on a model change, so a new pin reaches One on
+the next push (unlock, or the ten-minute keepalive).
 
 Two surfaces remain dangling and are recorded rather than hidden:
 `/one/profile/preferences/device` (breadcrumb "On-device first") has no panel

--- a/docs/reference/iam/hermes-trusted-device-vault-enrollment.md
+++ b/docs/reference/iam/hermes-trusted-device-vault-enrollment.md
@@ -267,13 +267,25 @@ it needs no device signature.
 
 Three properties keep it safe. The payload is untrusted device input written to
 JSONB, so the service reduces it to a fixed allow-list of runtime scalars
-(machine identifier, configured model, busy flag, active session count, next
-cron run) and drops everything else rather than sanitizing it; the reduction
-runs again on read. The server stamps its own timestamp, so a device cannot
-backdate or forward-date liveness. Only rows with `status = 'active'` are
-updated, so a revoked device can never appear live again. Enforcement never
-consults these columns: trust remains decided by `status` and
-`is_trusted_device_active`.
+(machine identifier, configured model, agent version, busy flag, active session
+count, next cron run, and the machine's brand, processor, RAM total and used
+share, battery percentage, minutes remaining, charging and mains state) and
+drops everything else rather than sanitizing it, truncating text to 120
+characters and dropping out-of-range numbers; the reduction runs again on read.
+The server stamps its own timestamp, so a device cannot backdate or
+forward-date liveness. Only rows with `status = 'active'` are updated, so a
+revoked device can never appear live again. Enforcement never consults these
+columns: trust remains decided by `status` and `is_trusted_device_active`.
+
+The route itself does not validate the body with a typed model, on purpose. A
+bounded request model in front of the allow-list rejected the WHOLE beat with a
+422 when one value ran over (a 121-character model id did it), and a device
+whose beats are refused reads as gone in One while it is healthy. The route
+forwards the body and the service decides per field. It also reads both body
+shapes: Hermes builds from 2026-08-28 to 2026-09-03 posted the telemetry
+wrapped as `{"heartbeat": {...}}`, later builds post it flat, and top-level
+keys win over the wrapped block. The wrapper can be retired once every
+installed agent has updated.
 
 ### A login is not trust
 

--- a/hushh-webapp/__tests__/agent/hermes-chat-panel-link-states.test.tsx
+++ b/hushh-webapp/__tests__/agent/hermes-chat-panel-link-states.test.tsx
@@ -1,0 +1,245 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchPuppyStatus: vi.fn(),
+  // What the shared link store would hand every surface on the page.
+  link: { current: null as unknown },
+}));
+
+vi.mock("@/lib/services/puppy-one-service", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/lib/services/puppy-one-service")>();
+  return {
+    ...original,
+    fetchPuppyStatus: mocks.fetchPuppyStatus,
+  };
+});
+
+vi.mock("@/lib/hermes/use-puppy-link", () => ({
+  usePuppyLink: () => mocks.link.current,
+}));
+
+vi.mock("@/components/agent/puppy-model-picker", () => ({
+  PuppyModelPicker: () => null,
+}));
+
+import { HermesChatPanel } from "@/components/agent/hermes-chat-panel";
+import type { PuppyLink, PuppyStatus } from "@/lib/services/puppy-one-service";
+
+/**
+ * What a person sees when the bridge on the SERVER is not connected.
+ *
+ * On uat.one.hushh.ai and one.hushh.ai that is every person, always: the
+ * loopback the bridge reaches is a container, not anyone's Mac. So the empty
+ * state has to be driven by what One knows about the owner's machine, and
+ * the developer's hint about a server env key has to stay on localhost.
+ */
+
+const NOT_CONFIGURED: PuppyStatus = {
+  connected: false,
+  reason: "not_configured",
+  message:
+    "Set HERMES_API_SERVER_KEY to talk to the Hermes agent on this machine.",
+};
+
+const GITHUB = "https://github.com/hushh-labs/hussh-one-hermes";
+const DEVICES = "/one/profile/security/devices";
+
+function link(overrides: Partial<PuppyLink>): PuppyLink {
+  return {
+    state: "unavailable",
+    device: null,
+    activeCount: 0,
+    checkedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function device(overrides: Partial<NonNullable<PuppyLink["device"]>> = {}) {
+  return {
+    id: "dev-1",
+    name: "Kushal's Mac",
+    lastHeartbeatAt: Date.now() - 3 * 60_000,
+    lastSyncedAt: null,
+    heartbeat: null,
+    ...overrides,
+  };
+}
+
+const realLocation = window.location;
+
+function setHostname(hostname: string) {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...realLocation, hostname, origin: `https://${hostname}` },
+  });
+}
+
+async function mount(value: PuppyLink, status: PuppyStatus = NOT_CONFIGURED) {
+  mocks.fetchPuppyStatus.mockResolvedValue(status);
+  mocks.link.current = value;
+  const view = render(<HermesChatPanel />);
+  await waitFor(() => expect(mocks.fetchPuppyStatus).toHaveBeenCalled());
+  return view;
+}
+
+beforeEach(() => {
+  setHostname("uat.one.hushh.ai");
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: realLocation,
+  });
+});
+
+describe("HermesChatPanel when the bridge is not connected", () => {
+  it("live: names the machine, the model and when it was seen, and links the devices page", async () => {
+    await mount(
+      link({
+        state: "live",
+        activeCount: 1,
+        device: device({
+          heartbeat: { current_model: "gemma-4-26b-a4b-qat", busy: false },
+        }),
+      }),
+    );
+
+    expect(
+      await screen.findByText(
+        /Puppy One is connected to your account on Kushal's Mac · gemma-4-26b-a4b-qat · seen 3 minutes ago\. Chat here works from that machine\./,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Trusted devices" })).toHaveAttribute(
+      "href",
+      DEVICES,
+    );
+    // The pill carries the device, in the colour that means live.
+    expect(screen.getByText("connected · Kushal's Mac")).toBeInTheDocument();
+    // The composer stays gated on the bridge, and says WHY in words that
+    // agree with the green pill above it. "Puppy One is not connected" under
+    // "connected · Kushal's Mac" was the contradiction this test used to pin.
+    expect(
+      screen.getByPlaceholderText("Chat with Puppy One from Kushal's Mac"),
+    ).toBeDisabled();
+    expect(screen.queryByPlaceholderText("Puppy One is not connected")).not.toBeInTheDocument();
+    expect(screen.queryByText(/HERMES_API_SERVER_KEY/)).not.toBeInTheDocument();
+  });
+
+  it("live: omits the model clause when the snapshot did not name one", async () => {
+    await mount(link({ state: "live", activeCount: 1, device: device() }));
+    expect(
+      await screen.findByText(
+        /Puppy One is connected to your account on Kushal's Mac · seen 3 minutes ago\./,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/running/)).not.toBeInTheDocument();
+  });
+
+  it("quiet: says when the machine was last seen and how to check it", async () => {
+    await mount(
+      link({
+        state: "quiet",
+        activeCount: 1,
+        device: device({ lastHeartbeatAt: Date.now() - 2 * 60 * 60_000 }),
+      }),
+    );
+    const copy = await screen.findByText(/Puppy One on Kushal's Mac was last seen 2 hours ago/);
+    expect(copy).toHaveTextContent(
+      "Puppy One on Kushal's Mac was last seen 2 hours ago. It may be asleep or offline. On that machine, run /hussh-one status.",
+    );
+    expect(screen.getByText("last seen 2 hours ago")).toBeInTheDocument();
+  });
+
+  it("quiet: says the machine has not reported when it never has", async () => {
+    await mount(
+      link({
+        state: "quiet",
+        activeCount: 1,
+        device: device({ lastHeartbeatAt: null }),
+      }),
+    );
+    // Never reported is not "offline": the device is trusted and either older
+    // than the heartbeat or between connecting and its first push.
+    const copy = await screen.findByText(
+      /Puppy One on Kushal's Mac is trusted but has not reported yet/,
+    );
+    expect(copy).not.toHaveTextContent(/asleep or offline/);
+    expect(screen.getByText("not connected")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Puppy One on Kushal's Mac has not reported yet"),
+    ).toBeDisabled();
+  });
+
+  it("unlinked: points at the install source and the devices page", async () => {
+    await mount(link({ state: "unlinked" }));
+    expect(
+      await screen.findByText(/Puppy One isn't connected to your account yet/),
+    ).toHaveTextContent(
+      "Puppy One isn't connected to your account yet. Install it on your Mac, then run /hussh-one connect.",
+    );
+    const github = screen.getByRole("link", { name: "Get Puppy One on GitHub" });
+    expect(github).toHaveAttribute("href", GITHUB);
+    expect(github).toHaveAttribute("target", "_blank");
+    expect(github).toHaveAttribute("rel", "noopener noreferrer");
+    expect(screen.getByRole("link", { name: "Trusted devices" })).toHaveAttribute(
+      "href",
+      DEVICES,
+    );
+    expect(screen.getByText("not connected")).toBeInTheDocument();
+  });
+
+  it("revoked: says so and names the way back", async () => {
+    await mount(link({ state: "revoked" }));
+    expect(
+      await screen.findByText(/Puppy One was unlinked from this account/),
+    ).toHaveTextContent(
+      // `connect`, not `reconnect`: the agent's own remedy for a revoked
+      // (sealed) device, and `reconnect` refuses to run on one.
+      "Puppy One was unlinked from this account. On that machine, run /hussh-one connect.",
+    );
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("unavailable: admits the link could not be checked", async () => {
+    await mount(link({ state: "unavailable" }));
+    expect(
+      await screen.findByText("Couldn't check your Puppy One link right now."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("not connected")).toBeInTheDocument();
+  });
+
+  it("keeps the HERMES_API_SERVER_KEY hint off a deployed origin", async () => {
+    setHostname("uat.one.hushh.ai");
+    await mount(link({ state: "unlinked" }));
+    await screen.findByText(/isn't connected to your account yet/);
+    expect(screen.queryByText(/HERMES_API_SERVER_KEY/)).not.toBeInTheDocument();
+  });
+
+  it("shows the HERMES_API_SERVER_KEY hint on localhost, under the real state", async () => {
+    setHostname("localhost");
+    await mount(link({ state: "unlinked" }));
+    const state = await screen.findByText(/isn't connected to your account yet/);
+    const hint = screen.getByText(
+      "Set HERMES_API_SERVER_KEY to talk to the Hermes agent on this machine.",
+    );
+    expect(hint).toBeInTheDocument();
+    // Second line, not the headline.
+    expect(
+      state.compareDocumentPosition(hint) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("leaves the bridge's own pill alone when the bridge is connected", async () => {
+    await mount(
+      link({ state: "unlinked" }),
+      { connected: true, model: "gemma-4-26b-a4b-qat" },
+    );
+    expect(await screen.findByText("gemma-4-26b-a4b-qat")).toBeInTheDocument();
+    expect(screen.queryByText(/isn't connected to your account/)).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Ask Puppy One…")).not.toBeDisabled();
+  });
+});

--- a/hushh-webapp/__tests__/agent/puppy-link-store.test.ts
+++ b/hushh-webapp/__tests__/agent/puppy-link-store.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listTrustedDevices: vi.fn(),
+}));
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    listTrustedDevices: mocks.listTrustedDevices,
+  },
+}));
+
+import {
+  PUPPY_LINK_POLL_MS,
+  getPuppyLinkSnapshot,
+  refreshPuppyLink,
+  resetPuppyLinkStoreForTests,
+  subscribePuppyLink,
+} from "@/lib/services/puppy-one-service";
+
+/**
+ * One reader of the link for the whole page.
+ *
+ * The chat panel and the machine strip used to poll One on their own
+ * cadences, and disagreed on screen for up to five minutes after a heartbeat.
+ * These pin the two things that stop that: every subscriber shares one poll,
+ * and a page with no Puppy surface costs One nothing.
+ */
+
+function devices(rows: unknown[]) {
+  return { ok: true, json: async () => ({ devices: rows }) } as Response;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  resetPuppyLinkStoreForTests();
+  mocks.listTrustedDevices.mockResolvedValue(devices([]));
+});
+
+afterEach(() => {
+  resetPuppyLinkStoreForTests();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("the shared Puppy One link store", () => {
+  it("reads once for any number of subscribers, and tells all of them", async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    subscribePuppyLink(first);
+    subscribePuppyLink(second);
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mocks.listTrustedDevices).toHaveBeenCalledTimes(1);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first.mock.calls[0][0]).toEqual(second.mock.calls[0][0]);
+    expect(getPuppyLinkSnapshot()?.state).toBe("unlinked");
+  });
+
+  it("polls on one interval, not one per subscriber", async () => {
+    subscribePuppyLink(() => {});
+    subscribePuppyLink(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mocks.listTrustedDevices).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(PUPPY_LINK_POLL_MS);
+    expect(mocks.listTrustedDevices).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(PUPPY_LINK_POLL_MS);
+    expect(mocks.listTrustedDevices).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops polling when the last subscriber leaves", async () => {
+    const stopFirst = subscribePuppyLink(() => {});
+    const stopSecond = subscribePuppyLink(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+
+    stopFirst();
+    await vi.advanceTimersByTimeAsync(PUPPY_LINK_POLL_MS);
+    // One subscriber is still listening, so the poll goes on.
+    expect(mocks.listTrustedDevices).toHaveBeenCalledTimes(2);
+
+    stopSecond();
+    await vi.advanceTimersByTimeAsync(PUPPY_LINK_POLL_MS * 3);
+    // Nobody is listening: One is not asked again.
+    expect(mocks.listTrustedDevices).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares an in-flight read rather than starting a second", async () => {
+    let release: (value: Response) => void = () => {};
+    mocks.listTrustedDevices.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    const a = refreshPuppyLink();
+    const b = refreshPuppyLink();
+    expect(a).toBe(b);
+    expect(mocks.listTrustedDevices).toHaveBeenCalledTimes(1);
+
+    release(
+      devices([
+        {
+          device_id: "dev-1",
+          device_name: "Kushal's Mac",
+          status: "active",
+          created_at: Date.now(),
+          last_heartbeat_at: Date.now(),
+          heartbeat: { current_model: "gemma" },
+        },
+      ]),
+    );
+    const link = await a;
+    expect(link.state).toBe("live");
+    expect(getPuppyLinkSnapshot()).toBe(link);
+  });
+
+  it("turns a failed read into unavailable, never into install advice", async () => {
+    mocks.listTrustedDevices.mockRejectedValueOnce(new Error("backend down"));
+    const heard = vi.fn();
+    subscribePuppyLink(heard);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(heard.mock.calls[0][0].state).toBe("unavailable");
+  });
+});

--- a/hushh-webapp/__tests__/agent/puppy-link.test.ts
+++ b/hushh-webapp/__tests__/agent/puppy-link.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listTrustedDevices: vi.fn(),
+}));
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    listTrustedDevices: mocks.listTrustedDevices,
+  },
+}));
+
+import {
+  derivePuppyLink,
+  fetchPuppyLink,
+} from "@/lib/services/puppy-one-service";
+import { HEARTBEAT_FRESH_MS } from "@/lib/trusted-device/sync-display";
+
+/**
+ * The link to Hussh One, read from One's own record of the owner's devices.
+ *
+ * This is what every deployed viewer sees instead of the loopback bridge, so
+ * the two things that matter are: it says "live" only on the same evidence
+ * the devices page calls "Active now", and it never turns a failed read into
+ * advice ("install Puppy One") that a person with a working machine would
+ * follow to their cost.
+ */
+
+const NOW = Date.parse("2026-09-03T10:00:00Z");
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    device_id: "dev-1",
+    device_name: "Kushal's Mac",
+    platform: "macos",
+    status: "active",
+    created_at: NOW - 86_400_000,
+    last_used_at: null,
+    last_synced_at: null,
+    last_heartbeat_at: null,
+    heartbeat: null,
+    ...overrides,
+  };
+}
+
+describe("derivePuppyLink", () => {
+  it("is live for an active device that reported inside the window", () => {
+    const link = derivePuppyLink(
+      [
+        row({
+          last_heartbeat_at: NOW - 60_000,
+          heartbeat: { current_model: "gemma-4-26b-a4b-qat", busy: false },
+        }),
+      ],
+      NOW,
+    );
+    expect(link.state).toBe("live");
+    expect(link.activeCount).toBe(1);
+    expect(link.checkedAt).toBe(NOW);
+    expect(link.device).toEqual({
+      id: "dev-1",
+      name: "Kushal's Mac",
+      lastHeartbeatAt: NOW - 60_000,
+      lastSyncedAt: null,
+      heartbeat: { current_model: "gemma-4-26b-a4b-qat", busy: false },
+    });
+  });
+
+  it("is quiet for an active device whose last report is stale", () => {
+    const link = derivePuppyLink(
+      [row({ last_heartbeat_at: NOW - 3 * 60 * 60 * 1000 })],
+      NOW,
+    );
+    expect(link.state).toBe("quiet");
+    expect(link.device?.lastHeartbeatAt).toBe(NOW - 3 * 60 * 60 * 1000);
+  });
+
+  it("is quiet for an active device that has never reported", () => {
+    const link = derivePuppyLink([row()], NOW);
+    expect(link.state).toBe("quiet");
+    expect(link.device?.name).toBe("Kushal's Mac");
+    expect(link.device?.lastHeartbeatAt).toBeNull();
+    expect(link.device?.heartbeat).toBeNull();
+  });
+
+  it("is unlinked when there are no devices at all", () => {
+    const link = derivePuppyLink([], NOW);
+    expect(link).toEqual({
+      state: "unlinked",
+      device: null,
+      activeCount: 0,
+      checkedAt: NOW,
+    });
+  });
+
+  it("is revoked when every device was unlinked", () => {
+    const link = derivePuppyLink(
+      [
+        row({ status: "revoked", revoked_at: NOW - 1000 }),
+        row({ device_id: "dev-2", status: "revoked" }),
+      ],
+      NOW,
+    );
+    expect(link.state).toBe("revoked");
+    expect(link.device).toBeNull();
+    expect(link.activeCount).toBe(0);
+  });
+
+  it("is unavailable, not unlinked, for input that is not a list", () => {
+    for (const bad of [null, undefined, {}, "devices", 42]) {
+      expect(derivePuppyLink(bad, NOW).state).toBe("unavailable");
+    }
+  });
+
+  it("does not throw on malformed rows and reads the well-formed one beside them", () => {
+    const link = derivePuppyLink(
+      [
+        null,
+        "not a row",
+        { device_name: "no id" },
+        { device_id: "   " },
+        row({
+          device_id: "dev-ok",
+          last_heartbeat_at: "yesterday",
+          heartbeat: "not an object",
+          created_at: "x",
+        }),
+      ],
+      NOW,
+    );
+    // The bad timestamps read as "never", the bad snapshot as "none".
+    expect(link.state).toBe("quiet");
+    expect(link.device?.id).toBe("dev-ok");
+    expect(link.device?.lastHeartbeatAt).toBeNull();
+    expect(link.device?.heartbeat).toBeNull();
+  });
+
+  it("names a device with a blank name rather than rendering nothing", () => {
+    const link = derivePuppyLink([row({ device_name: "  " })], NOW);
+    expect(link.device?.name).toBe("your Mac");
+  });
+
+  it("picks the active device with the freshest heartbeat", () => {
+    const link = derivePuppyLink(
+      [
+        row({ device_id: "older-beat", last_heartbeat_at: NOW - 10 * 60_000 }),
+        row({
+          device_id: "fresh",
+          device_name: "Studio",
+          last_heartbeat_at: NOW - 60_000,
+        }),
+        row({ device_id: "never", created_at: NOW }),
+        row({ device_id: "gone", status: "revoked", last_heartbeat_at: NOW }),
+      ],
+      NOW,
+    );
+    expect(link.state).toBe("live");
+    expect(link.device?.id).toBe("fresh");
+    expect(link.device?.name).toBe("Studio");
+    expect(link.activeCount).toBe(3);
+  });
+
+  it("falls back to the newest enrolment when no active device has reported", () => {
+    const link = derivePuppyLink(
+      [
+        row({ device_id: "old", created_at: NOW - 5_000_000 }),
+        row({ device_id: "new", created_at: NOW - 1_000 }),
+      ],
+      NOW,
+    );
+    expect(link.state).toBe("quiet");
+    expect(link.device?.id).toBe("new");
+  });
+
+  it("is live at exactly HEARTBEAT_FRESH_MS and quiet one millisecond past it", () => {
+    // The same inclusive boundary the devices page uses for "Active now", so
+    // the two surfaces can never disagree about one machine.
+    expect(
+      derivePuppyLink([row({ last_heartbeat_at: NOW - HEARTBEAT_FRESH_MS })], NOW)
+        .state,
+    ).toBe("live");
+    expect(
+      derivePuppyLink(
+        [row({ last_heartbeat_at: NOW - HEARTBEAT_FRESH_MS - 1 })],
+        NOW,
+      ).state,
+    ).toBe("quiet");
+  });
+
+  it("ignores a revoked device's heartbeat when deciding liveness", () => {
+    const link = derivePuppyLink(
+      [
+        row({ status: "revoked", last_heartbeat_at: NOW }),
+        row({ device_id: "dev-2", last_heartbeat_at: NOW - HEARTBEAT_FRESH_MS * 2 }),
+      ],
+      NOW,
+    );
+    expect(link.state).toBe("quiet");
+    expect(link.device?.id).toBe("dev-2");
+  });
+});
+
+describe("fetchPuppyLink", () => {
+  beforeEach(() => {
+    mocks.listTrustedDevices.mockReset();
+  });
+
+  it("derives the link from the backend's device list", async () => {
+    mocks.listTrustedDevices.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        devices: [row({ last_heartbeat_at: Date.now() - 1_000 })],
+      }),
+    });
+    const link = await fetchPuppyLink();
+    expect(link.state).toBe("live");
+    expect(link.device?.name).toBe("Kushal's Mac");
+  });
+
+  it("is unavailable when the backend rejects", async () => {
+    mocks.listTrustedDevices.mockRejectedValue(new Error("network down"));
+    await expect(fetchPuppyLink()).resolves.toMatchObject({
+      state: "unavailable",
+      device: null,
+    });
+  });
+
+  it("is unavailable, never unlinked, on a non-OK response", async () => {
+    mocks.listTrustedDevices.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "Missing Firebase ID token" }),
+    });
+    await expect(fetchPuppyLink()).resolves.toMatchObject({
+      state: "unavailable",
+    });
+  });
+
+  it("is unavailable when the body cannot be read", async () => {
+    mocks.listTrustedDevices.mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError("bad json");
+      },
+    });
+    await expect(fetchPuppyLink()).resolves.toMatchObject({
+      state: "unavailable",
+    });
+  });
+});

--- a/hushh-webapp/__tests__/agent/puppy-machine-sheet-remote-reading.test.tsx
+++ b/hushh-webapp/__tests__/agent/puppy-machine-sheet-remote-reading.test.tsx
@@ -1,0 +1,270 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchPuppyResources: vi.fn(),
+  fetchPuppyJobs: vi.fn(),
+  setPuppyJobPaused: vi.fn(),
+  // What the shared link store would hand every surface on the page.
+  link: { current: null as unknown },
+}));
+
+vi.mock("@/lib/services/puppy-one-service", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/lib/services/puppy-one-service")>();
+  return {
+    ...original,
+    fetchPuppyResources: mocks.fetchPuppyResources,
+    fetchPuppyJobs: mocks.fetchPuppyJobs,
+    setPuppyJobPaused: mocks.setPuppyJobPaused,
+  };
+});
+
+vi.mock("@/lib/hermes/use-puppy-link", () => ({
+  usePuppyLink: () => mocks.link.current,
+}));
+
+import { PuppyMachineSheet } from "@/components/agent/puppy-resource-monitor";
+import type {
+  PuppyJobs,
+  PuppyLink,
+  PuppyResources,
+} from "@/lib/services/puppy-one-service";
+
+/**
+ * The machine as One last heard from it, for a viewer the bridge cannot serve.
+ *
+ * On a deployed origin the bridge is a container and "not answering" is its
+ * permanent state, so the heartbeat One holds is the only reading a person
+ * gets. It must render in the same rows the live reading uses. The strip above
+ * the control speaks ONLY for the device's own report of its session; One's
+ * record is the chat panel's to explain, directly under the strip, so the same
+ * sentence and the same install link can never appear twice on one screen.
+ */
+
+const UNREACHABLE: PuppyResources = { configured: true, reachable: false };
+const NOT_CONFIGURED: PuppyResources = {
+  configured: false,
+  reason: "not_configured",
+  message: "Set HERMES_API_SERVER_KEY to read the machine.",
+};
+
+function link(overrides: Partial<PuppyLink>): PuppyLink {
+  return {
+    state: "unavailable",
+    device: null,
+    activeCount: 0,
+    checkedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function liveWithSnapshot(): PuppyLink {
+  const now = Date.now();
+  return link({
+    state: "live",
+    activeCount: 1,
+    checkedAt: now,
+    device: {
+      id: "dev-1",
+      name: "Kushal's Mac",
+      lastHeartbeatAt: now - 4 * 60_000,
+      lastSyncedAt: null,
+      heartbeat: {
+        current_model: "gemma-4-26b-a4b-qat",
+        busy: true,
+        active_sessions: 2,
+        agent_version: "0.9.1",
+        brand: "Apple",
+        processor: "Apple M4 Max",
+        ram_total_gb: 128,
+        ram_used_pct: 41.2,
+        battery_pct: 12,
+        battery_charging: false,
+        on_ac: false,
+        next_cron_at: now + 14 * 60_000 + 2_000,
+      },
+    },
+  });
+}
+
+async function mount(payload: PuppyResources, value: PuppyLink) {
+  mocks.fetchPuppyResources.mockResolvedValue(payload);
+  mocks.link.current = value;
+  const view = render(<PuppyMachineSheet />);
+  await waitFor(() => expect(mocks.fetchPuppyResources).toHaveBeenCalled());
+  return view;
+}
+
+async function open() {
+  fireEvent.click(await screen.findByRole("button", { name: /this machine/i }));
+  return screen.findByRole("dialog");
+}
+
+beforeEach(() => {
+  mocks.fetchPuppyJobs.mockResolvedValue({
+    configured: true,
+    reachable: true,
+    jobs: [],
+  } satisfies PuppyJobs);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PuppyMachineSheet reading from One", () => {
+  it("renders the reported snapshot when the bridge is unreachable", async () => {
+    await mount(UNREACHABLE, liveWithSnapshot());
+    const sheet = await open();
+
+    expect(
+      within(sheet).getByText("Puppy One is not answering on this machine."),
+    ).toBeInTheDocument();
+    expect(
+      within(sheet).getByText("As reported to Hussh One 4 minutes ago"),
+    ).toBeInTheDocument();
+    expect(within(sheet).getByText("gemma-4-26b-a4b-qat")).toBeInTheDocument();
+    expect(within(sheet).getByText("busy · 2 active sessions")).toBeInTheDocument();
+    expect(within(sheet).getByText("0.9.1")).toBeInTheDocument();
+    expect(within(sheet).getByText("Apple · Apple M4 Max")).toBeInTheDocument();
+    expect(within(sheet).getByText("41% used")).toBeInTheDocument();
+    expect(within(sheet).getByText("of 128 GB")).toBeInTheDocument();
+    expect(within(sheet).getByText("12%")).toBeInTheDocument();
+    expect(within(sheet).getByText("On battery")).toBeInTheDocument();
+    expect(within(sheet).getByText("Running down")).toBeInTheDocument();
+    expect(within(sheet).getByText("Next scheduled run in 14 min")).toBeInTheDocument();
+    // The jobs slot still renders under it.
+    expect(
+      within(sheet).getByText("Nothing is scheduled on this machine."),
+    ).toBeInTheDocument();
+    // A live link is silent on the strip.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("renders the reported snapshot when the bridge is not configured", async () => {
+    await mount(NOT_CONFIGURED, liveWithSnapshot());
+    const sheet = await open();
+    expect(
+      within(sheet).getByText("Set HERMES_API_SERVER_KEY to read the machine."),
+    ).toBeInTheDocument();
+    expect(within(sheet).getByText("gemma-4-26b-a4b-qat")).toBeInTheDocument();
+    expect(within(sheet).getByText("Apple · Apple M4 Max")).toBeInTheDocument();
+  });
+
+  it("does not repeat the snapshot when the bridge is answering", async () => {
+    await mount(
+      {
+        configured: true,
+        reachable: true,
+        agent: { model: "live-model", on_device: true, on_device_gate: true },
+        machine: { ram_used_pct: 55 },
+      },
+      liveWithSnapshot(),
+    );
+    const sheet = await open();
+    expect(within(sheet).getByText("live-model")).toBeInTheDocument();
+    expect(within(sheet).queryByText(/As reported to Hussh One/)).not.toBeInTheDocument();
+    expect(within(sheet).queryByText("gemma-4-26b-a4b-qat")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing reported when the device has no snapshot", async () => {
+    await mount(
+      UNREACHABLE,
+      link({
+        state: "quiet",
+        activeCount: 1,
+        device: {
+          id: "dev-1",
+          name: "Kushal's Mac",
+          lastHeartbeatAt: null,
+          lastSyncedAt: null,
+          heartbeat: null,
+        },
+      }),
+    );
+    const sheet = await open();
+    expect(within(sheet).queryByText(/As reported to Hussh One/)).not.toBeInTheDocument();
+  });
+
+  it("leaves One's record to the chat panel: no install link, no banner on the strip", async () => {
+    // The chat panel directly under this strip explains One's record with
+    // the way out. Saying it here too put the same sentence and the same
+    // install link on one screen twice, so the strip is silent about One in
+    // every state: unlinked, quiet, revoked.
+    for (const value of [
+      link({ state: "unlinked" }),
+      link({ state: "revoked" }),
+      link({
+        state: "quiet",
+        activeCount: 1,
+        device: {
+          id: "dev-1",
+          name: "Kushal's Mac",
+          lastHeartbeatAt: Date.now() - 3 * 60 * 60_000,
+          lastSyncedAt: null,
+          heartbeat: null,
+        },
+      }),
+    ]) {
+      const view = await mount(UNREACHABLE, value);
+      expect(screen.queryByRole("status"), value.state).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: "Get Puppy One on GitHub" }),
+        value.state,
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/Hussh One/), value.state).not.toBeInTheDocument();
+      view.unmount();
+      vi.clearAllMocks();
+      mocks.fetchPuppyJobs.mockResolvedValue({
+        configured: true,
+        reachable: true,
+        jobs: [],
+      } satisfies PuppyJobs);
+    }
+  });
+
+  it("lets the device's own report speak when the bridge can read it, never both", async () => {
+    await mount(
+      {
+        configured: true,
+        reachable: true,
+        link: { session: "expired", remedy: "/hussh-one reconnect" },
+      },
+      link({ state: "unlinked" }),
+    );
+    expect(
+      await screen.findByText(/signed out of Hussh One/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Not connected to Hussh One yet/)).not.toBeInTheDocument();
+    expect(screen.getAllByRole("status")).toHaveLength(1);
+  });
+
+  it("stays silent when the bridge says not_connected, whatever One says", async () => {
+    await mount(
+      {
+        configured: true,
+        reachable: true,
+        link: { connected: false, session: "not_connected" },
+      },
+      link({ state: "revoked" }),
+    );
+    await waitFor(() =>
+      expect(mocks.fetchPuppyResources).toHaveBeenCalledTimes(1),
+    );
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Hussh One/)).not.toBeInTheDocument();
+  });
+
+  it("shows nothing from One while the bridge is still being read", async () => {
+    // Until the bridge answers, One's reading would be a second account of
+    // the machine that a live bridge is about to replace.
+    mocks.fetchPuppyResources.mockReturnValue(new Promise(() => {}));
+    mocks.link.current = liveWithSnapshot();
+    render(<PuppyMachineSheet />);
+    fireEvent.click(await screen.findByRole("button", { name: /this machine/i }));
+    const sheet = await screen.findByRole("dialog");
+    expect(within(sheet).getByText("Reading this machine…")).toBeInTheDocument();
+    expect(within(sheet).queryByText(/As reported to Hussh One/)).not.toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/__tests__/agent/puppy-machine-sheet.test.tsx
+++ b/hushh-webapp/__tests__/agent/puppy-machine-sheet.test.tsx
@@ -25,6 +25,13 @@ vi.mock("@/lib/services/puppy-one-service", async (importOriginal) => {
   };
 });
 
+// One's own record of the device is a separate authority, tested next door
+// in `puppy-machine-sheet-remote-reading.test.tsx`. Here it has nothing to
+// say, so every assertion in this file is about the device's own report.
+vi.mock("@/lib/hermes/use-puppy-link", () => ({
+  usePuppyLink: () => null,
+}));
+
 import {
   MACHINE_PANEL_SHEET_QUERY,
   PuppyMachineSheet,

--- a/hushh-webapp/__tests__/components/shared-sheet-consumers.contract.test.tsx
+++ b/hushh-webapp/__tests__/components/shared-sheet-consumers.contract.test.tsx
@@ -52,6 +52,7 @@ const SHEET_CONSUMERS = [
   "components/profile/profile-avatar-editor.tsx",
   "components/app-ui/settings-ui.tsx",
   "components/onboarding/AuthLegalDialog.tsx",
+  "components/agent/puppy-resource-monitor.tsx",
 ] as const;
 
 describe("the shared bottom sheet stays shared", () => {

--- a/hushh-webapp/components/agent/hermes-chat-panel.tsx
+++ b/hushh-webapp/components/agent/hermes-chat-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { HttpAgent } from "@ag-ui/client";
 import { Laptop, Loader2, Send } from "lucide-react";
 
@@ -9,7 +10,16 @@ import {
   PuppyModelPicker,
   type ModelSelection,
 } from "@/components/agent/puppy-model-picker";
-import { fetchPuppyStatus, type PuppyStatus } from "@/lib/services/puppy-one-service";
+import { formatRelativeTime } from "@/lib/format/relative-time";
+import { isLocalHost } from "@/lib/hermes/local-host";
+import { usePuppyLink } from "@/lib/hermes/use-puppy-link";
+import { ROUTES } from "@/lib/navigation/routes";
+import {
+  PUPPY_ONE_INSTALL_URL,
+  fetchPuppyStatus,
+  type PuppyLink,
+  type PuppyStatus,
+} from "@/lib/services/puppy-one-service";
 import { cn } from "@/lib/utils";
 
 /** Per-viewer browser preference for the on-device pill ("1" or "0"). */
@@ -68,6 +78,13 @@ export function HermesChatPanel({ className }: { className?: string }) {
   const [error, setError] = useState("");
   const sessionRef = useRef<string>("");
   const endRef = useRef<HTMLDivElement | null>(null);
+
+  // One's record of the machine comes from the shared store, so this panel
+  // and the strip above it change in the same moment. Deliberately NOT tied
+  // to the bridge read: the loopback gateway answers in under a second and
+  // the backend list can take a minute when One is slow, and awaiting both
+  // together held a connected agent hostage to a hung backend.
+  const link = usePuppyLink();
 
   const loadStatus = useCallback(async () => {
     // Through the service layer, not a raw fetch: not-running is an ordinary
@@ -178,6 +195,11 @@ export function HermesChatPanel({ className }: { className?: string }) {
   }
 
   const connected = status?.connected === true;
+  // The bridge, when it is connected, is the stronger claim and keeps the
+  // pill. Otherwise the pill says what One knows about the owner's machine.
+  const pill = connected
+    ? { live: true, label: status?.model ?? "connected" }
+    : describeLinkPill(link);
 
   return (
     <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
@@ -186,7 +208,7 @@ export function HermesChatPanel({ className }: { className?: string }) {
         <span
           className={cn(
             "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5",
-            connected
+            pill.live
               ? "bg-[rgba(52,199,89,0.12)] text-[#34C759]"
               : "bg-muted text-muted-foreground",
           )}
@@ -194,10 +216,10 @@ export function HermesChatPanel({ className }: { className?: string }) {
           <span
             className={cn(
               "size-1.5 rounded-full",
-              connected ? "bg-current" : "bg-muted-foreground/60",
+              pill.live ? "bg-current" : "bg-muted-foreground/60",
             )}
           />
-          {connected ? (status?.model ?? "connected") : "not connected"}
+          {pill.label}
         </span>
         {connected ? (
           <PuppyModelPicker onApplied={applyModel} className="ml-auto" />
@@ -226,9 +248,7 @@ export function HermesChatPanel({ className }: { className?: string }) {
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
         {!connected && status ? (
-          <p className="rounded-xl border border-dashed p-6 text-center text-sm text-muted-foreground">
-            {status.message || "Puppy One is not answering on this machine."}
-          </p>
+          <PuppyLinkEmptyState link={link} status={status} />
         ) : null}
         {connected && turns.length === 0 ? (
           <p className="rounded-xl border border-dashed p-6 text-center text-sm text-muted-foreground">
@@ -277,9 +297,7 @@ export function HermesChatPanel({ className }: { className?: string }) {
           }}
           disabled={!connected || sending}
           rows={1}
-          placeholder={
-            connected ? "Ask Puppy One…" : "Puppy One is not connected"
-          }
+          placeholder={connected ? "Ask Puppy One…" : composerPlaceholder(link)}
           className="max-h-32 min-h-[2.5rem] flex-1 resize-none rounded-xl border border-border/70 bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-accent/60 disabled:opacity-60"
         />
         <Button
@@ -294,4 +312,173 @@ export function HermesChatPanel({ className }: { className?: string }) {
       </div>
     </div>
   );
+}
+
+/**
+ * What the disabled composer says when the bridge is not the one answering.
+ *
+ * It must agree with the pill and the empty state above it. The old fixed
+ * "Puppy One is not connected" sat under a green "connected · {device}" pill,
+ * which is the one contradiction this surface exists to avoid.
+ */
+function composerPlaceholder(link: PuppyLink | null): string {
+  if (link?.state === "live" && link.device) {
+    return `Chat with Puppy One from ${link.device.name}`;
+  }
+  if (link?.state === "quiet" && link.device) {
+    return link.device.lastHeartbeatAt === null
+      ? `Puppy One on ${link.device.name} has not reported yet`
+      : "Puppy One is asleep or offline";
+  }
+  if (link?.state === "unlinked" || link?.state === "revoked") {
+    return "Connect Puppy One to start";
+  }
+  return "Puppy One is not connected";
+}
+
+/** "seen 3 minutes ago", or null when the device has never reported. */
+function seenRelative(link: PuppyLink): string | null {
+  const at = link.device?.lastHeartbeatAt ?? null;
+  if (at === null) return null;
+  return formatRelativeTime(at, Date.now()) || null;
+}
+
+/**
+ * The header pill when the bridge is not the one answering.
+ *
+ * Green means "a machine is reporting to One right now" and nothing weaker:
+ * a quiet device and an unknown link share the muted form, so the colour
+ * that promises a live agent is never spent on a guess.
+ */
+function describeLinkPill(link: PuppyLink | null): {
+  live: boolean;
+  label: string;
+} {
+  if (link?.state === "live" && link.device) {
+    return { live: true, label: `connected · ${link.device.name}` };
+  }
+  if (link?.state === "quiet") {
+    const seen = seenRelative(link);
+    if (seen) return { live: false, label: `last seen ${seen}` };
+  }
+  return { live: false, label: "not connected" };
+}
+
+/**
+ * What a person sees when the bridge on THIS server is not connected.
+ *
+ * Driven by One's own record of the owner's machine, because that is the fact
+ * the person came for. The bridge's own message is a developer's hint about
+ * a server-side env key, and it is meaningless on a deployed origin, where the
+ * server is a container and not anyone's Mac: it renders only on localhost,
+ * and then only as a second line under the real state.
+ */
+function PuppyLinkEmptyState({
+  link,
+  status,
+}: {
+  link: PuppyLink | null;
+  status: PuppyStatus;
+}) {
+  const developerHint = isLocalHost() ? status.message?.trim() || null : null;
+  return (
+    <div className="rounded-xl border border-dashed p-6 text-center text-sm text-muted-foreground">
+      <PuppyLinkCopy link={link} />
+      {developerHint ? (
+        <p className="mt-3 text-[11px] text-muted-foreground/80">
+          {developerHint}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function PuppyLinkCopy({ link }: { link: PuppyLink | null }) {
+  const trustedDevices = (
+    <Link
+      href={ROUTES.PROFILE_SECURITY_DEVICES}
+      className="underline underline-offset-2 hover:text-foreground"
+    >
+      Trusted devices
+    </Link>
+  );
+
+  if (link?.state === "live" && link.device) {
+    const model = link.device.heartbeat?.current_model?.trim();
+    const seen = seenRelative(link);
+    return (
+      <>
+        <p>
+          {/* The model is the one the machine has CONFIGURED, as it reported
+              it. "running" would claim it is loaded, which One cannot see. */}
+          Puppy One is connected to your account on {link.device.name}
+          {model ? ` · ${model}` : ""}
+          {seen ? ` · seen ${seen}` : ""}. Chat here works from that machine.
+        </p>
+        <p className="mt-2">{trustedDevices}</p>
+      </>
+    );
+  }
+
+  if (link?.state === "quiet" && link.device) {
+    const seen = seenRelative(link);
+    // A device that has NEVER reported is not asleep: it is trusted and
+    // either older than the heartbeat or between connecting and its first
+    // push. Saying "offline" about it would be a guess dressed as a fact.
+    return (
+      <p>
+        {seen ? (
+          <>
+            Puppy One on {link.device.name} was last seen {seen}. It may be
+            asleep or offline.
+          </>
+        ) : (
+          <>
+            Puppy One on {link.device.name} is trusted but has not reported
+            yet.
+          </>
+        )}{" "}
+        On that machine, run{" "}
+        <code className="font-mono text-[0.85em]">/hussh-one status</code>.
+      </p>
+    );
+  }
+
+  if (link?.state === "unlinked") {
+    return (
+      <>
+        <p>
+          Puppy One isn&apos;t connected to your account yet. Install it on
+          your Mac, then run{" "}
+          <code className="font-mono text-[0.85em]">/hussh-one connect</code>.
+        </p>
+        <p className="mt-2 flex flex-wrap justify-center gap-x-3 gap-y-1">
+          <a
+            href={PUPPY_ONE_INSTALL_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            Get Puppy One on GitHub
+          </a>
+          {trustedDevices}
+        </p>
+      </>
+    );
+  }
+
+  if (link?.state === "revoked") {
+    return (
+      <p>
+        {/* `connect`, not `reconnect`: a revoked device is sealed, and the
+            agent's own remedy for that state is a fresh connect. `reconnect`
+            is the repair for an expired login on a still-trusted machine,
+            and refuses to run on a device that is not connected. */}
+        Puppy One was unlinked from this account. On that machine, run{" "}
+        <code className="font-mono text-[0.85em]">/hussh-one connect</code>.
+      </p>
+    );
+  }
+
+  return <p>Couldn&apos;t check your Puppy One link right now.</p>;
 }

--- a/hushh-webapp/components/agent/puppy-resource-monitor.tsx
+++ b/hushh-webapp/components/agent/puppy-resource-monitor.tsx
@@ -27,12 +27,15 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
+import { formatRelativeTime } from "@/lib/format/relative-time";
+import { usePuppyLink } from "@/lib/hermes/use-puppy-link";
 import {
   fetchPuppyJobs,
   fetchPuppyResources,
   setPuppyJobPaused,
   type PuppyJob,
   type PuppyJobs,
+  type PuppyLink,
   type PuppyResidentModel,
   type PuppyResourceLink,
   type PuppyResources,
@@ -134,12 +137,22 @@ const TONE_CHIP: Record<Tone, string> = {
  * mount, because the link banner has to be able to announce a dead session
  * without the owner opening anything and the gateway offers no cheaper
  * question than the whole reading. Open, it keeps that reading current.
+ *
+ * Two links are read, from two authorities. The bridge's `payload.link` is the
+ * device's own view of its session with One, readable only on the machine the
+ * page is served from. `link` is One's own view of the device, readable from
+ * anywhere. On a deployed origin the bridge is a container and never the
+ * owner's Mac, so the second is the only one a deployed viewer ever has.
  */
 function useMachineReading(live: boolean): {
   payload: PuppyResources | null;
   readAt: number;
+  link: PuppyLink | null;
 } {
   const [payload, setPayload] = useState<PuppyResources | null>(null);
+  // One's record of the device, from the store every Puppy surface shares:
+  // one poll for the page, and one moment of change for every reader of it.
+  const link = usePuppyLink();
   // Epoch ms of the last successful read, used only when the gateway did not
   // stamp the payload. Preferring the gateway's own clock keeps "in 14 min"
   // free of skew between this browser and the machine.
@@ -188,7 +201,7 @@ function useMachineReading(live: boolean): {
     return () => clearInterval(timer);
   }, [live, read]);
 
-  return { payload, readAt };
+  return { payload, readAt, link };
 }
 
 /**
@@ -352,8 +365,13 @@ const PANEL_DESCRIPTION =
  */
 export function PuppyMachineSheet({ className }: { className?: string }) {
   const [open, setOpen] = useState(false);
-  const { payload, readAt } = useMachineReading(open);
+  const { payload, readAt, link } = useMachineReading(open);
   const scheduled = usePuppyScheduledWork(open);
+  // This strip speaks for the DEVICE's own account of its session, which
+  // knows things One cannot (an expired token on a still-trusted machine).
+  // One's record of the device is the chat panel's to explain, directly under
+  // this strip, with the way out; saying it here too put the same sentence
+  // and the same install link on one screen twice. One fact, one place.
   const linkState = describeLink(payload?.link);
   // "ok" resolves to `healthy` and "not_connected" to null, so what is left is
   // exactly the set the owner cannot be left to discover by tapping.
@@ -384,6 +402,7 @@ export function PuppyMachineSheet({ className }: { className?: string }) {
     <PuppyResourceMonitor
       payload={payload}
       readAt={readAt}
+      link={link}
       className="rounded-none border-0"
       scheduled={
         <PuppyJobList
@@ -455,7 +474,22 @@ function LinkNotice({
 }) {
   if (state.kind === "quiet") {
     return (
-      <p className="text-[11px] text-muted-foreground">{state.message}</p>
+      <p className="text-[11px] text-muted-foreground">
+        {state.message}
+        {state.action ? (
+          <>
+            {" · "}
+            <a
+              href={state.action.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              {state.action.label}
+            </a>
+          </>
+        ) : null}
+      </p>
     );
   }
   return (
@@ -500,12 +534,19 @@ function LinkNotice({
 export function PuppyResourceMonitor({
   payload,
   readAt = 0,
+  link = null,
   className,
   scheduled,
 }: {
   payload: PuppyResources | null;
   /** Epoch ms of that read. 0 means "not stamped": no relative time is shown. */
   readAt?: number;
+  /**
+   * One's record of the owner's device. Rendered ONLY when the bridge has
+   * nothing to say: a live reading from the machine itself is always the
+   * better one, and showing both would be two readings of one machine.
+   */
+  link?: PuppyLink | null;
   className?: string;
   /**
    * The job list, rendered under the "Scheduled work" summary.
@@ -522,6 +563,13 @@ export function PuppyResourceMonitor({
   // in exactly the states an owner is most likely to be looking for them: while
   // the readings are still loading, or when the readings call failed. The jobs
   // section carries its own calm states and can speak for itself.
+  //
+  // The two that KNOW the bridge has nothing also carry what One last heard
+  // from the machine: on a deployed origin the bridge is a container, so
+  // "not answering" is the permanent state there and the heartbeat is the
+  // only reading a person will ever get. The loading branch does not: until
+  // the bridge answers, showing One's reading would be a second account of
+  // the machine that a live bridge is about to replace.
   if (!payload) {
     return (
       <Shell className={className}>
@@ -541,6 +589,7 @@ export function PuppyResourceMonitor({
           {payload.message ||
             "Set HERMES_API_SERVER_KEY to read the machine Puppy One runs on."}
         </p>
+        <ReportedReading link={link} />
         {scheduled}
       </Shell>
     );
@@ -552,13 +601,14 @@ export function PuppyResourceMonitor({
         <p className="px-4 py-3 text-xs text-muted-foreground">
           Puppy One is not answering on this machine.
         </p>
+        <ReportedReading link={link} />
         {scheduled}
       </Shell>
     );
   }
 
-  const { agent, machine, models, jobs, link } = payload;
-  const linkState = describeLink(link);
+  const { agent, machine, models, jobs } = payload;
+  const linkState = describeLink(payload.link);
   const origin = describeOrigin(agent?.on_device, agent?.on_device_gate);
   const OriginIcon = origin?.icon ?? Cpu;
 
@@ -829,6 +879,139 @@ export function PuppyResourceMonitor({
         </p>
       ) : null}
     </Shell>
+  );
+}
+
+/**
+ * The machine as it last described itself to Hussh One.
+ *
+ * Only what the heartbeat carried, in the rows the live reading already uses:
+ * the model line, the memory and battery tiles, the next scheduled run. A
+ * field the device did not send renders as nothing. A desktop sends no
+ * battery, and that is not 0%.
+ */
+function ReportedReading({ link }: { link: PuppyLink | null }) {
+  const device = link?.device ?? null;
+  const snapshot = device?.heartbeat ?? null;
+  if (!device || !snapshot) return null;
+
+  const model = nonEmpty(snapshot.current_model);
+  const version = nonEmpty(snapshot.agent_version);
+  const activeSessions = finiteNumber(snapshot.active_sessions);
+  const brand = nonEmpty(snapshot.brand);
+  const processor = nonEmpty(snapshot.processor);
+  const ramTotalGb = finiteNumber(snapshot.ram_total_gb);
+  const ramUsedPct = finiteNumber(snapshot.ram_used_pct);
+  const batteryPct = finiteNumber(snapshot.battery_pct);
+  const batteryDischarging =
+    snapshot.battery_charging === false && snapshot.on_ac === false;
+  // A run that was due before this read is history the snapshot cannot
+  // update, so it is dropped rather than shown as "due now" on a machine that
+  // may have been asleep for a day.
+  const checkedAt = link?.checkedAt ?? 0;
+  const nextCronAt = finiteNumber(snapshot.next_cron_at);
+  // Bounded above as well: the backend stores any non-negative integer, and
+  // `new Date(n).toISOString()` throws past 8.64e15, which with no boundary
+  // between this sheet and the page would replace the page with the error
+  // screen for every viewer of that account. No device sends this field
+  // today; the row exists for the one that will.
+  const nextRun =
+    nextCronAt !== null && nextCronAt > checkedAt && nextCronAt <= 8.64e15
+      ? relativeTime(checkedAt, new Date(nextCronAt).toISOString())
+      : null;
+
+  const hasMachine =
+    brand !== null || processor !== null || ramTotalGb !== null;
+  const hasTiles = ramUsedPct !== null || batteryPct !== null;
+  if (!model && !hasMachine && !hasTiles && !nextRun) return null;
+
+  const activity: string[] = [];
+  if (snapshot.busy === true) activity.push("busy");
+  if (activeSessions !== null) {
+    activity.push(
+      `${activeSessions} active ${activeSessions === 1 ? "session" : "sessions"}`,
+    );
+  }
+  const seen =
+    device.lastHeartbeatAt !== null
+      ? formatRelativeTime(device.lastHeartbeatAt, link?.checkedAt)
+      : "";
+
+  return (
+    <Section label={seen ? `As reported to Hussh One ${seen}` : "As reported to Hussh One"}>
+      {model || activity.length > 0 ? (
+        <div className="flex items-start gap-3">
+          <Cpu
+            className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+            aria-hidden
+          />
+          <div className="min-w-0 flex-1">
+            {model ? (
+              <p className="truncate text-sm font-medium">{model}</p>
+            ) : null}
+            {activity.length > 0 ? (
+              <p className="text-[11px] tabular-nums text-muted-foreground">
+                {activity.join(" · ")}
+              </p>
+            ) : null}
+          </div>
+          {version ? (
+            <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+              {version}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+
+      {brand || processor ? (
+        <p
+          className={cn(
+            "truncate text-xs text-muted-foreground",
+            (model || activity.length > 0) && "mt-2",
+          )}
+        >
+          {[brand, processor].filter(Boolean).join(" · ")}
+        </p>
+      ) : null}
+
+      {hasTiles ? (
+        <div className="mt-2 grid gap-2 sm:grid-cols-3">
+          {ramUsedPct !== null ? (
+            <Tile
+              label="Memory"
+              value={`${formatPct(ramUsedPct)} used`}
+              detail={
+                ramTotalGb !== null ? `of ${formatGb(ramTotalGb)}` : undefined
+              }
+            />
+          ) : null}
+          {batteryPct !== null ? (
+            <Tile
+              label="Battery"
+              value={formatPct(batteryPct)}
+              detail={describePower(snapshot.battery_charging, snapshot.on_ac)}
+              warning={
+                batteryPct < BATTERY_WARNING_PCT && batteryDischarging
+                  ? "Running down"
+                  : undefined
+              }
+            />
+          ) : null}
+        </div>
+      ) : null}
+
+      {ramTotalGb !== null && ramUsedPct === null ? (
+        <p className="mt-2 text-[11px] tabular-nums text-muted-foreground">
+          {formatGb(ramTotalGb)} RAM on this machine
+        </p>
+      ) : null}
+
+      {nextRun ? (
+        <p className="mt-2 text-xs tabular-nums text-muted-foreground">
+          Next scheduled run {nextRun}
+        </p>
+      ) : null}
+    </Section>
   );
 }
 
@@ -1146,7 +1329,7 @@ function JobRow({
 
 type LinkState =
   | { kind: "alert"; tone: "warning" | "danger"; message: string; remedy?: string }
-  | { kind: "quiet"; message: string }
+  | { kind: "quiet"; message: string; action?: { href: string; label: string } }
   | { kind: "healthy"; message: string | null };
 
 /**

--- a/hushh-webapp/lib/hermes/local-host.ts
+++ b/hushh-webapp/lib/hermes/local-host.ts
@@ -1,0 +1,29 @@
+import { isNative } from "@/lib/capacitor/platform";
+
+/**
+ * Whether this page is being viewed from the machine that serves it.
+ *
+ * The Hermes bridge reaches a gateway over loopback ON THE SERVER. On a
+ * deployed origin that loopback is a Cloud Run container, never the viewer's
+ * own Mac, so a developer hint about the bridge's env key is meaningless to
+ * everyone but the person running `next dev` on their laptop. This is the one
+ * test that separates those two readers, and it is client-side only: on the
+ * server there is no viewer to speak of, so the answer is no.
+ */
+const LOCAL_HOSTNAMES: ReadonlySet<string> = new Set(["localhost", "127.0.0.1"]);
+
+export function isLocalHost(): boolean {
+  if (typeof window === "undefined") return false;
+  // The iOS and Android shells serve the app from a "localhost" origin too
+  // (App://localhost, https://localhost), and nobody holding a phone is the
+  // person running next dev. Without this the developer hint could reach the
+  // native app the day a status payload carries a message.
+  if (isNative()) return false;
+  try {
+    return LOCAL_HOSTNAMES.has(
+      String(window.location?.hostname ?? "").toLowerCase(),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/hushh-webapp/lib/hermes/use-puppy-link.ts
+++ b/hushh-webapp/lib/hermes/use-puppy-link.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+import {
+  getPuppyLinkSnapshot,
+  subscribePuppyLink,
+  type PuppyLink,
+} from "@/lib/services/puppy-one-service";
+
+/**
+ * The link to Hussh One, as One's backend sees it, shared by every surface
+ * on the page.
+ *
+ * Backed by one store and one poll (`subscribePuppyLink`), so the chat panel
+ * and the machine strip change together and can never disagree about one
+ * machine. Null until the first read lands; "unavailable" after a failed one.
+ */
+export function usePuppyLink(): PuppyLink | null {
+  return useSyncExternalStore(
+    subscribePuppyLink,
+    getPuppyLinkSnapshot,
+    () => null,
+  );
+}

--- a/hushh-webapp/lib/services/puppy-one-service.ts
+++ b/hushh-webapp/lib/services/puppy-one-service.ts
@@ -10,7 +10,16 @@
  *
  * These endpoints are Next route handlers on our own origin. The loopback
  * bearer key never reaches the browser; the route handler holds it.
+ *
+ * One reading here does NOT go over loopback: the link to Hussh One
+ * (`fetchPuppyLink`) is read from One's own backend, which every deployed
+ * viewer can reach. The bridge answers "is a gateway on THIS server", which on
+ * a deployed origin is never the owner's Mac; the backend answers "has the
+ * owner's machine reported in", which is the fact a person actually wants.
  */
+
+import { ApiService } from "@/lib/services/api-service";
+import { HEARTBEAT_FRESH_MS } from "@/lib/trusted-device/sync-display";
 
 export interface PuppyStatus {
   connected: boolean;
@@ -367,4 +376,276 @@ export async function assignPuppyModel(input: {
   } catch {
     return { ok: false, error: "Puppy One is not answering on this machine." };
   }
+}
+
+/** Where Puppy One is installed from. Public, so it is linked, not described. */
+export const PUPPY_ONE_INSTALL_URL =
+  "https://github.com/hushh-labs/hussh-one-hermes";
+
+/**
+ * The runtime snapshot a device posts with its heartbeat, as One stores it.
+ *
+ * Field names stay snake_case: this is the backend's allow-list
+ * (`_safe_heartbeat` in `trusted_device_service.py`) read back verbatim, and
+ * every field is optional because a device sends only what it can measure. A
+ * desktop omits the battery fields entirely rather than sending 0, so an
+ * absent field must render as nothing and never as a number.
+ */
+export interface PuppyLinkHeartbeat {
+  current_model?: string;
+  busy?: boolean;
+  active_sessions?: number;
+  /** Epoch ms of the next scheduled job on the device. */
+  next_cron_at?: number;
+  agent_version?: string;
+  machine_id?: string;
+  brand?: string;
+  processor?: string;
+  ram_total_gb?: number;
+  ram_used_pct?: number;
+  battery_pct?: number;
+  battery_minutes_remaining?: number;
+  battery_charging?: boolean;
+  on_ac?: boolean;
+}
+
+export interface PuppyLinkDevice {
+  id: string;
+  name: string;
+  /** Epoch ms. Null when the device has never reported. */
+  lastHeartbeatAt: number | null;
+  /** Epoch ms. Null when the device has never pulled the sync channel. */
+  lastSyncedAt: number | null;
+  heartbeat: PuppyLinkHeartbeat | null;
+}
+
+/**
+ * Whether Hussh One has a Puppy One to point at, as the BACKEND sees it.
+ *
+ *   live         an active device reported within `HEARTBEAT_FRESH_MS`.
+ *   quiet        an active device exists but none has reported recently:
+ *                asleep, offline, or never reported at all.
+ *   unlinked     no device has ever been connected to this account.
+ *   revoked      every device this account had was unlinked.
+ *   unavailable  the list could not be read. Says nothing about the device.
+ *
+ * `device` is set for `live` and `quiet` only: the active device with the
+ * freshest heartbeat, falling back to the most recently created one.
+ */
+export type PuppyLinkState =
+  | "live"
+  | "quiet"
+  | "unlinked"
+  | "revoked"
+  | "unavailable";
+
+export interface PuppyLink {
+  state: PuppyLinkState;
+  device: PuppyLinkDevice | null;
+  /** How many devices are still trusted, whatever their liveness. */
+  activeCount: number;
+  /** Epoch ms of the read, and the base every relative time is measured from. */
+  checkedAt: number;
+}
+
+interface TrustedDeviceRow {
+  id: string;
+  name: string;
+  status: string;
+  createdAt: number;
+  lastHeartbeatAt: number | null;
+  lastSyncedAt: number | null;
+  heartbeat: PuppyLinkHeartbeat | null;
+}
+
+function epochMs(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * One backend row, read defensively.
+ *
+ * A row that is not an object, or has no id, is skipped rather than allowed
+ * to throw: the caller must be able to say "unavailable" for a malformed list
+ * and still say "live" for a well-formed row beside a broken one.
+ */
+function readRow(value: unknown): TrustedDeviceRow | null {
+  if (!value || typeof value !== "object") return null;
+  const row = value as Record<string, unknown>;
+  const id = typeof row.device_id === "string" ? row.device_id.trim() : "";
+  if (!id) return null;
+  const name =
+    typeof row.device_name === "string" && row.device_name.trim()
+      ? row.device_name.trim()
+      : "your Mac";
+  const heartbeat =
+    row.heartbeat && typeof row.heartbeat === "object"
+      ? (row.heartbeat as PuppyLinkHeartbeat)
+      : null;
+  return {
+    id,
+    name,
+    status: typeof row.status === "string" ? row.status : "",
+    createdAt: epochMs(row.created_at) ?? 0,
+    lastHeartbeatAt: epochMs(row.last_heartbeat_at),
+    lastSyncedAt: epochMs(row.last_synced_at),
+    heartbeat,
+  };
+}
+
+function toLinkDevice(row: TrustedDeviceRow): PuppyLinkDevice {
+  return {
+    id: row.id,
+    name: row.name,
+    lastHeartbeatAt: row.lastHeartbeatAt,
+    lastSyncedAt: row.lastSyncedAt,
+    heartbeat: row.heartbeat,
+  };
+}
+
+/** Freshest heartbeat first; among the never-reported, newest enrolment first. */
+function preferFresher(
+  a: TrustedDeviceRow,
+  b: TrustedDeviceRow,
+): TrustedDeviceRow {
+  const aBeat = a.lastHeartbeatAt ?? Number.NEGATIVE_INFINITY;
+  const bBeat = b.lastHeartbeatAt ?? Number.NEGATIVE_INFINITY;
+  if (aBeat !== bBeat) return aBeat > bBeat ? a : b;
+  return b.createdAt > a.createdAt ? b : a;
+}
+
+/**
+ * Read the link state out of the backend's device list. Pure, so the same
+ * (rows, now) always answers the same way and a test can pin every branch.
+ *
+ * The freshness window is the SAME constant the devices page uses to say
+ * "Active now", so the two surfaces cannot disagree about one machine.
+ */
+export function derivePuppyLink(devices: unknown, nowMs: number): PuppyLink {
+  if (!Array.isArray(devices)) {
+    return {
+      state: "unavailable",
+      device: null,
+      activeCount: 0,
+      checkedAt: nowMs,
+    };
+  }
+
+  const rows = devices
+    .map(readRow)
+    .filter((row): row is TrustedDeviceRow => row !== null);
+  const active = rows.filter((row) => row.status === "active");
+  const revoked = rows.filter((row) => row.status === "revoked");
+
+  if (active.length === 0) {
+    return {
+      state: revoked.length > 0 ? "revoked" : "unlinked",
+      device: null,
+      activeCount: 0,
+      checkedAt: nowMs,
+    };
+  }
+
+  const chosen = active.reduce(preferFresher);
+  const fresh = active.some(
+    (row) =>
+      row.lastHeartbeatAt !== null &&
+      nowMs - row.lastHeartbeatAt <= HEARTBEAT_FRESH_MS,
+  );
+  return {
+    state: fresh ? "live" : "quiet",
+    device: toLinkDevice(chosen),
+    activeCount: active.length,
+    checkedAt: nowMs,
+  };
+}
+
+/**
+ * Read the link to Hussh One from One's own backend. Never throws: a failed
+ * read is "unavailable", which the surfaces render calmly, and is
+ * deliberately NOT "unlinked", which would tell a person with a working
+ * device to go and install one.
+ */
+export async function fetchPuppyLink(): Promise<PuppyLink> {
+  const checkedAt = Date.now();
+  try {
+    const response = await ApiService.listTrustedDevices();
+    if (!response.ok) return derivePuppyLink(null, checkedAt);
+    const payload = (await response.json()) as { devices?: unknown } | null;
+    return derivePuppyLink(payload?.devices, checkedAt);
+  } catch {
+    return derivePuppyLink(null, checkedAt);
+  }
+}
+
+/**
+ * One reader of the link for the whole page.
+ *
+ * The chat panel and the machine strip both need this fact, and when each
+ * polled it on its own cadence the two disagreed on screen: the pill turned
+ * green within thirty seconds of a heartbeat while the strip above it kept
+ * saying One had not heard from the machine for another five minutes. One
+ * fact, one poller, one moment of change. The device pushes a keepalive every
+ * ten minutes, so a read a minute is already generous.
+ */
+export const PUPPY_LINK_POLL_MS = 60_000;
+
+type LinkListener = (link: PuppyLink | null) => void;
+
+const linkStore: {
+  link: PuppyLink | null;
+  listeners: Set<LinkListener>;
+  timer: ReturnType<typeof setInterval> | null;
+  inFlight: Promise<PuppyLink> | null;
+} = { link: null, listeners: new Set(), timer: null, inFlight: null };
+
+/** The last link read, or null before the first read lands. */
+export function getPuppyLinkSnapshot(): PuppyLink | null {
+  return linkStore.link;
+}
+
+/**
+ * Re-read the link now. Single-flight: a second caller while a read is in
+ * the air shares that read rather than starting another. Every subscriber
+ * hears the answer at once.
+ */
+export function refreshPuppyLink(): Promise<PuppyLink> {
+  if (linkStore.inFlight) return linkStore.inFlight;
+  const read = fetchPuppyLink().then((next) => {
+    linkStore.inFlight = null;
+    linkStore.link = next;
+    for (const listener of linkStore.listeners) listener(next);
+    return next;
+  });
+  linkStore.inFlight = read;
+  return read;
+}
+
+/**
+ * Subscribe to the link. The first subscriber starts the poll and the last
+ * one leaving stops it, so a page with no Puppy surface costs One nothing.
+ * `useSyncExternalStore` shaped: the listener is called with the new value.
+ */
+export function subscribePuppyLink(listener: LinkListener): () => void {
+  linkStore.listeners.add(listener);
+  if (linkStore.timer === null) {
+    void refreshPuppyLink();
+    linkStore.timer = setInterval(() => void refreshPuppyLink(), PUPPY_LINK_POLL_MS);
+  }
+  return () => {
+    linkStore.listeners.delete(listener);
+    if (linkStore.listeners.size === 0 && linkStore.timer !== null) {
+      clearInterval(linkStore.timer);
+      linkStore.timer = null;
+    }
+  };
+}
+
+/** Test seam: forget the last read and stop any poll. */
+export function resetPuppyLinkStoreForTests(): void {
+  if (linkStore.timer !== null) clearInterval(linkStore.timer);
+  linkStore.timer = null;
+  linkStore.link = null;
+  linkStore.inFlight = null;
+  linkStore.listeners.clear();
 }


### PR DESCRIPTION
Closes #6451.

Two commits on top of main.

**f8f3ba813** the machine panel is a dialog on desktop (sheet below 640px) and the scheduled jobs are visible with a pause/resume switch each; the jobs route validates the id by shape, both mutation routes refuse cross-site requests, and a 2xx refusal is no longer read as success.

**f2518d602** on a deployed origin the Puppy tab said not connected to everyone because the Hermes bridge reaches loopback ON THE SERVER. The link's source of truth for every deployed viewer is now One's own heartbeat record (five states, each with a way out, install link to the public repo); one shared store and poll per page; the strip and the chat body never repeat one fact. The null heartbeat on UAT was a wire-shape mismatch: the fork now posts flat (its own commit d06d1b70c4), the route reads both shapes and never rejects a whole beat for one bad field. deploy-production.yml now reads the trusted-device flag from the production environment variable (default off) instead of a hardcoded false.

**Verified:** tsc, 186 webapp tests (20 files), eslint, service-boundary, design-system, surface map, docs; backend CI manifest 1877 pass; web-core check pass; production workflow parses.

**Not verified:** the surfaces in a browser on UAT with a linked device. The founder's device is unlinked (local disconnect 2026-09-02 19:42) and re-linking is their browser approval.

**Still open:** a command relay so a remote browser can chat and toggle jobs; the production flag itself.