### PR TITLE
fix(ios): guard location-state synonyms behind iOS 17 availability

### DIFF
--- a/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
+++ b/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
@@ -269,16 +269,27 @@ enum OneLocationStateIntentValue: String, AppEnum {
     case off
 
     static let typeDisplayRepresentation: TypeDisplayRepresentation = "Location State"
-    static let caseDisplayRepresentations: [Self: DisplayRepresentation] = [
-        .on: DisplayRepresentation(
-            title: "On",
-            synonyms: ["Enable", "Enabled", "Resume", "Resumed", "Start"]
-        ),
-        .off: DisplayRepresentation(
-            title: "Off",
-            synonyms: ["Disable", "Disabled", "Pause", "Paused", "Stop"]
-        )
-    ]
+
+    // `DisplayRepresentation(title:synonyms:)` needs iOS 17; this app's
+    // deployment target is 15, so older devices fall back to plain titles.
+    static let caseDisplayRepresentations: [Self: DisplayRepresentation] = {
+        if #available(iOS 17.0, *) {
+            return [
+                .on: DisplayRepresentation(
+                    title: "On",
+                    synonyms: ["Enable", "Enabled", "Resume", "Resumed", "Start"]
+                ),
+                .off: DisplayRepresentation(
+                    title: "Off",
+                    synonyms: ["Disable", "Disabled", "Pause", "Paused", "Stop"]
+                )
+            ]
+        }
+        return [
+            .on: "On",
+            .off: "Off"
+        ]
+    }()
 }
 
 // MARK: - Shared App Intent adapter


### PR DESCRIPTION
## Summary
PR #6501 (merged) added Siri synonyms via `DisplayRepresentation(title:synonyms:)`, which requires iOS 17. This app's deployment target is 15, so the CI native build failed the ship-ios-testflight run:

```
OneVoiceAppIntent.swift:273:14: error: 'init(title:subtitle:image:synonyms:)' is only available in iOS 17.0 or newer
```

This fixes it forward: `caseDisplayRepresentations` is now computed at runtime with `#available(iOS 17.0, *)` — iOS 17+ devices get the enable/disable/pause/resume synonyms, earlier devices fall back to the original plain "On"/"Off" titles they already had before #6501.

## Test plan
- [x] `swiftc -parse` clean
- [x] `npm run verify:siri-action-contract` still reports 7 direct / 10 review UI / 1 conversation-only
- [ ] CI native/Swift build green on this exact head SHA (this is what failed last time — the real check)