### PR TITLE
fix(location): 1-hour circle re-add cooldown, toast states exact time left

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -40,7 +40,7 @@ CIRCLE_CODE_TTL_HOURS = 72
 # invited. It stays because the invitations written before that change are
 # still readable, and accept/decline still refuse the ones that ran out.
 CIRCLE_MEMBER_INVITE_TTL_HOURS = 72
-CIRCLE_MEMBER_REINVITE_COOLDOWN_HOURS = 12
+CIRCLE_MEMBER_REINVITE_COOLDOWN_HOURS = 1
 # How many people may be on one SMS Circle.
 #
 # Deliberately far below an ordinary Circle's hundred, because this is not a
@@ -119,6 +119,26 @@ class OneLocationCircleError(RuntimeError):
         self.message = message
         self.status_code = status_code
         super().__init__(message)
+
+
+def _format_cooldown_remaining(remaining_seconds: int | float | None) -> str:
+    """"in 47 minutes" / "in 2 hours 5 minutes" / "in under a minute".
+
+    Rounds UP to the minute so the toast never promises a shorter wait than
+    the database will actually honor -- the person re-tries at the stated
+    time and it works, rather than "in 1 minute" meaning "in 1-119 seconds".
+    """
+    total_seconds = max(0, int(remaining_seconds or 0))
+    if total_seconds < 60:
+        return "in under a minute"
+    total_minutes = -(-total_seconds // 60)  # ceil
+    hours, minutes = divmod(total_minutes, 60)
+    if hours <= 0:
+        return f"in {minutes} minute{'s' if minutes != 1 else ''}"
+    parts = [f"{hours} hour{'s' if hours != 1 else ''}"]
+    if minutes:
+        parts.append(f"{minutes} minute{'s' if minutes != 1 else ''}")
+    return "in " + " ".join(parts)
 
 
 def normalize_circle_code(value: str) -> str:
@@ -3403,7 +3423,12 @@ class OneLocationCircleService:
                                 AND ended_at > NOW() - make_interval(
                                   hours => :reinvite_cooldown_hours
                                 )
-                              ) AS left_recently
+                              ) AS left_recently,
+                              GREATEST(0, EXTRACT(EPOCH FROM (
+                                ended_at + make_interval(
+                                  hours => :reinvite_cooldown_hours
+                                ) - NOW()
+                              )))::int AS left_recently_remaining_seconds
                             FROM one_location_circle_memberships
                             WHERE circle_id = CAST(:circle_id AS UUID)
                               AND user_id = ANY(CAST(:invitee_user_ids AS TEXT[]))
@@ -3435,6 +3460,7 @@ class OneLocationCircleService:
                 # added, and an add naming only blocked people still fails
                 # loudly rather than silently succeeding with nobody.
                 blocked_reasons: dict[str, str] = {}
+                left_recently_remaining_seconds: list[int] = []
                 for row in target_membership_rows:
                     blocked_user_id = str(row.get("user_id") or "")
                     if not blocked_user_id:
@@ -3443,6 +3469,9 @@ class OneLocationCircleService:
                         blocked_reasons[blocked_user_id] = "already_member"
                     elif bool(row.get("left_recently")):
                         blocked_reasons[blocked_user_id] = "left_recently"
+                        left_recently_remaining_seconds.append(
+                            int(row.get("left_recently_remaining_seconds") or 0)
+                        )
                 if blocked_reasons:
                     cleaned_invitee_user_ids = [
                         user_id
@@ -3459,9 +3488,15 @@ class OneLocationCircleService:
                             "One or more selected connections are already in the Circle.",
                             status_code=409,
                         )
+                    # The longest wait among everyone blocked this way, so the
+                    # toast never understates how long the cooldown actually
+                    # runs when more than one person is affected at once.
+                    retry_in = _format_cooldown_remaining(
+                        max(left_recently_remaining_seconds, default=0)
+                    )
                     raise OneLocationCircleError(
                         "LOCATION_CIRCLE_MEMBER_LEFT_RECENTLY",
-                        "Someone you selected recently left this Circle. Try again later.",
+                        f"They recently left this Circle. You can add them again {retry_in}.",
                         status_code=429,
                     )
                 # Leaving is that person saying no to this Circle specifically,
@@ -3623,14 +3658,28 @@ class OneLocationCircleService:
                 # actor; the check above requires it. So everyone named here is
                 # added, and nobody is left waiting.
                 new_user_ids = list(cleaned_invitee_user_ids)
-                if any(
-                    str(row.get("invitee_user_id") or "") in new_user_ids
-                    and str(row.get("status") or "") in {"declined", "cancelled", "expired"}
+                cooldown_invite_rows = [
+                    row
                     for row in existing_rows
-                ):
+                    if str(row.get("invitee_user_id") or "") in new_user_ids
+                    and str(row.get("status") or "") in {"declined", "cancelled", "expired"}
+                ]
+                if cooldown_invite_rows:
+                    now = datetime.now(timezone.utc)
+                    responded_at_values = [
+                        value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+                        for row in cooldown_invite_rows
+                        if isinstance(value := row.get("updated_at"), datetime)
+                    ]
+                    cooldown_until = max(responded_at_values, default=now) + timedelta(
+                        hours=CIRCLE_MEMBER_REINVITE_COOLDOWN_HOURS
+                    )
+                    retry_in = _format_cooldown_remaining(
+                        (cooldown_until - now).total_seconds()
+                    )
                     raise OneLocationCircleError(
                         "LOCATION_CIRCLE_INVITE_COOLDOWN",
-                        "This person recently responded to a Circle invitation. Try again later.",
+                        f"This person recently responded to a Circle invitation. Try again {retry_in}.",
                         status_code=429,
                     )
                 capacity_row = _first(

--- a/consent-protocol/tests/services/test_one_location_circle_service.py
+++ b/consent-protocol/tests/services/test_one_location_circle_service.py
@@ -9,6 +9,7 @@ import pytest
 import hushh_mcp.services.one_location_circle_service as circle_service_module
 import hushh_mcp.services.push_notifications as push_notifications_module
 from hushh_mcp.services.one_location_circle_service import (
+    CIRCLE_MEMBER_REINVITE_COOLDOWN_HOURS,
     OneLocationCircleError,
     OneLocationCircleService,
     format_circle_code,
@@ -1807,7 +1808,7 @@ def test_recent_terminal_invite_enforces_a_circle_wide_reinvite_cooldown() -> No
     assert raised.value.status_code == 429
     # The cooldown outlived the invitation flow on purpose. A declined
     # invitation is that person saying no; without this, adding them directly
-    # would be a way to overrule it twelve hours early.
+    # would be a way to overrule it early.
     assert not any("INSERT INTO one_location_circle_memberships" in sql for sql in conn.sql)
 
 
@@ -2093,9 +2094,10 @@ def test_leaving_a_circle_cannot_be_undone_the_moment_it_happens() -> None:
     could put you back the instant you left, as many times as they liked, and
     each round is a push notification.
 
-    So leaving now costs the same twelve hours a decline does. It binds the
-    OWNER too: every other rule here protects a Circle from its members, and
-    this one protects a person from the Circle.
+    So leaving now costs the same cooldown a decline does
+    (CIRCLE_MEMBER_REINVITE_COOLDOWN_HOURS). It binds the OWNER too: every
+    other rule here protects a Circle from its members, and this one protects
+    a person from the Circle.
 
     The permanent remedy is one level up and always was -- a connection is
     what makes adding possible at all, so disconnecting ends it outright.
@@ -2134,6 +2136,149 @@ def test_leaving_a_circle_cannot_be_undone_the_moment_it_happens() -> None:
     # Refused before anything is read about the pair, and nobody is written.
     assert not any("FROM connections connection" in sql for sql in conn.sql)
     assert not any("INSERT INTO one_location_circle_memberships" in sql for sql in conn.sql)
+
+
+def test_the_reinvite_cooldown_is_one_hour() -> None:
+    """#6467: was twelve hours, product asked for one."""
+    assert CIRCLE_MEMBER_REINVITE_COOLDOWN_HOURS == 1
+
+
+def test_left_recently_toast_states_the_exact_time_remaining() -> None:
+    """#6467: the toast must say when, not just "later"."""
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    conn = _CapacityConnection(
+        {
+            "id": circle_id,
+            "name": "Family",
+            "kind": "family",
+            "owner_user_id": "owner-user",
+            "member_limit": 20,
+        },
+        {"role": "owner", "inviter_display_name": "Owner"},
+        [{"user_id": "friend-one"}],
+        None,
+        [
+            {
+                "user_id": "friend-one",
+                "status": "left",
+                "left_recently": True,
+                "left_recently_remaining_seconds": 45 * 60,
+            }
+        ],
+    )
+    service = OneLocationCircleService(
+        db=_TransactionDb(conn),  # type: ignore[arg-type]
+        hmac_key="a" * 32,
+    )
+
+    with pytest.raises(OneLocationCircleError) as raised:
+        service.create_member_invites(
+            actor_user_id="owner-user",
+            circle_id=circle_id,
+            invitee_user_ids=["friend-one"],
+        )
+
+    assert raised.value.code == "LOCATION_CIRCLE_MEMBER_LEFT_RECENTLY"
+    assert "in 45 minutes" in raised.value.message
+
+
+def test_left_recently_toast_rounds_up_and_reports_the_longest_wait() -> None:
+    """Two people blocked at once: the toast must not understate either wait."""
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    conn = _CapacityConnection(
+        {
+            "id": circle_id,
+            "name": "Family",
+            "kind": "family",
+            "owner_user_id": "owner-user",
+            "member_limit": 20,
+        },
+        {"role": "owner", "inviter_display_name": "Owner"},
+        [{"user_id": "friend-one"}, {"user_id": "friend-two"}],
+        None,
+        [
+            {
+                "user_id": "friend-one",
+                "status": "left",
+                "left_recently": True,
+                # 61 seconds must round UP to 2 minutes, never down to 1 --
+                # retrying at "1 minute" would still be inside the window.
+                "left_recently_remaining_seconds": 61,
+            },
+            {
+                "user_id": "friend-two",
+                "status": "left",
+                "left_recently": True,
+                "left_recently_remaining_seconds": 75 * 60,  # 1h 15m
+            },
+        ],
+    )
+    service = OneLocationCircleService(
+        db=_TransactionDb(conn),  # type: ignore[arg-type]
+        hmac_key="a" * 32,
+    )
+
+    with pytest.raises(OneLocationCircleError) as raised:
+        service.create_member_invites(
+            actor_user_id="owner-user",
+            circle_id=circle_id,
+            invitee_user_ids=["friend-one", "friend-two"],
+        )
+
+    assert "in 1 hour 15 minutes" in raised.value.message
+
+
+def test_invite_cooldown_toast_states_the_exact_time_remaining() -> None:
+    """#6467: same exact-time requirement for the declined-invite cooldown."""
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    conn = _CapacityConnection(
+        {
+            "id": circle_id,
+            "name": "Family",
+            "kind": "family",
+            "owner_user_id": "owner-user",
+            "member_limit": 20,
+            "role": "member",
+        },
+        {"role": "member", "inviter_display_name": "Member"},
+        [{"user_id": "friend-one"}],
+        None,
+        [],
+        [
+            {
+                "connection_id": "connection-1",
+                "user_id": "friend-one",
+                "invitee_display_name": "Friend One",
+            }
+        ],
+        [{"connection_id": "connection-1"}],
+        [
+            {
+                "id": "550e8400-e29b-41d4-a716-446655440002",
+                "circle_id": circle_id,
+                "inviter_user_id": "another-member",
+                "invitee_user_id": "friend-one",
+                "status": "declined",
+                "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+                # Declined 45 minutes ago against a 1-hour cooldown -> 15 left.
+                "updated_at": datetime.now(timezone.utc) - timedelta(minutes=45),
+            }
+        ],
+    )
+    service = OneLocationCircleService(
+        db=_TransactionDb(conn),  # type: ignore[arg-type]
+        hmac_key="a" * 32,
+    )
+
+    with pytest.raises(OneLocationCircleError) as raised:
+        service.create_member_invites(
+            actor_user_id="owner-user",
+            circle_id=circle_id,
+            invitee_user_ids=["friend-one"],
+        )
+
+    assert raised.value.code == "LOCATION_CIRCLE_INVITE_COOLDOWN"
+    assert "in 15 minutes" in raised.value.message
 
 
 def test_an_old_departure_does_not_block_being_added_back(


### PR DESCRIPTION
Fixes #6467.

## Summary
- `CIRCLE_MEMBER_REINVITE_COOLDOWN_HOURS` was 12; product asked for 1.
- The two cooldown refusals -- adding back someone who just left a Circle, and re-inviting someone who just declined/cancelled/expired an invite -- gave generic "Try again later" toasts with no way to know when "later" was.
- Both now compute the exact remaining time (from the DB row already read in the same transaction, so no clock skew against the cooldown it is reporting) and state it: "in 47 minutes", "in 1 hour 15 minutes", "in under a minute". When more than one person in a batch is blocked, the longest wait is reported so the toast never understates it.
- Already circle-kind-agnostic: `create_member_invites` is the one add path for every Circle type (family/friends/other/system), not an SMS-specific one -- so no separate generalization work was needed for the "apply to all circle types" requirement.

## Test plan
- [x] New tests: cooldown constant is 1 hour; left-recently toast states exact minutes; rounds up and reports the longest wait across a blocked batch; declined-invite cooldown toast states exact minutes (`tests/services/test_one_location_circle_service.py`, 89/89 passing incl. 4 new)
- [x] `ruff check` on changed files
- [x] `mypy` on the changed service file -- the 2 pre-existing errors it reports are unrelated to this change (confirmed against the pre-change file)