### PR TITLE
revert(ios): drop location-state Siri synonyms, keep the collision fix

### DIFF
--- a/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
+++ b/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
@@ -269,27 +269,10 @@ enum OneLocationStateIntentValue: String, AppEnum {
     case off
 
     static let typeDisplayRepresentation: TypeDisplayRepresentation = "Location State"
-
-    // `DisplayRepresentation(title:synonyms:)` needs iOS 17; this app's
-    // deployment target is 15, so older devices fall back to plain titles.
-    static let caseDisplayRepresentations: [Self: DisplayRepresentation] = {
-        if #available(iOS 17.0, *) {
-            return [
-                .on: DisplayRepresentation(
-                    title: "On",
-                    synonyms: ["Enable", "Enabled", "Resume", "Resumed", "Start"]
-                ),
-                .off: DisplayRepresentation(
-                    title: "Off",
-                    synonyms: ["Disable", "Disabled", "Pause", "Paused", "Stop"]
-                )
-            ]
-        }
-        return [
-            .on: "On",
-            .off: "Off"
-        ]
-    }()
+    static let caseDisplayRepresentations: [Self: DisplayRepresentation] = [
+        .on: "On",
+        .off: "Off"
+    ]
 }
 
 // MARK: - Shared App Intent adapter


### PR DESCRIPTION
## Summary
PR #6504's fix for PR #6501's iOS-17-only `DisplayRepresentation(synonyms:)` call was itself wrong: Apple's `appintentsmetadataprocessor` statically extracts `AppEnum.caseDisplayRepresentations` at build time and rejects any computed/conditional value outright, regardless of `#available` guards:

```
error: The property 'caseDisplayRepresentations' must have a compile-time
static value and cannot be computed or dynamic
```

Two consecutive `ship-ios-testflight` runs failed on this (33903820627, 33905589705). This reverts `caseDisplayRepresentations` to the plain static `"On"`/`"Off"` literals that shipped and compiled cleanly before (TestFlight build 95).

The actual bug fix from PR #6501 — removing the `"Call \(.applicationName) \(\.$target)"` phrase that collided with Apple's native Calling domain — is untouched and stays in. That's the one confirmed on-device (Siri prompting "Agent One or Phone?").

Enable/disable synonym support is deferred to a follow-up done against a real Xcode build, not guessed at from CI failures.

## Test plan
- [x] `swiftc -parse` clean
- [x] `npm run verify:siri-action-contract` — 7 direct / 10 review UI / 1 conversation-only
- [ ] CI native build green (this is the real check, given the last two failures)