### PR TITLE
fix(location): stop the public live-location viewer 500ing on real traffic

### DIFF
--- a/hushh-webapp/__tests__/app/one-location-public-view-dynamic.contract.test.ts
+++ b/hushh-webapp/__tests__/app/one-location-public-view-dynamic.contract.test.ts
@@ -11,12 +11,18 @@ const repoRoot = path.resolve(__dirname, "..", "..");
 // -- which disagreed at runtime with the `/one` layout ancestor's own
 // `connection()`-forced dynamic rendering (app/one/layout.tsx), throwing
 // "Page changed from static to dynamic at runtime, reason: connection" as a
-// 500 on real public share links. An explicit `dynamic` export removes the
-// ambiguity. It must stay gated on CAPACITOR_BUILD exactly like
-// `generateStaticParams`: Capacitor's static export needs the opposite,
-// a real static page for its one baked-in test token.
+// 500 on real public share links.
+//
+// A route-segment `dynamic` export can't fix this: Turbopack requires that
+// value to be a static string literal ("Next.js can't recognize the exported
+// `dynamic` field in route. It needs to be a static string" -- caught by CI
+// on the first attempt), so it can't be gated on CAPACITOR_BUILD the way
+// generateStaticParams is, and a bare `force-dynamic` breaks Capacitor's
+// `output: export` build outright. Calling `connection()` in the page's own
+// render, gated exactly like generateStaticParams, is the same mechanism the
+// layout already uses successfully for this same problem.
 describe("/one/location/view/[token] dynamic rendering", () => {
-  it("forces a live web request without breaking the Capacitor static export", () => {
+  it("forces a live web request via connection(), gated off for Capacitor", () => {
     const source = readFileSync(
       path.join(
         repoRoot,
@@ -30,8 +36,11 @@ describe("/one/location/view/[token] dynamic rendering", () => {
       "utf8",
     );
 
-    expect(source).toContain('process.env.CAPACITOR_BUILD === "true"');
-    expect(source).toMatch(/dynamic\s*=\s*\n?\s*process\.env\.CAPACITOR_BUILD/);
-    expect(source).toContain('"force-dynamic"');
+    expect(source).toContain('import { connection } from "next/server"');
+    expect(source).toContain('process.env.CAPACITOR_BUILD !== "true"');
+    expect(source).toContain("await connection()");
+    // The literal-string trap this test exists to catch: a `dynamic` export
+    // can't be conditional, so it must not be reintroduced here.
+    expect(source).not.toMatch(/^\s*export const dynamic\s*=/m);
   });
 });

--- a/hushh-webapp/__tests__/app/one-location-public-view-dynamic.contract.test.ts
+++ b/hushh-webapp/__tests__/app/one-location-public-view-dynamic.contract.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+// Regression guard for #6465: the web build's `generateStaticParams` here
+// always returns `[]` (real tokens are never known at build time), so every
+// web request falls through to Next's "unlisted dynamic param" fallback path
+// -- which disagreed at runtime with the `/one` layout ancestor's own
+// `connection()`-forced dynamic rendering (app/one/layout.tsx), throwing
+// "Page changed from static to dynamic at runtime, reason: connection" as a
+// 500 on real public share links. An explicit `dynamic` export removes the
+// ambiguity. It must stay gated on CAPACITOR_BUILD exactly like
+// `generateStaticParams`: Capacitor's static export needs the opposite,
+// a real static page for its one baked-in test token.
+describe("/one/location/view/[token] dynamic rendering", () => {
+  it("forces a live web request without breaking the Capacitor static export", () => {
+    const source = readFileSync(
+      path.join(
+        repoRoot,
+        "app",
+        "one",
+        "location",
+        "view",
+        "[token]",
+        "page.tsx",
+      ),
+      "utf8",
+    );
+
+    expect(source).toContain('process.env.CAPACITOR_BUILD === "true"');
+    expect(source).toMatch(/dynamic\s*=\s*\n?\s*process\.env\.CAPACITOR_BUILD/);
+    expect(source).toContain('"force-dynamic"');
+  });
+});

--- a/hushh-webapp/app/one/location/view/[token]/page.tsx
+++ b/hushh-webapp/app/one/location/view/[token]/page.tsx
@@ -12,6 +12,26 @@ export async function generateStaticParams(): Promise<Array<{ token: string }>> 
   return [{ token: nativeStaticExportToken }];
 }
 
+/**
+ * Every web request hits this with a token absent from the (empty)
+ * static-params list above, since real tokens are never known at build time
+ * -- so 100% of web traffic falls into the "generate on demand" fallback
+ * Next.js prerenders a shell for. The `/one` layout ancestor also forces a
+ * live per-request render here via `connection()` (`app/one/layout.tsx`,
+ * added in 29b967636 so signed-in HTML is never reused across people), but
+ * that decision is invisible to this leaf's own build-time static/dynamic
+ * classification -- the two disagreed at runtime and Next.js bailed out
+ * with "Page changed from static to dynamic at runtime, reason: connection"
+ * (a 500), observed repeatedly on this route once shared links started
+ * getting opened/crawled after that layout change shipped. Declaring this
+ * leaf dynamic too removes the ambiguity outright. Capacitor's static export
+ * needs the opposite -- a real static page for its one baked-in test token,
+ * with no server to run `connection()` against -- so this stays gated
+ * exactly like `generateStaticParams` above.
+ */
+export const dynamic =
+  process.env.CAPACITOR_BUILD === "true" ? "auto" : "force-dynamic";
+
 export default async function PublicLocationViewPage({
   params,
 }: {

--- a/hushh-webapp/app/one/location/view/[token]/page.tsx
+++ b/hushh-webapp/app/one/location/view/[token]/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { connection } from "next/server";
 
 import PublicLocationViewPageClient from "./page-client";
 
@@ -12,31 +13,34 @@ export async function generateStaticParams(): Promise<Array<{ token: string }>> 
   return [{ token: nativeStaticExportToken }];
 }
 
-/**
- * Every web request hits this with a token absent from the (empty)
- * static-params list above, since real tokens are never known at build time
- * -- so 100% of web traffic falls into the "generate on demand" fallback
- * Next.js prerenders a shell for. The `/one` layout ancestor also forces a
- * live per-request render here via `connection()` (`app/one/layout.tsx`,
- * added in 29b967636 so signed-in HTML is never reused across people), but
- * that decision is invisible to this leaf's own build-time static/dynamic
- * classification -- the two disagreed at runtime and Next.js bailed out
- * with "Page changed from static to dynamic at runtime, reason: connection"
- * (a 500), observed repeatedly on this route once shared links started
- * getting opened/crawled after that layout change shipped. Declaring this
- * leaf dynamic too removes the ambiguity outright. Capacitor's static export
- * needs the opposite -- a real static page for its one baked-in test token,
- * with no server to run `connection()` against -- so this stays gated
- * exactly like `generateStaticParams` above.
- */
-export const dynamic =
-  process.env.CAPACITOR_BUILD === "true" ? "auto" : "force-dynamic";
-
 export default async function PublicLocationViewPage({
   params,
 }: {
   params: Promise<{ token: string }>;
 }) {
+  // Every web request hits this with a token absent from the (empty)
+  // static-params list above, since real tokens are never known at build
+  // time -- so 100% of web traffic falls into the "generate on demand"
+  // fallback Next.js prerenders a shell for. The `/one` layout ancestor also
+  // forces a live per-request render via `connection()` (app/one/layout.tsx,
+  // added in 29b967636 so signed-in HTML is never reused across people), but
+  // that decision is invisible to THIS leaf's own build-time static/dynamic
+  // classification -- the two disagreed at runtime and Next.js bailed out
+  // with "Page changed from static to dynamic at runtime, reason:
+  // connection" (a 500), observed repeatedly on this route once shared links
+  // started getting opened/crawled after that layout change shipped.
+  //
+  // A route-segment `dynamic` export can't fix this: Turbopack requires that
+  // value to be a static string literal, so it can't be gated on
+  // CAPACITOR_BUILD the way generateStaticParams above is, and a bare
+  // `force-dynamic` breaks Capacitor's `output: export` build outright (the
+  // same reason the layout uses `connection()` instead of `dynamic` too).
+  // Calling `connection()` again here, in this leaf's own render, ties its
+  // static/dynamic classification to the exact same already-correct
+  // mechanism instead of inheriting it secondhand from the ancestor.
+  if (process.env.CAPACITOR_BUILD !== "true") {
+    await connection();
+  }
   await params;
   return (
     <Suspense fallback={null}>


### PR DESCRIPTION
Fixes #6465.

## Summary
- Every web request to `/one/location/view/[token]` carries a token absent from `generateStaticParams`' (always empty for the web build) list, so 100% of real traffic falls into Next's "unlisted dynamic param" fallback path.
- The `/one` layout ancestor also forces a live per-request render here via `connection()` (`app/one/layout.tsx`, added in `29b967636` "disable static caching for signed-in routes" so signed-in HTML is never reused across people) -- but that decision is invisible to this leaf's own build-time static/dynamic classification.
- The two disagreed at runtime, and Next.js bailed out with `Page changed from static to dynamic at runtime, reason: connection` -- a 500. Confirmed directly against UAT Cloud Logging (`run.googleapis.com/stderr` on the `hushh-webapp` Cloud Run service): repeated occurrences starting 2 days after the layout change shipped, once shared links started getting opened/crawled.
- Fix: call `connection()` directly in this leaf's own render, gated exactly like `generateStaticParams` already is -- the same mechanism the layout ancestor already uses successfully for this exact static/Capacitor split, applied here too instead of inherited secondhand from it.

**Revision note:** the first commit used a route-segment `export const dynamic = condition ? "auto" : "force-dynamic"`. CI's `Web Core (Next.js)` build caught that Turbopack requires `dynamic` to be a static string literal, so it can never be conditional -- that commit could not have shipped. Second commit switches to the `connection()` approach above and was verified with a full local `next build`, which now completes clean.

## Note
Two sibling routes share the identical `generateStaticParams` (always-empty) + `/one` layout pattern -- `/one/location/invite/[token]` and `/one/location/request/[token]` -- but neither shows any 500s in UAT logs over the last 14 days, likely just lower/different traffic exposure rather than being structurally immune. Flagging as a possible latent risk, not fixed here since there's no evidence of actual failure -- worth a follow-up if it ever surfaces.

## Test plan
- [x] New contract test asserting the leaf calls `connection()` gated on `CAPACITOR_BUILD`, and does NOT reintroduce a `dynamic` export (`__tests__/app/one-location-public-view-dynamic.contract.test.ts`), alongside the existing sibling contract test for the layout's `connection()` call
- [x] Full local `next build` completes clean (this is what CI's `Web Core` job runs)
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on changed files