### PR TITLE
fix(location): resolve your own SMS Circle, not one you were added to

### DIFF
--- a/hushh-webapp/__tests__/lib/one-location-system-circles.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location-system-circles.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveOwnSmsSystemCircleId } from "@/lib/one-location/system-circles";
+import type { OneLocationCircleSummary } from "@/lib/one-location/types";
+
+function circle(
+  overrides: Partial<OneLocationCircleSummary>,
+): OneLocationCircleSummary {
+  return {
+    id: "circle_default",
+    name: "Circle",
+    kind: "other",
+    role: "member",
+    memberCount: 1,
+    memberLimit: null,
+    isSystem: false,
+    systemKind: null,
+    ...overrides,
+  };
+}
+
+describe("resolveOwnSmsSystemCircleId", () => {
+  it("returns the viewer's own SMS system Circle", () => {
+    const circles = [
+      circle({ id: "own_sms", isSystem: true, role: "owner" }),
+    ];
+    expect(resolveOwnSmsSystemCircleId(circles)).toBe("own_sms");
+  });
+
+  // The regression: joining someone else's SMS Circle after your own was
+  // provisioned put theirs first (backend orders by recency), and an
+  // unfiltered `find` picked it -- redirecting "Edit contacts" and "add a
+  // contact" into a Circle the viewer cannot manage.
+  it("skips a foreign SMS Circle even when it sorts first", () => {
+    const circles = [
+      circle({ id: "someone_elses_sms", isSystem: true, role: "member" }),
+      circle({ id: "own_sms", isSystem: true, role: "owner" }),
+    ];
+    expect(resolveOwnSmsSystemCircleId(circles)).toBe("own_sms");
+  });
+
+  it("returns null when the viewer has no own system Circle yet", () => {
+    const circles = [
+      circle({ id: "someone_elses_sms", isSystem: true, role: "member" }),
+      circle({ id: "an_ordinary_circle", role: "owner" }),
+    ];
+    expect(resolveOwnSmsSystemCircleId(circles)).toBeNull();
+  });
+
+  it("returns null for an empty Circle list", () => {
+    expect(resolveOwnSmsSystemCircleId([])).toBeNull();
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -122,6 +122,7 @@ import {
   type CircleRecipientSelection,
 } from "@/lib/one-location/circle-recipient-selection";
 import type { AutoApproveScope } from "@/lib/one-location/location-control-state";
+import { resolveOwnSmsSystemCircleId } from "@/lib/one-location/system-circles";
 
 import {
   Avatar,
@@ -1241,9 +1242,11 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
    * and redirecting again. And it waits for the Circle to exist -- provisioning
    * is a network call, and until it answers the old screen is still a working
    * answer to the same question rather than a dead end.
+   *
+   * Must be YOUR OWN system Circle -- see resolveOwnSmsSystemCircleId.
    */
   const smsSystemCircleId = useMemo(
-    () => vm.circles.find((circle) => circle.isSystem)?.id ?? null,
+    () => resolveOwnSmsSystemCircleId(vm.circles),
     [vm.circles],
   );
   // Trusted can grow to thousands of auto-synced connections. It is a useful

--- a/hushh-webapp/lib/one-location/system-circles.ts
+++ b/hushh-webapp/lib/one-location/system-circles.ts
@@ -1,0 +1,24 @@
+import type { OneLocationCircleSummary } from "@/lib/one-location/types";
+
+/**
+ * Resolve the viewer's OWN SMS/Emergency system Circle, never one they were
+ * merely added to.
+ *
+ * A system Circle lists everyone who belongs to it, including on the
+ * accounts of people who joined someone else's -- that is how an SMS Circle
+ * you were added to shows up in your own Circles list at all. An unfiltered
+ * `find` over that list can therefore return a circle you do not own, and
+ * the backend orders Circles by recency (`list_circles`), so joining one
+ * after your own was provisioned made theirs sort first. Every action that
+ * assumed "my system Circle" -- Edit contacts, adding a contact -- then
+ * landed on someone else's, where you are not the owner and cannot manage
+ * it.
+ */
+export function resolveOwnSmsSystemCircleId(
+  circles: readonly OneLocationCircleSummary[],
+): string | null {
+  return (
+    circles.find((circle) => circle.isSystem && circle.role === "owner")
+      ?.id ?? null
+  );
+}


### PR DESCRIPTION
Fixes #6466.

## Summary
- A system Circle lists everyone who belongs to it, including on the accounts of people who joined someone else's -- that is how an SMS/Emergency Circle you were added to shows up in your own Circles list at all.
- The hub's `smsSystemCircleId` lookup did an unfiltered `find()` over that list, and the backend orders Circles by recency (`list_circles`), so joining one after your own was provisioned made theirs sort first.
- Every action that assumed "my system Circle" -- Edit contacts (including from the SOS flow), adding a contact -- then redirected into someone else's Circle, where you are not the owner and cannot manage it:
  - Creating/reaching your own circle silently landed you on theirs.
  - Adding a user bounced you right back to it.
- Fix: extracted the lookup into `resolveOwnSmsSystemCircleId`, filtered by `role === "owner"` (a field the backend already returns precisely for this purpose), so a foreign SMS Circle can never be picked regardless of list order.

## Test plan
- [x] New unit tests for `resolveOwnSmsSystemCircleId`, including the exact regression scenario (foreign circle sorts first) (`__tests__/lib/one-location-system-circles.test.ts`)
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on changed files