### PR TITLE
fix(location): push on Circle invite decline/cancel and member remove/leave

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -4298,17 +4298,42 @@ class OneLocationCircleService:
         try:
             result = self._db.execute_raw(
                 """
-                UPDATE one_location_circle_member_invites
+                UPDATE one_location_circle_member_invites invite
                 SET status = 'declined', responded_at = NOW(), updated_at = NOW()
-                WHERE id = CAST(:invite_id AS UUID)
-                  AND invitee_user_id = :user_id
-                  AND status = 'pending'
-                  AND expires_at > NOW()
-                RETURNING id
+                FROM one_location_circles circle
+                WHERE invite.id = CAST(:invite_id AS UUID)
+                  AND invite.invitee_user_id = :user_id
+                  AND invite.status = 'pending'
+                  AND invite.expires_at > NOW()
+                  AND circle.id = invite.circle_id
+                RETURNING invite.id, invite.circle_id, invite.inviter_user_id,
+                          circle.name AS circle_name
                 """,
                 {"invite_id": cleaned_invite_id, "user_id": user_id},
             )
-            if result.data or []:
+            declined_row = next(iter(result.data or []), None)
+            if declined_row:
+                try:
+                    from hushh_mcp.services.push_notifications import (
+                        send_circle_member_invite_declined_push,
+                    )
+                    from hushh_mcp.services.requester_identity import (
+                        resolve_requester_label,
+                    )
+
+                    send_circle_member_invite_declined_push(
+                        inviter_user_id=str(declined_row.get("inviter_user_id") or ""),
+                        invitee_user_id=user_id,
+                        invitee_display_name=resolve_requester_label(user_id),
+                        circle_id=str(declined_row.get("circle_id") or ""),
+                        circle_name=str(declined_row.get("circle_name") or ""),
+                        invite_id=cleaned_invite_id,
+                    )
+                except Exception:
+                    logger.exception(
+                        "circle.notify_invite_declined_failed invite_id=%s",
+                        cleaned_invite_id,
+                    )
                 return self.get_member_invite(user_id=user_id, invite_id=cleaned_invite_id)
             existing = self._db.execute_raw(
                 """
@@ -4357,14 +4382,32 @@ class OneLocationCircleService:
                   )
                   AND circle.status = 'active'
                   AND invite.status = 'pending'
-                RETURNING invite.id
+                RETURNING invite.id, invite.circle_id, invite.invitee_user_id,
+                          circle.name AS circle_name
                 """,
                 {
                     "invite_id": cleaned_invite_id,
                     "actor_user_id": actor_user_id,
                 },
             )
-            if result.data or []:
+            cancelled_row = next(iter(result.data or []), None)
+            if cancelled_row:
+                try:
+                    from hushh_mcp.services.push_notifications import (
+                        send_circle_member_invite_cancelled_push,
+                    )
+
+                    send_circle_member_invite_cancelled_push(
+                        invitee_user_id=str(cancelled_row.get("invitee_user_id") or ""),
+                        circle_id=str(cancelled_row.get("circle_id") or ""),
+                        circle_name=str(cancelled_row.get("circle_name") or ""),
+                        invite_id=cleaned_invite_id,
+                    )
+                except Exception:
+                    logger.exception(
+                        "circle.notify_invite_cancelled_failed invite_id=%s",
+                        cleaned_invite_id,
+                    )
                 return True
             existing = self._db.execute_raw(
                 """
@@ -4729,7 +4772,7 @@ class OneLocationCircleService:
                     conn.execute(
                         text(
                             """
-                            SELECT owner_user_id, system_kind
+                            SELECT owner_user_id, system_kind, name
                             FROM one_location_circles
                             WHERE id = CAST(:circle_id AS UUID)
                               AND status = 'active'
@@ -4852,6 +4895,36 @@ class OneLocationCircleService:
                 self._cleanup_ineligible_sms_contacts(
                     conn,
                     user_id=target_user_id,
+                )
+            try:
+                circle_name = str(circle_row.get("name") or "")
+                from hushh_mcp.services.push_notifications import (
+                    send_circle_member_left_push,
+                    send_circle_member_removed_push,
+                )
+                from hushh_mcp.services.requester_identity import (
+                    resolve_requester_label,
+                )
+
+                if status == "removed":
+                    send_circle_member_removed_push(
+                        member_user_id=target_user_id,
+                        circle_id=cleaned_circle_id,
+                        circle_name=circle_name,
+                    )
+                elif status == "left":
+                    send_circle_member_left_push(
+                        owner_user_id=owner_user_id,
+                        member_user_id=target_user_id,
+                        member_display_name=resolve_requester_label(target_user_id),
+                        circle_id=cleaned_circle_id,
+                        circle_name=circle_name,
+                    )
+            except Exception:
+                logger.exception(
+                    "circle.notify_end_membership_failed circle_id=%s status=%s",
+                    cleaned_circle_id,
+                    status,
                 )
         except OneLocationCircleError:
             raise

--- a/consent-protocol/hushh_mcp/services/push_notifications.py
+++ b/consent-protocol/hushh_mcp/services/push_notifications.py
@@ -413,3 +413,130 @@ def send_circle_member_invite_accepted_push(
             "network_display_label": invitee_display_name or "",
         },
     )
+
+
+def send_circle_member_invite_declined_push(
+    *,
+    inviter_user_id: str,
+    invitee_user_id: str,
+    invitee_display_name: str,
+    circle_id: str,
+    circle_name: str,
+    invite_id: str,
+) -> int:
+    """Tell whoever sent a named Circle invite that it was declined.
+
+    Mirrors ``send_circle_member_invite_accepted_push`` for the opposite
+    outcome, which previously sent nothing at all -- the inviter only found
+    out the invite went nowhere on a manual reload of the Circle screen.
+    """
+
+    label = str(invitee_display_name or "").strip() or "Someone"
+    deep_link = f"/one/location?tab=people&circleId={circle_id}"
+    return send_user_data_push(
+        inviter_user_id,
+        notification_type="location_circle_member_invite_declined",
+        title=circle_name or "Circle invitation",
+        body=f"{label} declined your Circle invitation.",
+        deep_link=deep_link,
+        notification_tag=f"location-circle-member-invite-declined:{invite_id}",
+        notification_category="ONE_LOCATION",
+        data={
+            "invite_id": invite_id,
+            "circle_id": circle_id,
+            "circle_name": circle_name,
+            "invitee_user_id": invitee_user_id,
+            "network_display_label": label,
+        },
+    )
+
+
+def send_circle_member_invite_cancelled_push(
+    *,
+    invitee_user_id: str,
+    circle_id: str,
+    circle_name: str,
+    invite_id: str,
+) -> int:
+    """Tell an invitee that their pending Circle invitation was withdrawn.
+
+    Without this the invite simply vanishes from their list on the next
+    refresh -- indistinguishable from a client-side bug.
+    """
+
+    circle = str(circle_name or "").strip()
+    body = f'Your invitation to "{circle}" was withdrawn.' if circle else "A Circle invitation was withdrawn."
+    deep_link = "/one/location?tab=people"
+    return send_user_data_push(
+        invitee_user_id,
+        notification_type="location_circle_member_invite_cancelled",
+        title=circle or "Circle invitation",
+        body=body,
+        deep_link=deep_link,
+        notification_tag=f"location-circle-member-invite-cancelled:{invite_id}",
+        notification_category="ONE_LOCATION",
+        data={
+            "invite_id": invite_id,
+            "circle_id": circle_id,
+            "circle_name": circle,
+        },
+    )
+
+
+def send_circle_member_removed_push(
+    *,
+    member_user_id: str,
+    circle_id: str,
+    circle_name: str,
+) -> int:
+    """Tell a member the Circle owner removed them.
+
+    Otherwise the Circle just disappears from their list on the next reload,
+    with no way to tell that from a sync glitch.
+    """
+
+    circle = str(circle_name or "").strip()
+    body = f'You were removed from "{circle}".' if circle else "You were removed from a Circle."
+    deep_link = "/one/location?tab=people"
+    return send_user_data_push(
+        member_user_id,
+        notification_type="location_circle_member_removed",
+        title=circle or "Circle",
+        body=body,
+        deep_link=deep_link,
+        notification_tag=f"location-circle-member-removed:{circle_id}:{member_user_id}",
+        notification_category="ONE_LOCATION",
+        data={
+            "circle_id": circle_id,
+            "circle_name": circle,
+        },
+    )
+
+
+def send_circle_member_left_push(
+    *,
+    owner_user_id: str,
+    member_user_id: str,
+    member_display_name: str,
+    circle_id: str,
+    circle_name: str,
+) -> int:
+    """Tell a Circle's owner that a member left on their own."""
+
+    label = str(member_display_name or "").strip() or "Someone"
+    circle = str(circle_name or "").strip()
+    body = f'{label} left "{circle}".' if circle else f"{label} left your Circle."
+    deep_link = f"/one/location?tab=people&circleId={circle_id}"
+    return send_user_data_push(
+        owner_user_id,
+        notification_type="location_circle_member_left",
+        title=circle or "Your Circle",
+        body=body,
+        deep_link=deep_link,
+        notification_tag=f"location-circle-member-left:{circle_id}:{member_user_id}",
+        notification_category="ONE_LOCATION",
+        data={
+            "circle_id": circle_id,
+            "circle_name": circle,
+        },
+    )

--- a/consent-protocol/tests/services/test_one_location_circle_service.py
+++ b/consent-protocol/tests/services/test_one_location_circle_service.py
@@ -8,6 +8,7 @@ import pytest
 
 import hushh_mcp.services.one_location_circle_service as circle_service_module
 import hushh_mcp.services.push_notifications as push_notifications_module
+import hushh_mcp.services.requester_identity as requester_identity_module
 from hushh_mcp.services.one_location_circle_service import (
     CIRCLE_MEMBER_REINVITE_COOLDOWN_HOURS,
     OneLocationCircleError,
@@ -3779,3 +3780,190 @@ def test_an_add_naming_only_blocked_people_still_fails_loudly():
     assert raised.value.status_code == 409
     # Unnamed, like every other refusal about somebody else's history.
     assert "friend-one" not in raised.value.args[0]
+
+
+# ---------------------------------------------------------------------------
+# Resolution pushes for invite decline/cancel and membership removal/leave --
+# the same "creation notifies, resolution goes silent" gap the Connect fix
+# (#6507/#6509) closed, found to repeat in this Circle service too.
+# ---------------------------------------------------------------------------
+
+
+def test_decline_member_invite_notifies_the_inviter(monkeypatch: pytest.MonkeyPatch) -> None:
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    invite_id = "550e8400-e29b-41d4-a716-446655440002"
+    db = _RecordingDb(
+        [
+            {
+                "id": invite_id,
+                "circle_id": circle_id,
+                "inviter_user_id": "inviter-member",
+                "circle_name": "Family",
+            }
+        ],
+        [{"id": invite_id, "status": "declined"}],
+    )
+    service = OneLocationCircleService(db=db, hmac_key="a" * 32)  # type: ignore[arg-type]
+    monkeypatch.setattr(
+        requester_identity_module, "resolve_requester_label", lambda _uid: "Member User"
+    )
+    push_calls: list[dict] = []
+    monkeypatch.setattr(
+        push_notifications_module,
+        "send_circle_member_invite_declined_push",
+        lambda **kwargs: push_calls.append(kwargs) or 1,
+    )
+
+    service.decline_member_invite(user_id="member-user", invite_id=invite_id)
+
+    assert push_calls == [
+        {
+            "inviter_user_id": "inviter-member",
+            "invitee_user_id": "member-user",
+            "invitee_display_name": "Member User",
+            "circle_id": circle_id,
+            "circle_name": "Family",
+            "invite_id": invite_id,
+        }
+    ]
+
+
+def test_decline_member_invite_does_not_notify_when_invite_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    invite_id = "550e8400-e29b-41d4-a716-446655440002"
+    db = _RecordingDb([], [{"status": "pending"}])
+    service = OneLocationCircleService(db=db, hmac_key="a" * 32)  # type: ignore[arg-type]
+    push_calls: list[dict] = []
+    monkeypatch.setattr(
+        push_notifications_module,
+        "send_circle_member_invite_declined_push",
+        lambda **kwargs: push_calls.append(kwargs) or 1,
+    )
+
+    with pytest.raises(OneLocationCircleError):
+        service.decline_member_invite(user_id="member-user", invite_id=invite_id)
+
+    assert push_calls == []
+
+
+def test_cancel_member_invite_notifies_the_invitee(monkeypatch: pytest.MonkeyPatch) -> None:
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    invite_id = "550e8400-e29b-41d4-a716-446655440002"
+    db = _RecordingDb(
+        [
+            {
+                "id": invite_id,
+                "circle_id": circle_id,
+                "invitee_user_id": "invitee-member",
+                "circle_name": "Family",
+            }
+        ]
+    )
+    service = OneLocationCircleService(db=db, hmac_key="a" * 32)  # type: ignore[arg-type]
+    push_calls: list[dict] = []
+    monkeypatch.setattr(
+        push_notifications_module,
+        "send_circle_member_invite_cancelled_push",
+        lambda **kwargs: push_calls.append(kwargs) or 1,
+    )
+
+    result = service.cancel_member_invite(actor_user_id="owner-user", invite_id=invite_id)
+
+    assert result is True
+    assert push_calls == [
+        {
+            "invitee_user_id": "invitee-member",
+            "circle_id": circle_id,
+            "circle_name": "Family",
+            "invite_id": invite_id,
+        }
+    ]
+
+
+def test_remove_member_notifies_the_removed_member(monkeypatch: pytest.MonkeyPatch) -> None:
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    conn = _CapacityConnection(
+        {"owner_user_id": "owner-user", "system_kind": None, "name": "Family"},
+        {"user_id": "member-user"},
+    )
+    service = OneLocationCircleService(
+        db=_TransactionDb(conn),  # type: ignore[arg-type]
+        hmac_key="a" * 32,
+    )
+    monkeypatch.setattr(circle_service_module, "revoke_circle_origins", lambda *_a, **_kw: None)
+    monkeypatch.setattr(service, "_reconcile_circle_sourced_grants", lambda *_a, **_kw: None)
+    monkeypatch.setattr(service, "_cleanup_ineligible_sms_contacts", lambda *_a, **_kw: None)
+    push_calls: list[dict] = []
+    monkeypatch.setattr(
+        push_notifications_module,
+        "send_circle_member_removed_push",
+        lambda **kwargs: push_calls.append(kwargs) or 1,
+    )
+
+    service.remove_member(
+        owner_user_id="owner-user", circle_id=circle_id, member_user_id="member-user"
+    )
+
+    assert push_calls == [
+        {"member_user_id": "member-user", "circle_id": circle_id, "circle_name": "Family"}
+    ]
+
+
+def test_leave_circle_notifies_the_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    conn = _CapacityConnection(
+        {"owner_user_id": "owner-user", "system_kind": None, "name": "Family"},
+        {"user_id": "member-user"},
+    )
+    service = OneLocationCircleService(
+        db=_TransactionDb(conn),  # type: ignore[arg-type]
+        hmac_key="a" * 32,
+    )
+    monkeypatch.setattr(circle_service_module, "revoke_circle_origins", lambda *_a, **_kw: None)
+    monkeypatch.setattr(service, "_reconcile_circle_sourced_grants", lambda *_a, **_kw: None)
+    monkeypatch.setattr(service, "_cleanup_ineligible_sms_contacts", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        requester_identity_module, "resolve_requester_label", lambda _uid: "Member User"
+    )
+    push_calls: list[dict] = []
+    monkeypatch.setattr(
+        push_notifications_module,
+        "send_circle_member_left_push",
+        lambda **kwargs: push_calls.append(kwargs) or 1,
+    )
+
+    service.leave_circle(user_id="member-user", circle_id=circle_id)
+
+    assert push_calls == [
+        {
+            "owner_user_id": "owner-user",
+            "member_user_id": "member-user",
+            "member_display_name": "Member User",
+            "circle_id": circle_id,
+            "circle_name": "Family",
+        }
+    ]
+
+
+def test_notify_failure_does_not_break_leave_circle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The write must survive a broken notifier -- best-effort, never load-bearing."""
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    conn = _CapacityConnection(
+        {"owner_user_id": "owner-user", "system_kind": None, "name": "Family"},
+        {"user_id": "member-user"},
+    )
+    service = OneLocationCircleService(
+        db=_TransactionDb(conn),  # type: ignore[arg-type]
+        hmac_key="a" * 32,
+    )
+    monkeypatch.setattr(circle_service_module, "revoke_circle_origins", lambda *_a, **_kw: None)
+    monkeypatch.setattr(service, "_reconcile_circle_sourced_grants", lambda *_a, **_kw: None)
+    monkeypatch.setattr(service, "_cleanup_ineligible_sms_contacts", lambda *_a, **_kw: None)
+
+    def _boom(**_kwargs):
+        raise RuntimeError("fcm is down")
+
+    monkeypatch.setattr(push_notifications_module, "send_circle_member_left_push", _boom)
+
+    service.leave_circle(user_id="member-user", circle_id=circle_id)

--- a/consent-protocol/tests/services/test_push_notifications.py
+++ b/consent-protocol/tests/services/test_push_notifications.py
@@ -5,6 +5,10 @@ from hushh_mcp.services import push_notifications as push_module
 from hushh_mcp.services.push_notifications import (
     _GENERIC_CONNECTION_REQUEST_BODY,
     _connection_request_body,
+    send_circle_member_invite_cancelled_push,
+    send_circle_member_invite_declined_push,
+    send_circle_member_left_push,
+    send_circle_member_removed_push,
     send_connection_request_push,
 )
 from hushh_mcp.services.requester_identity import (
@@ -420,3 +424,128 @@ def test_the_email_handle_rung_is_a_privacy_switch_not_a_default():
     # the person.
     named = {"user_id": "u1", "display_name": "Neelesh", "email": "n@example.com"}
     assert label_from_identity_row(named, allow_email_handle=False) == "Neelesh"
+
+
+# ---------------------------------------------------------------------------
+# Circle invite/membership resolution pushes -- the same "creation notifies,
+# resolution goes silent" gap the Connect fix (#6507/#6509) closed, found to
+# repeat across every other request/invite surface in the app.
+# ---------------------------------------------------------------------------
+
+
+def test_circle_member_invite_declined_push_names_the_invitee_and_targets_the_inviter(
+    monkeypatch,
+):
+    captured = _capture_push(monkeypatch)
+
+    send_circle_member_invite_declined_push(
+        inviter_user_id="inviter-1",
+        invitee_user_id="invitee-1",
+        invitee_display_name="Ankit Sharma",
+        circle_id="circle-1",
+        circle_name="Family",
+        invite_id="invite-1",
+    )
+
+    assert captured["user_id"] == "inviter-1"
+    assert captured["body"] == "Ankit Sharma declined your Circle invitation."
+    assert captured["data"]["invitee_user_id"] == "invitee-1"
+    assert captured["data"]["network_display_label"] == "Ankit Sharma"
+
+
+def test_circle_member_invite_declined_push_falls_back_when_name_is_missing(monkeypatch):
+    captured = _capture_push(monkeypatch)
+
+    send_circle_member_invite_declined_push(
+        inviter_user_id="inviter-1",
+        invitee_user_id="invitee-1",
+        invitee_display_name="",
+        circle_id="circle-1",
+        circle_name="Family",
+        invite_id="invite-1",
+    )
+
+    assert captured["body"] == "Someone declined your Circle invitation."
+
+
+def test_circle_member_invite_cancelled_push_targets_the_invitee(monkeypatch):
+    captured = _capture_push(monkeypatch)
+
+    send_circle_member_invite_cancelled_push(
+        invitee_user_id="invitee-1",
+        circle_id="circle-1",
+        circle_name="Family",
+        invite_id="invite-1",
+    )
+
+    assert captured["user_id"] == "invitee-1"
+    assert captured["body"] == 'Your invitation to "Family" was withdrawn.'
+    assert captured["data"]["circle_id"] == "circle-1"
+
+
+def test_circle_member_removed_push_targets_the_removed_member(monkeypatch):
+    captured = _capture_push(monkeypatch)
+
+    send_circle_member_removed_push(
+        member_user_id="member-1",
+        circle_id="circle-1",
+        circle_name="Family",
+    )
+
+    assert captured["user_id"] == "member-1"
+    assert captured["body"] == 'You were removed from "Family".'
+
+
+def test_circle_member_left_push_names_the_member_and_targets_the_owner(monkeypatch):
+    captured = _capture_push(monkeypatch)
+
+    send_circle_member_left_push(
+        owner_user_id="owner-1",
+        member_user_id="member-1",
+        member_display_name="Ankit Sharma",
+        circle_id="circle-1",
+        circle_name="Family",
+    )
+
+    assert captured["user_id"] == "owner-1"
+    assert captured["body"] == 'Ankit Sharma left "Family".'
+
+
+def test_circle_member_invite_declined_and_cancelled_pushes_use_distinct_tags(monkeypatch):
+    captured = _capture_push(monkeypatch)
+    send_circle_member_invite_declined_push(
+        inviter_user_id="inviter-1",
+        invitee_user_id="invitee-1",
+        invitee_display_name="Ankit",
+        circle_id="circle-1",
+        circle_name="Family",
+        invite_id="invite-1",
+    )
+    declined_tag = captured["notification_tag"]
+
+    captured = _capture_push(monkeypatch)
+    send_circle_member_invite_cancelled_push(
+        invitee_user_id="invitee-1",
+        circle_id="circle-1",
+        circle_name="Family",
+        invite_id="invite-1",
+    )
+    cancelled_tag = captured["notification_tag"]
+
+    assert declined_tag != cancelled_tag
+
+
+def test_circle_member_removed_and_left_pushes_use_distinct_tags_per_member(monkeypatch):
+    captured = _capture_push(monkeypatch)
+    send_circle_member_removed_push(
+        member_user_id="member-1", circle_id="circle-1", circle_name="Family"
+    )
+    removed_tag_1 = captured["notification_tag"]
+
+    captured = _capture_push(monkeypatch)
+    send_circle_member_removed_push(
+        member_user_id="member-2", circle_id="circle-1", circle_name="Family"
+    )
+    removed_tag_2 = captured["notification_tag"]
+
+    assert removed_tag_1 != removed_tag_2


### PR DESCRIPTION
## Summary

Follow-up to #6509 (Connect accept/decline had no push) — same audit widened to the whole app per direction to not limit the fix to Connect. Circle membership had the identical gap: notifies on invite creation and accept, silent on every other resolution.

- `decline_member_invite` now notifies the inviter.
- `cancel_member_invite` now notifies the invitee whose invite was withdrawn.
- `_end_membership` (backs `remove_member` and `leave_circle`) now notifies the removed member, and separately notifies the owner when a member leaves on their own.

Each push fires after the transaction commits (best-effort, wrapped, never breaks the write), mirroring the existing `send_circle_member_invite_accepted_push` pattern already in this file.

Fixes #6510.

## Test plan
- `pytest tests/services/test_one_location_circle_service.py tests/services/test_push_notifications.py` — 127/127 pass (6 new circle-service wiring tests, 7 new push-body tests)
- `ruff check` clean on all touched files
- `mypy` — same 3 pre-existing unrelated errors confirmed present with these changes stashed out (none introduced)