### PR TITLE
fix(location): saved-place category icons were white on white

### DIFF
--- a/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
@@ -204,9 +204,17 @@ describe("SavedLocationsSection", () => {
     expect(
       screen.queryByText("Encrypted in your vault."),
     ).not.toBeInTheDocument();
-    expect(screen.getByTestId("saved-location-icon-home")).toHaveAttribute(
-      "data-icon-tone",
-      "neutral-graphite",
+    const homeIcon = screen.getByTestId("saved-location-icon-home");
+    expect(homeIcon).toHaveAttribute("data-icon-tone", "neutral-graphite");
+    // Regression guard: this tile previously painted a white icon on a white
+    // background (both pointed at the "foreground" token), rendering
+    // invisible. The tile must use -background and the glyph -foreground,
+    // like every other icon tile in the app.
+    expect(homeIcon.className).toContain(
+      "bg-[color:var(--app-icon-tile-background)]",
+    );
+    expect(homeIcon.className).toContain(
+      "text-[color:var(--app-icon-tile-foreground)]",
     );
     expect(screen.queryByText(/12\.9763|77\.5929/)).not.toBeInTheDocument();
     expect(mocks.loadSavedLocations).toHaveBeenCalledWith({

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -52,7 +52,11 @@ function CategoryIcon({ category }: { category: SavedLocationCategory }) {
     category === "home" ? Home : category === "work" ? Briefcase : MapPin;
   return (
     <span
-      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[9px] bg-[color:var(--app-icon-tile-foreground)] text-white"
+      // Was `bg-[...-foreground]` with `text-white` -- the tile's own
+      // foreground token IS white, so that painted a white icon on a white
+      // tile. Every other icon tile in the app pairs -background (the tile)
+      // with -foreground (the glyph); see components/app-ui/page-sections.tsx.
+      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[9px] bg-[color:var(--app-icon-tile-background)] text-[color:var(--app-icon-tile-foreground)]"
       data-testid={`saved-location-icon-${category}`}
       data-icon-tone="neutral-graphite"
       aria-hidden="true"


### PR DESCRIPTION
Fixes #6469.

## Summary
- `CategoryIcon` (Home/Work/Other rows on the Places list) painted its tile background from `--app-icon-tile-foreground` (white) and the glyph with a hardcoded `text-white` -- both pointed at the same white, so the icon rendered with zero contrast against its own tile. Visually: no icon at all, just the label and chevron, matching the screenshot.
- Every other icon tile in the app pairs `-background` (the tile color) with `-foreground` (the glyph color) -- see `components/app-ui/page-sections.tsx`. Swapped `CategoryIcon` to that same pairing (`--app-icon-tile-background` for the tile, `--app-icon-tile-foreground` for the glyph), which also makes the tile match its own `data-icon-tone="neutral-graphite"` marker that was already on the element.

## Test plan
- [x] New assertion locking in the correct background/foreground class pairing so this can't silently regress (`components/one-location/__tests__/saved-locations-section.test.tsx`), 10/10 passing
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on changed files