### PR TITLE
fix(ios): stop Siri Location shortcuts colliding with the Phone domain

### DIFF
--- a/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
+++ b/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
@@ -270,8 +270,14 @@ enum OneLocationStateIntentValue: String, AppEnum {
 
     static let typeDisplayRepresentation: TypeDisplayRepresentation = "Location State"
     static let caseDisplayRepresentations: [Self: DisplayRepresentation] = [
-        .on: "On",
-        .off: "Off"
+        .on: DisplayRepresentation(
+            title: "On",
+            synonyms: ["Enable", "Enabled", "Resume", "Resumed", "Start"]
+        ),
+        .off: DisplayRepresentation(
+            title: "Off",
+            synonyms: ["Disable", "Disabled", "Pause", "Paused", "Stop"]
+        )
     ]
 }
 
@@ -880,7 +886,6 @@ struct HusshOneAppShortcuts: AppShortcutsProvider {
             phrases: [
                 "Open \(.applicationName) \(\.$target)",
                 "Show \(\.$target) in \(.applicationName)",
-                "Call \(.applicationName) \(\.$target)",
                 "Ask \(.applicationName) to open \(\.$target)",
                 "Tell \(.applicationName) to show \(\.$target)",
                 "Talk to \(.applicationName) and open \(\.$target)"


### PR DESCRIPTION
## Summary
- Removes the `"Call \(.applicationName) \(\.$target)"` phrase from the Location-destination Siri shortcut. It shared the word "Call" with Apple's native Calling domain, which is why Siri was prompting "Do you want to use Agent One or Phone?" instead of just running the action.
- Adds `enable/disable/resume/pause/start/stop` as recognized synonyms for the Location on/off state, since natural phrasing like "enable my location" wasn't matching the declared "turn location on" template.

## Context
Found by on-device testing right after the PR #6497 TestFlight build: asking Siri to "enable location using Agent One" triggered a Phone-vs-Agent-One disambiguation dialog, then failed to toggle location either way. Traced to the phrase collision above.

## Test plan
- [x] `swiftc -parse` clean on the edited file
- [x] `npm run verify:siri-action-contract` still reports 7 direct / 10 review UI / 1 conversation-only (no action_id/vault/fallback wiring changed, phrase-only edit)
- [ ] CI native/Swift build green on this exact head SHA
- [ ] On-device: "Hey Siri, turn Agent One Location off/on" and "Hey Siri, enable/disable Agent One location" both execute without a Phone disambiguation prompt