### PR TITLE
fix(location): return SOS Edit contacts back to SOS, not People

### DIFF
--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -845,6 +845,39 @@ describe("top shell breadcrumbs", () => {
       "Location",
       "Emergency contacts",
     ]);
+
+    // SOS → SMS contacts → the hub immediately redirects `?action=sms-contacts`
+    // to `?action=circle-detail` (contacts now live in Circles), carrying
+    // `source=sos` along. This is the URL the person is actually looking at,
+    // so it -- not the transient `sms-contacts` one above -- is what the back
+    // button must resolve against, or it falls through to the generic
+    // circle-detail case and strands them on the People tab mid-emergency.
+    const fromSosRedirected = new URLSearchParams();
+    fromSosRedirected.set("action", "circle-detail");
+    fromSosRedirected.set("circleId", "sms-circle-1");
+    fromSosRedirected.set("view", "people");
+    fromSosRedirected.set("source", "sos");
+    const sosRedirectedTrail = resolveTopShellBreadcrumb(
+      "/one/location",
+      fromSosRedirected,
+    );
+    expect(sosRedirectedTrail?.backHref).toBe("/one/location?action=sos");
+    expect(sosRedirectedTrail?.items.map((item) => item.label)).toEqual([
+      "One",
+      "Location",
+      "Save My Soul",
+      "Emergency contacts",
+    ]);
+
+    // A circle opened from People (no SOS source) keeps its ordinary back
+    // target -- this check must not swallow every circle-detail view.
+    const fromPeopleCircle = new URLSearchParams();
+    fromPeopleCircle.set("action", "circle-detail");
+    fromPeopleCircle.set("circleId", "some-other-circle");
+    fromPeopleCircle.set("view", "people");
+    expect(
+      resolveTopShellBreadcrumb("/one/location", fromPeopleCircle)?.backHref,
+    ).toBe("/one/location?view=people");
   });
   it("retraces setup-hub-opened capabilities through their terminal acknowledgement", () => {
     // From the Set up One hub, capability handoffs carry ?from=/one/setup so the

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -767,7 +767,20 @@ function resolveTopShellBreadcrumbInner(
       // whichever one opened it (see resolveSmsContactsBackAction).
       const hubView = String(searchParams?.get("view") || "").trim();
       const smsContactsSource = searchParams?.get("source");
-      if (action === "sms-contacts" && smsContactsSource === "sos") {
+      // `?action=sms-contacts` immediately redirects (replace) to
+      // `?action=circle-detail` once the SMS Circle exists -- Issue #5426's
+      // "contacts moved into Circles" redirect above. `source=sos` rides
+      // along on that replace, so the screen the person is actually looking
+      // at carries `action=circle-detail`, not `sms-contacts`. This check
+      // used to only match `sms-contacts`, which is the URL for maybe one
+      // paint before the redirect fires -- so the SOS-aware back target
+      // below was effectively dead, and back fell through to the generic
+      // circle-detail case (`?view=people`), dropping the person on the
+      // People tab instead of back into their SOS.
+      if (
+        (action === "sms-contacts" || action === "circle-detail") &&
+        smsContactsSource === "sos"
+      ) {
         return {
           backHref: `${ROUTES.ONE_LOCATION}?action=sos`,
           width: "profile",


### PR DESCRIPTION
## Summary
- `Edit contacts` from the SOS screen opens `?action=sms-contacts&source=sos`, which immediately redirects (replace) to `?action=circle-detail` once the SMS Circle exists.
- `source=sos` rides along on that replace, but the top-shell back-button resolver only special-cased the transient `sms-contacts` URL, not the `circle-detail` one actually on screen.
- Result: tapping Back from Edit contacts mid-SOS dropped the person on the People tab instead of back into their SOS flow.
- Fix: `resolveTopShellBreadcrumb` now also recognizes `action=circle-detail` with `source=sos` and routes back to `?action=sos`.

## Test plan
- [x] `npx vitest run __tests__/utils/top-shell-breadcrumbs.test.ts` (37 passed, incl. 2 new cases covering the post-redirect URL and a non-SOS circle-detail control)
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on changed files