### PR TITLE
chore(governance): grant msainani the same standing as kushaltrivedi5

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -21,6 +21,7 @@
     "require_conversation_resolution": true,
     "review_bypass_users": [
       "kushaltrivedi5",
+      "msainani",
       "RGlodAkshat",
       "ankitkumarsingh1702",
       "azfx",
@@ -41,6 +42,7 @@
     "merge_queue_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_bypass_users": [
       "kushaltrivedi5",
+      "msainani",
       "RGlodAkshat",
       "ankitkumarsingh1702",
       "azfx",
@@ -56,6 +58,7 @@
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
+      "msainani",
       "RGlodAkshat",
       "ankitkumarsingh1702",
       "azfx",
@@ -80,6 +83,7 @@
     "require_conversation_resolution": true,
     "review_bypass_users": [
       "kushaltrivedi5",
+      "msainani",
       "RGlodAkshat",
       "ankitkumarsingh1702",
       "azfx",
@@ -100,6 +104,7 @@
     "merge_queue_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_bypass_users": [
       "kushaltrivedi5",
+      "msainani",
       "RGlodAkshat",
       "ankitkumarsingh1702",
       "azfx",
@@ -118,6 +123,7 @@
     "environment": "dev",
     "manual_dispatch_users": [
       "kushaltrivedi5",
+      "msainani",
       "RGlodAkshat",
       "ankitkumarsingh1702",
       "azfx",
@@ -136,6 +142,7 @@
     ],
     "manual_dispatch_users": [
       "kushaltrivedi5",
+      "msainani",
       "RGlodAkshat",
       "ankitkumarsingh1702",
       "azfx",
@@ -153,6 +160,7 @@
     ],
     "manual_dispatch_users": [
       "kushaltrivedi5",
+      "msainani",
       "ankitkumarsingh1702",
       "RGlodAkshat",
       "DamriaNeelesh",

--- a/scripts/ci/verify-deployment-environment-governance.py
+++ b/scripts/ci/verify-deployment-environment-governance.py
@@ -25,6 +25,12 @@ DEFAULT_REPO = "hushh-labs/hushh-research"
 # grant on 2026-08-28 widened the gap to 5-vs-2). Stated explicitly now.
 PRODUCTION_MANUAL_DISPATCH_USERS = [
     "kushaltrivedi5",
+    # Manish Sainani's second GitHub account, granted parity with `kushaltrivedi5`
+    # on 2026-09-04 at the founder's request after `msainani` became the pushing
+    # actor and every protected-surface edit on the workstream branch went red.
+    # Mirrored here deliberately, which is what this constant exists to force: a
+    # production-dispatch grant is stated twice or not at all.
+    "msainani",
     "ankitkumarsingh1702",
     "RGlodAkshat",
     "DamriaNeelesh",


### PR DESCRIPTION
Delta only: two files, fourteen added lines, nothing else from the workstream branch.

## Why this has to be on `main`

All three deploy lanes check out `ref: main` before running
`scripts/ci/assert-governed-actor.py --surface <lane> --actor "$GITHUB_ACTOR"`, and that
script reads `config/ci-governance.json` from **main's** checkout. `main` carries no
`msainani`, so dev, uat and production dispatch are refused for that actor no matter what
the feature branch says.

The PR-validation half was already fixed on the workstream branch, because
`verify-protected-pipeline-edits.py` reads the config from the PR head.

## What changed

`msainani` (Manish Sainani, id 4391006, already a repo admin) added to the eight lists
that carry `kushaltrivedi5`: `protected_pipeline_edit_users`, `review_bypass_users` and
`merge_queue_bypass_users` on both `main` and `pr_train`, and the `dev`, `uat` and
**`production`** `manual_dispatch_users`.

The production grant is stated twice on purpose. `PRODUCTION_MANUAL_DISPATCH_USERS` in
`scripts/ci/verify-deployment-environment-governance.py` exists so a production-dispatch
grant cannot ride in as a one-line JSON diff nobody reads closely, and it is mirrored in
this same PR, which is what that control asks for.

## Verified locally on this branch

- governance lane green
- `assert-governed-actor.py` exits 0 for `msainani` on dev, uat and production
- negative control: `random-contributor` still refused on production (exit 1)
- `verify-protected-pipeline-edits.py` allows `msainani`, still blocks a stranger
- the branch-governance doc still transcribes no membership
