### PR TITLE
fix(location): sync request outcomes across devices without a full reload

### DIFF
--- a/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
+++ b/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
@@ -98,6 +98,9 @@ import {
   useConsentNotificationState,
 } from "@/components/consent/notification-provider";
 import { markOneLocationGrantUnwatched } from "@/lib/one-location/notifications";
+import { OneLocationStateResource } from "@/lib/one-location/one-location-state-resource";
+import type { OneLocationState } from "@/lib/one-location/types";
+import { CacheService } from "@/lib/services/cache-service";
 
 const EMPTY_LOCATION_STATE = {
   recipients: [],
@@ -158,6 +161,7 @@ function dispatchLocation(
 beforeEach(() => {
   window.localStorage.clear();
   window.sessionStorage.clear();
+  CacheService.getInstance().clear();
   vi.clearAllMocks();
   mocks.auth.user = mocks.user;
   mocks.platform.native = false;
@@ -490,5 +494,68 @@ describe("global One Location Feed-first notification policy", () => {
 
     expect(mocks.toast).not.toHaveBeenCalled();
     expect(mocks.startTask).not.toHaveBeenCalled();
+  });
+
+  // Without this patch, the counterpart's device only learns of a decline,
+  // withdrawal, or approval once the next full `list_state` reload lands
+  // (~10s+ on UAT) -- see mergeRequestStatus in one-location-state-resource.ts.
+  it.each([
+    { type: "location_access_denied", status: "denied" },
+    { type: "location_access_request_withdrawn", status: "cancelled" },
+    { type: "location_access_approved", status: "approved" },
+  ])(
+    "patches the cached request's status to $status on $type",
+    async ({ type, status }) => {
+      await renderReady();
+      // Seeded after mount: the provider's own reconcile-on-mount load
+      // (mocks.getState) already wrote EMPTY_LOCATION_STATE, so seeding
+      // earlier would be overwritten before the push under test fires.
+      OneLocationStateResource.write("recipient-user", {
+        ...EMPTY_LOCATION_STATE,
+        requests: [
+          {
+            id: "request-outcome-1",
+            ownerUserId: "owner-user",
+            requesterUserId: "recipient-user",
+            status: "pending",
+          },
+        ],
+      } as unknown as OneLocationState);
+
+      dispatchLocation({
+        type,
+        request_id: "request-outcome-1",
+        ...(type === "location_access_approved"
+          ? { grant_id: "grant-outcome-1" }
+          : {}),
+        owner_display_label: "Alex",
+        notification_title: "Location activity",
+        notification_body: "Location activity changed.",
+      });
+
+      expect(
+        OneLocationStateResource.peek("recipient-user")?.data.requests[0],
+      ).toMatchObject({ id: "request-outcome-1", status });
+    },
+  );
+
+  it("leaves cached state untouched when it has no row for the pushed request", async () => {
+    await renderReady();
+    OneLocationStateResource.write(
+      "recipient-user",
+      EMPTY_LOCATION_STATE as OneLocationState,
+    );
+
+    dispatchLocation({
+      type: "location_access_denied",
+      request_id: "request-unknown-1",
+      owner_display_label: "Alex",
+      notification_title: "Location activity",
+      notification_body: "Location activity changed.",
+    });
+
+    expect(
+      OneLocationStateResource.peek("recipient-user")?.data.requests,
+    ).toEqual([]);
   });
 });

--- a/hushh-webapp/__tests__/lib/one-location-state-resource.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location-state-resource.test.ts
@@ -148,4 +148,65 @@ describe("OneLocationStateResource", () => {
       expiresAt: null,
     });
   });
+
+  it("patches a request's status from a push payload without a full reload", async () => {
+    const userId = "location-resource-requester";
+    const initial = {
+      recipients: [],
+      requests: [
+        {
+          id: "req_1",
+          ownerUserId: "friend",
+          requesterUserId: userId,
+          status: "pending",
+        },
+      ],
+    } as unknown as OneLocationState;
+    OneLocationStateResource.write(userId, initial);
+
+    let resolveStale!: (state: OneLocationState) => void;
+    const staleLoad = OneLocationStateResource.load(
+      userId,
+      () =>
+        new Promise<OneLocationState>((resolve) => {
+          resolveStale = resolve;
+        }),
+    );
+
+    expect(
+      OneLocationStateResource.mergeRequestStatus(userId, {
+        id: "req_1",
+        status: "denied",
+        resolvedAt: "2026-09-04T00:00:00.000Z",
+      }),
+    ).toBe(true);
+    expect(OneLocationStateResource.peek(userId)?.data.requests[0]).toMatchObject({
+      id: "req_1",
+      ownerUserId: "friend",
+      status: "denied",
+      resolvedAt: "2026-09-04T00:00:00.000Z",
+    });
+
+    // A stale in-flight full reload from before the patch must not clobber it.
+    resolveStale(initial);
+    await staleLoad;
+    expect(
+      OneLocationStateResource.peek(userId)?.data.requests[0].status,
+    ).toBe("denied");
+  });
+
+  it("does not patch a request id it has no cached row for", () => {
+    const userId = "location-resource-requester";
+    OneLocationStateResource.write(userId, {
+      recipients: [],
+      requests: [],
+    } as unknown as OneLocationState);
+
+    expect(
+      OneLocationStateResource.mergeRequestStatus(userId, {
+        id: "req_missing",
+        status: "denied",
+      }),
+    ).toBe(false);
+  });
 });

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -808,6 +808,32 @@ export function ConsentNotificationProvider({
         dismissOneLocationShareNotification(grantId);
       }
 
+      // These three outcomes are a status flip on a request the recipient's
+      // cached state (if any) already has a row for. Patch it in place so the
+      // screen agrees with what just happened as soon as the push arrives,
+      // instead of waiting on the ~25-query full state reload every push
+      // otherwise triggers (see dispatchConsentStateChanged below) -- that
+      // reload still runs and reconciles anything this can't express, such as
+      // the new grant an approval creates.
+      if (
+        requestId &&
+        (msgType === "location_access_denied" ||
+          msgType === "location_access_request_withdrawn" ||
+          msgType === "location_access_approved")
+      ) {
+        OneLocationStateResource.mergeRequestStatus(user.uid, {
+          id: requestId,
+          status:
+            msgType === "location_access_denied"
+              ? "denied"
+              : msgType === "location_access_request_withdrawn"
+                ? "cancelled"
+                : "approved",
+          resolvedAt: new Date().toISOString(),
+          ...(grantId ? { approvedGrantId: grantId } : null),
+        });
+      }
+
       const generatedCopy = locationWorkflowNotificationCopy({
         type: msgType,
         ownerLabel: oneLocationOwnerLabel(data),

--- a/hushh-webapp/lib/one-location/one-location-state-resource.ts
+++ b/hushh-webapp/lib/one-location/one-location-state-resource.ts
@@ -1,4 +1,5 @@
 import type {
+  OneLocationAccessRequest,
   OneLocationGrant,
   OneLocationState,
 } from "@/lib/one-location/types";
@@ -85,6 +86,40 @@ export const OneLocationStateResource = {
 
     this.invalidate(userId);
     this.write(userId, { ...current, ownerGrants });
+    return true;
+  },
+
+  /**
+   * Publish a request-status outcome (denied / withdrawn / approved) without
+   * waiting for the next full state reload.
+   *
+   * The counterpart's device learns of a decision by push, and the handler
+   * used to answer it by discarding the whole cached snapshot and re-running
+   * `list_state`'s ~25 queries -- 10+ seconds to move one request from
+   * "pending" to "denied". The FCM payload already carries the request id and
+   * the outcome, so patch the matching row in place; the full reload behind
+   * it still runs in the background and reconciles anything this cannot
+   * express (e.g. the new grant an approval creates).
+   */
+  mergeRequestStatus(
+    userId: string,
+    request: Pick<OneLocationAccessRequest, "id"> &
+      Partial<OneLocationAccessRequest>,
+    fallbackState?: OneLocationState,
+  ): boolean {
+    const current = this.peek(userId)?.data ?? fallbackState;
+    if (!current) return false;
+
+    let matched = false;
+    const requests = current.requests.map((row) => {
+      if (row.id !== request.id) return row;
+      matched = true;
+      return { ...row, ...request };
+    });
+    if (!matched) return false;
+
+    this.invalidate(userId);
+    this.write(userId, { ...current, requests });
     return true;
   },
 


### PR DESCRIPTION
## Summary
- A decline/withdraw/approve on one device already sends a push carrying the request id and the outcome to the counterpart's device.
- The handler discarded that and waited for the next full Location state reload (`list_state`'s ~25 queries, ~10-12.5s on UAT even after 1610ed85e's parallelization) to reflect it -- matching the "takes 10+ sec to show up on the other device" report.
- Added `OneLocationStateResource.mergeRequestStatus` (mirrors the existing `mergeOwnerGrant` pattern) and patch the cached request's status in place the instant `location_access_denied` / `_request_withdrawn` / `_approved` arrives.
- The Location page already re-renders from any cache write via its existing `CacheService` subscription, so no new UI wiring was needed.
- The full background reload still runs afterward to reconcile anything a status-only patch can't express (e.g. the new grant an approval creates).

## Test plan
- [x] `npx vitest run __tests__/lib/one-location-state-resource.test.ts __tests__/consent-notification-provider-location.test.tsx __tests__/consent-notification-provider-connections.test.tsx` (46 passed, incl. new coverage for the merge helper and the push-handler wiring)
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on changed files