### PR TITLE
fix(connect): push the requester when their request is accepted/declined

### DIFF
--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -196,6 +196,29 @@ def _default_notifier(
     )
 
 
+def _default_resolution_notifier(
+    *,
+    requester_user_id: str,
+    resolver_user_id: str,
+    accepted: bool,
+    connection_request_id: str | None = None,
+) -> None:
+    """Best-effort push telling the requester their request was resolved.
+
+    `accept_request`/`reject_request` had no notifier call at all before this
+    -- the requester's only signal was an unpushed Feed row, so they learned
+    the outcome from the Feed's foreground poll (45s) or their next app open.
+    """
+    from hushh_mcp.services.push_notifications import send_connection_request_resolved_push
+
+    send_connection_request_resolved_push(
+        requester_user_id,
+        resolver_user_id,
+        accepted=accepted,
+        connection_request_id=connection_request_id,
+    )
+
+
 def _default_scope_entries_lookup(owner_user_id: str) -> list[dict[str, Any]]:
     """Read discoverable scope metadata only; never materialized information."""
     from hushh_mcp.consent.scope_generator import DynamicScopeGenerator
@@ -212,12 +235,16 @@ class ConnectionsService:
         directory_visible: Callable[[str, str], bool] | None = None,
         scope_entries_lookup: Callable[[str], list[dict[str, Any]]] | None = None,
         notifier: Callable[..., Any] | None = None,
+        resolution_notifier: Callable[..., Any] | None = None,
     ) -> None:
         self._directory_lookup = directory_lookup or _default_directory_lookup
         self._directory_search = directory_search or _default_directory_search
         self._directory_visible = directory_visible or _default_directory_visible
         self._scope_entries_lookup = scope_entries_lookup or _default_scope_entries_lookup
         self._notifier = notifier if notifier is not None else _default_notifier
+        self._resolution_notifier = (
+            resolution_notifier if resolution_notifier is not None else _default_resolution_notifier
+        )
 
     # ---- DB seam ----
     def _execute_one(self, sql: str, params: dict[str, Any] | None = None) -> dict[str, Any] | None:
@@ -1459,6 +1486,35 @@ class ConnectionsService:
         except Exception as exc:  # noqa: BLE001
             logger.warning("connections.notify_failed error=%s", exc)
 
+    def _notify_request_resolved(
+        self,
+        requester_user_id: str,
+        resolver_user_id: str,
+        *,
+        accepted: bool,
+        connection_request_id: str | None = None,
+    ) -> None:
+        """Fire the (best-effort) requester nudge once accept/reject commits.
+
+        Same shape as `_notify_new_request`: called AFTER the transaction
+        commits (never inside it -- push is best-effort and must not become a
+        reason the mutation itself can fail or roll back), never raises, and
+        resolves the resolver's display name lazily inside the notifier so
+        this stays a cheap call on the response path.
+        """
+        notifier = getattr(self, "_resolution_notifier", None)
+        if notifier is None:
+            return
+        try:
+            notifier(
+                requester_user_id=requester_user_id,
+                resolver_user_id=resolver_user_id,
+                accepted=accepted,
+                connection_request_id=str(connection_request_id or "").strip() or None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("connections.notify_resolved_failed error=%s", exc)
+
     def _load_request(self, request_id: str, *, for_update: bool = False) -> dict[str, Any]:
         lock_clause = " FOR UPDATE" if for_update else ""
         row = self._execute_one(
@@ -2310,6 +2366,17 @@ class ConnectionsService:
                     source_row_id=source_request_id,
                 )
 
+        # After commit, not inside the transaction: push is best-effort and
+        # must never be why an accept can fail or roll back. The requester
+        # (not `user_id`, who is the addressee doing the accepting) is who
+        # gets nudged -- this was missing entirely; see _notify_request_resolved.
+        self._notify_request_resolved(
+            requester,
+            user_id,
+            accepted=True,
+            connection_request_id=source_request_id,
+        )
+
         # Accepting a connection grants nothing on its own. Location sharing is
         # opt-in and one-directional: it starts only when a person explicitly
         # requests the other's location and that request is approved (see
@@ -2424,6 +2491,14 @@ class ConnectionsService:
                     event_type="connection_rejected",
                     source_row_id=source_request_id,
                 )
+        # After commit, not inside the transaction -- see accept_request's
+        # identical placement and rationale.
+        self._notify_request_resolved(
+            requester,
+            user_id,
+            accepted=False,
+            connection_request_id=source_request_id,
+        )
         return {"status": "rejected", "requestId": req.get("id")}
 
     def cancel_request(self, user_id: str, request_id: str) -> dict[str, Any]:

--- a/consent-protocol/hushh_mcp/services/push_notifications.py
+++ b/consent-protocol/hushh_mcp/services/push_notifications.py
@@ -267,6 +267,94 @@ def send_connection_request_push(
     )
 
 
+def send_connection_request_resolved_push(
+    requester_user_id: str,
+    resolver_user_id: str,
+    *,
+    accepted: bool,
+    resolver_display_name: str | None = None,
+    connection_request_id: str | None = None,
+) -> int:
+    """Tell the REQUESTER their sent connection request was accepted/declined.
+
+    `accept_request`/`reject_request` had no notifier call at all -- the only
+    signal toward the requester was a Feed row nobody pushed, so they learned
+    the outcome from the Feed's foreground poll (45s) or their next app open.
+    Mirrors `send_connection_request_push`'s shape, addressed the other way:
+    that one nudges the ADDRESSEE that a request arrived, this nudges the
+    REQUESTER that theirs was resolved.
+
+    `resolver_display_name` lets the caller pass a name it already holds, the
+    same reason `send_connection_request_push` accepts one.
+    """
+    from hushh_mcp.services.requester_identity import resolve_requester_label
+
+    resolver_name = resolve_requester_label(
+        resolver_user_id,
+        display_name=resolver_display_name,
+    )
+    title = "Connection accepted" if accepted else "Connection declined"
+    body = (
+        f"{resolver_name} accepted your connection request."
+        if accepted
+        else f"{resolver_name} declined your connection request."
+    )
+    # The request is resolved, not pending review any more -- send the
+    # requester to their connections list rather than a review sheet that no
+    # longer has anything to review.
+    deep_link = CONNECTION_REQUEST_LIST_LINK
+    request_id = str(connection_request_id or "").strip()
+    message_id = f"connection-request-resolved:{request_id}" if request_id else ""
+
+    client_data = {
+        "message_id": message_id,
+        "resolver_label": resolver_name,
+        "request_id": request_id,
+        "accepted": "true" if accepted else "false",
+    }
+
+    try:
+        import asyncio
+
+        from api.consent_listener import _push_to_consent_queue
+
+        sse_payload = {
+            "type": "connection_request_resolved",
+            "action": "ACCEPTED" if accepted else "DECLINED",
+            "request_id": request_id or f"conn_req_resolved:{resolver_user_id}",
+            "user_id": requester_user_id,
+            "resolver_user_id": resolver_user_id,
+            "resolver_label": resolver_name,
+            "title": title,
+            "body": body,
+            "deep_link": deep_link,
+            "request_url": deep_link,
+        }
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_push_to_consent_queue(requester_user_id, sse_payload))
+        except RuntimeError:
+            # No running loop: both real callers (accept_request, reject_request)
+            # run on a FastAPI threadpool worker. See send_connection_request_push's
+            # identical fallback for why this cannot be `pass`.
+            from api.consent_listener import push_to_consent_queue_threadsafe
+
+            push_to_consent_queue_threadsafe(requester_user_id, sse_payload)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("push.sse_queue_failed error=%s", exc)
+
+    return send_user_data_push(
+        requester_user_id,
+        notification_type="connection_request_resolved",
+        title=title,
+        body=body,
+        deep_link=deep_link,
+        notification_tag=message_id or "connection-request-resolved",
+        notification_category="ONE_CONNECTIONS",
+        data=client_data,
+    )
+
+
 def send_circle_code_joined_push(
     *,
     inviter_user_id: str,

--- a/consent-protocol/tests/services/test_connections_service.py
+++ b/consent-protocol/tests/services/test_connections_service.py
@@ -910,6 +910,100 @@ def test_accept_creates_connection_and_two_trusted_edges():
     assert all("counterpart_user_id" not in params for _, params in feed_inserts)
 
 
+def test_accept_notifies_the_requester_not_the_acceptor():
+    """#6507: accept_request had no notifier call at all before this.
+
+    The nudge must go to the ORIGINAL requester (user-a), not the person who
+    just acted (user-b, the addressee) -- they already know what they did.
+    """
+    svc = _svc()
+    db = _RecordingDB(
+        [
+            [
+                {
+                    "id": "req-1",
+                    "requester_user_id": "user-a",
+                    "addressee_user_id": "user-b",
+                    "status": "pending",
+                }
+            ],
+            [],  # no expired scope proposals
+            [],  # proposal review -> no scopes
+            [{"id": "conn-1"}],
+            [{"id": "tc-1"}],
+            [{"id": "tc-2"}],
+            [{"id": "req-1"}],
+        ]
+    )
+    svc._display_name_for = lambda user_id: {"user-a": "Alice", "user-b": "Bob"}[user_id]
+    calls = []
+    svc._resolution_notifier = lambda **kw: calls.append(kw)
+    with patch("hushh_mcp.services.connections_service.get_db", lambda: db):
+        svc.accept_request("user-b", "req-1")
+
+    assert calls == [
+        {
+            "requester_user_id": "user-a",
+            "resolver_user_id": "user-b",
+            "accepted": True,
+            "connection_request_id": "req-1",
+        }
+    ]
+
+
+def test_accept_does_not_notify_on_idempotent_replay():
+    """Re-accepting an already-accepted request must not fire a second push."""
+    svc = _svc()
+    svc._transaction = nullcontext
+    svc._load_request = lambda _request_id, *, for_update=False: {
+        "id": "req-1",
+        "requester_user_id": "user-a",
+        "addressee_user_id": "user-b",
+        "status": "accepted",
+    }
+    svc._proposal_items = lambda _request_id: []
+    calls = []
+    svc._resolution_notifier = lambda **kw: calls.append(kw)
+
+    svc.accept_request("user-b", "req-1")
+
+    assert calls == []
+
+
+def test_accept_resolution_notify_failure_does_not_break_the_write():
+    """A failing resolution notifier is swallowed; acceptance still succeeds."""
+    svc = _svc()
+    db = _RecordingDB(
+        [
+            [
+                {
+                    "id": "req-1",
+                    "requester_user_id": "user-a",
+                    "addressee_user_id": "user-b",
+                    "status": "pending",
+                }
+            ],
+            [],
+            [],
+            [{"id": "conn-1"}],
+            [{"id": "tc-1"}],
+            [{"id": "tc-2"}],
+            [{"id": "req-1"}],
+        ]
+    )
+    svc._display_name_for = lambda user_id: {"user-a": "Alice", "user-b": "Bob"}[user_id]
+
+    def _boom(**_kw):
+        raise RuntimeError("fcm down")
+
+    svc._resolution_notifier = _boom
+    with patch("hushh_mcp.services.connections_service.get_db", lambda: db):
+        out = svc.accept_request("user-b", "req-1")
+
+    assert out["status"] == "accepted"
+    assert out["connectionId"] == "conn-1"
+
+
 def test_accept_request_never_imports_or_calls_location_service():
     """Structural guard against re-wiring auto-share into accept_request.
 
@@ -1206,6 +1300,79 @@ def test_reject_feed_projection_is_idempotent_and_omits_user_ids() -> None:
     assert len(feed_inserts) == 2
     assert {params["source_row_id"] for _, params in feed_inserts} == {"req-1"}
     assert all("counterpart_user_id" not in params for _, params in feed_inserts)
+
+
+def test_reject_notifies_the_requester_not_the_rejecter():
+    """#6507: reject_request had no notifier call at all before this."""
+    svc = _svc()
+    svc._transaction = nullcontext
+    svc._load_request = lambda _request_id, *, for_update=False: {
+        "id": "req-1",
+        "requester_user_id": "user-a",
+        "addressee_user_id": "user-b",
+        "status": "pending",
+    }
+    svc._execute_one = lambda _sql, _params=None: {"id": "req-1"}
+    svc._resolve_pending_scope_proposals = lambda *_args, **_kwargs: None
+    svc._display_name_for = lambda user_id: {"user-a": "Alice", "user-b": "Bob"}[user_id]
+    calls = []
+    svc._resolution_notifier = lambda **kw: calls.append(kw)
+
+    svc.reject_request("user-b", "req-1")
+
+    assert calls == [
+        {
+            "requester_user_id": "user-a",
+            "resolver_user_id": "user-b",
+            "accepted": False,
+            "connection_request_id": "req-1",
+        }
+    ]
+
+
+def test_reject_does_not_notify_on_idempotent_replay():
+    """Re-rejecting an already-rejected request must not fire a second push."""
+    svc = _svc()
+    svc._transaction = nullcontext
+    svc._load_request = lambda _request_id, *, for_update=False: {
+        "id": "req-1",
+        "requester_user_id": "user-a",
+        "addressee_user_id": "user-b",
+        "status": "rejected",
+    }
+    svc._execute_one = lambda *_args, **_kwargs: pytest.fail(
+        "an already-rejected request must not be mutated or projected"
+    )
+    calls = []
+    svc._resolution_notifier = lambda **kw: calls.append(kw)
+
+    svc.reject_request("user-b", "req-1")
+
+    assert calls == []
+
+
+def test_reject_resolution_notify_failure_does_not_break_the_write():
+    """A failing resolution notifier is swallowed; rejection still succeeds."""
+    svc = _svc()
+    svc._transaction = nullcontext
+    svc._load_request = lambda _request_id, *, for_update=False: {
+        "id": "req-1",
+        "requester_user_id": "user-a",
+        "addressee_user_id": "user-b",
+        "status": "pending",
+    }
+    svc._execute_one = lambda _sql, _params=None: {"id": "req-1"}
+    svc._resolve_pending_scope_proposals = lambda *_args, **_kwargs: None
+    svc._display_name_for = lambda user_id: {"user-a": "Alice", "user-b": "Bob"}[user_id]
+
+    def _boom(**_kw):
+        raise RuntimeError("fcm down")
+
+    svc._resolution_notifier = _boom
+
+    out = svc.reject_request("user-b", "req-1")
+
+    assert out == {"status": "rejected", "requestId": "req-1"}
 
 
 def test_reject_feed_failure_rolls_back_the_relationship_transition() -> None:

--- a/consent-protocol/tests/services/test_push_notifications.py
+++ b/consent-protocol/tests/services/test_push_notifications.py
@@ -6,6 +6,7 @@ from hushh_mcp.services.push_notifications import (
     _GENERIC_CONNECTION_REQUEST_BODY,
     _connection_request_body,
     send_connection_request_push,
+    send_connection_request_resolved_push,
 )
 from hushh_mcp.services.requester_identity import (
     label_from_identity_row,
@@ -232,6 +233,134 @@ def test_connection_request_push_reaches_sse_from_a_sync_handler(monkeypatch):
     assert payload["request_id"] == "req-42"
     assert payload["body"] == "John Smith wants to connect with you on Hussh."
     assert payload["deep_link"] == "/one/consent?tab=pending&requestId=req-42"
+
+
+# ---------------------------------------------------------------------------
+# #6507: the requester learning their OWN request was accepted/declined --
+# previously not pushed at all. Mirrors the connection_request push tests
+# above, addressed the other way (requester, not addressee).
+# ---------------------------------------------------------------------------
+
+
+def test_connection_request_resolved_push_names_the_resolver_when_accepted(monkeypatch):
+    captured = _capture_push(monkeypatch)
+
+    send_connection_request_resolved_push(
+        "requester-1",
+        "resolver-1",
+        accepted=True,
+        resolver_display_name="Ankit Sharma",
+        connection_request_id="req-42",
+    )
+
+    assert captured["user_id"] == "requester-1"
+    assert captured["title"] == "Connection accepted"
+    assert captured["body"] == "Ankit Sharma accepted your connection request."
+    assert captured["data"]["resolver_label"] == "Ankit Sharma"
+    assert captured["data"]["accepted"] == "true"
+    assert captured["data"]["request_id"] == "req-42"
+
+
+def test_connection_request_resolved_push_names_the_resolver_when_declined(monkeypatch):
+    captured = _capture_push(monkeypatch)
+
+    send_connection_request_resolved_push(
+        "requester-1",
+        "resolver-1",
+        accepted=False,
+        resolver_display_name="Ankit Sharma",
+        connection_request_id="req-42",
+    )
+
+    assert captured["title"] == "Connection declined"
+    assert captured["body"] == "Ankit Sharma declined your connection request."
+    assert captured["data"]["accepted"] == "false"
+
+
+def test_connection_request_resolved_push_deep_links_to_the_connections_list(monkeypatch):
+    """The request is resolved, not pending review -- a review-sheet deep
+    link with nothing left to review would be a dead end."""
+    captured = _capture_push(monkeypatch)
+
+    send_connection_request_resolved_push(
+        "requester-1",
+        "resolver-1",
+        accepted=True,
+        resolver_display_name="Ankit",
+        connection_request_id="req-42",
+    )
+
+    assert captured["deep_link"] == "/one/consent?tab=connections"
+
+
+def test_connection_request_resolved_push_uses_distinct_request_scoped_tags(monkeypatch):
+    captured: list[dict] = []
+
+    def _fake_send(user_id, **kwargs):
+        captured.append({"user_id": user_id, **kwargs})
+        return 1
+
+    monkeypatch.setattr(push_module, "send_user_data_push", _fake_send)
+    for request_id in ("req-1", "req-2", "req-1"):
+        send_connection_request_resolved_push(
+            "requester-1",
+            "resolver-1",
+            accepted=True,
+            resolver_display_name="Ankit",
+            connection_request_id=request_id,
+        )
+
+    assert [item["notification_tag"] for item in captured] == [
+        "connection-request-resolved:req-1",
+        "connection-request-resolved:req-2",
+        "connection-request-resolved:req-1",
+    ]
+
+
+def test_connection_request_resolved_push_prefers_the_caller_supplied_name(monkeypatch):
+    captured = _capture_push(monkeypatch)
+
+    def _explode():
+        raise AssertionError("must not query when the caller already has the name")
+
+    monkeypatch.setattr("db.db_client.get_db", _explode)
+
+    send_connection_request_resolved_push(
+        "requester-1",
+        "resolver-1",
+        accepted=True,
+        resolver_display_name="Ankit",
+        connection_request_id="r1",
+    )
+
+    assert captured["data"]["resolver_label"] == "Ankit"
+
+
+def test_connection_request_resolved_push_reaches_sse_from_a_sync_handler(monkeypatch):
+    """Same sync-handler SSE requirement as send_connection_request_push --
+    both real callers (accept_request, reject_request) are sync."""
+    _capture_push(monkeypatch)
+    scheduled: list = []
+    monkeypatch.setattr(
+        "api.consent_listener.push_to_consent_queue_threadsafe",
+        lambda user_id, data: scheduled.append((user_id, data)) or True,
+    )
+
+    send_connection_request_resolved_push(
+        "requester-1",
+        "resolver-1",
+        accepted=False,
+        resolver_display_name="John Smith",
+        connection_request_id="req-42",
+    )
+
+    assert len(scheduled) == 1, "the SSE payload was dropped instead of scheduled"
+    user_id, payload = scheduled[0]
+    assert user_id == "requester-1"
+    assert payload["type"] == "connection_request_resolved"
+    assert payload["action"] == "DECLINED"
+    assert payload["resolver_label"] == "John Smith"
+    assert payload["request_id"] == "req-42"
 
 
 def test_threadsafe_enqueue_delivers_to_a_waiting_sse_consumer():

--- a/hushh-webapp/__tests__/consent-notification-provider-connections.test.tsx
+++ b/hushh-webapp/__tests__/consent-notification-provider-connections.test.tsx
@@ -147,6 +147,21 @@ function dispatchConnectionRequest(data: Record<string, string>) {
   return detail;
 }
 
+function dispatchConnectionRequestResolved(data: Record<string, string>) {
+  const detail: {
+    data: Record<string, string>;
+    accepted?: boolean;
+  } = { data: { type: "connection_request_resolved", ...data } };
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent("fcm-message", {
+        detail,
+      }),
+    );
+  });
+  return detail;
+}
+
 beforeEach(() => {
   window.localStorage.clear();
   window.sessionStorage.clear();
@@ -396,5 +411,51 @@ describe("connection-request Feed-first foreground policy", () => {
     expect(mocks.toast).not.toHaveBeenCalled();
     expect(mocks.dispatchFeedStateChanged).toHaveBeenCalledOnce();
     expect(mocks.onConsentMutated).not.toHaveBeenCalled();
+  });
+
+  describe("connection-request-resolved (#6507)", () => {
+    // The requester learning their OWN request was accepted/declined --
+    // previously not pushed at all, so this branch did not exist. Same
+    // Feed-first shape as the sibling connection_request tests above.
+    it.each([
+      { accepted: "true", label: "accepted" },
+      { accepted: "false", label: "declined" },
+    ])(
+      "refreshes Feed and invalidates consent cache when $label",
+      async ({ accepted }) => {
+        await renderProvider();
+
+        const detail = dispatchConnectionRequestResolved({
+          user_id: "recipient-user",
+          resolver_user_id: "resolver-user",
+          resolver_label: "Rohan",
+          request_id: "conn-req-1",
+          accepted,
+        });
+
+        expect(mocks.toast).not.toHaveBeenCalled();
+        expect(mocks.dispatchFeedStateChanged).toHaveBeenCalledOnce();
+        expect(mocks.onConsentMutated).toHaveBeenCalledWith("recipient-user");
+        expect(mocks.dispatchConsentStateChanged).toHaveBeenCalledWith({
+          source: "fcm_connection_request_resolved",
+          reconcile: true,
+        });
+        expect(detail.accepted).toBe(true);
+      },
+    );
+
+    it("drops a payload addressed to a different signed-in user", async () => {
+      await renderProvider();
+      const detail = dispatchConnectionRequestResolved({
+        user_id: "someone-else",
+        request_id: "conn-req-1",
+        accepted: "true",
+      });
+
+      expect(mocks.toast).not.toHaveBeenCalled();
+      expect(mocks.dispatchFeedStateChanged).not.toHaveBeenCalled();
+      expect(mocks.onConsentMutated).not.toHaveBeenCalled();
+      expect(detail.accepted).not.toBe(true);
+    });
   });
 });

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -1581,6 +1581,19 @@ export function ConsentNotificationProvider({
           source: "fcm_connection_request",
           reconcile: true,
         });
+      } else if (msgType === "connection_request_resolved") {
+        // The requester learning their own request was accepted/declined --
+        // previously not pushed at all (accept/reject sent no notification),
+        // so this only ever surfaced via the Feed's 45s foreground poll or the
+        // next app open. Same shape as the sibling branch above: invalidate
+        // and let Connect/Consent Center pick it up on their own refresh.
+        if (user?.uid) {
+          CacheSyncService.onConsentMutated(user.uid);
+        }
+        dispatchConsentStateChanged({
+          source: "fcm_connection_request_resolved",
+          reconcile: true,
+        });
       }
     };
 


### PR DESCRIPTION
Fixes #6507.

## Summary
`accept_request` and `reject_request` never notified anyone -- their only side effect toward the other party was an unpushed Feed row. The requester learned the outcome only via the Feed's 45s foreground poll, or their next app open. This was traced as part of a broader "connect requests should be real-time" report: request *creation* pushes the addressee (`_notify_new_request`), but neither resolution path ever pushed the requester back.

## Fix
- **`send_connection_request_resolved_push`** (`push_notifications.py`): mirrors `send_connection_request_push`'s shape, addressed the other way -- nudges the requester, not the addressee.
- **`_notify_request_resolved`** (`connections_service.py`, mirrors `_notify_new_request`): called from `accept_request`/`reject_request` **after** their transaction commits, never inside it, so a down push can never be why an accept/reject fails or rolls back. Both idempotent-replay early-returns (already-accepted, already-rejected) sit inside the transaction and return before reaching the notify call, so a retry cannot double-push.
- **Frontend** (`notification-provider.tsx`): a `connection_request_resolved` branch mirroring the existing `connection_request` one exactly (invalidate consent cache, dispatch reconcile). `app/connect/page-client.tsx` already listens generically on `action || reconcile`, not on `source`, so no changes were needed there. `dispatchFeedStateChanged` also already fires unconditionally for every push type ("this also covers notification families added in the future"), so Feed picks this up with no changes either.

## Test plan
- [x] New backend tests: notifies the requester (not the resolver) on accept and on reject, does not double-notify on idempotent replay, a failing notifier never breaks the write (`test_connections_service.py`, 98/98 passing incl. 6 new)
- [x] New push-builder tests: title/body/data map for accepted vs. declined, deep-links to the connections list (not a dead review-sheet link), distinct request-scoped tags, prefers a caller-supplied name, reaches SSE from a sync handler (`test_push_notifications.py`, 31/31 passing incl. 7 new)
- [x] New frontend test: Feed-first refresh + cache invalidation on both outcomes, drops a payload addressed to a different signed-in user (`consent-notification-provider-connections.test.tsx`, 15/15 passing incl. 3 new)
- [x] `ruff check` + `mypy` on changed Python files (1 pre-existing, unrelated `mypy` note confirmed present before this change too)
- [x] `npx tsc --noEmit` + `npx eslint` on changed TS/TSX files