### PR TITLE
fix(connect): push the addressee when a connection request is cancelled

### DIFF
--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -196,6 +196,21 @@ def _default_notifier(
     )
 
 
+def _default_cancel_notifier(
+    *,
+    addressee_user_id: str,
+    requester_user_id: str,
+    connection_request_id: str | None = None,
+) -> None:
+    from hushh_mcp.services.push_notifications import send_connection_request_cancelled_push
+
+    send_connection_request_cancelled_push(
+        addressee_user_id,
+        requester_user_id,
+        connection_request_id=connection_request_id,
+    )
+
+
 def _default_scope_entries_lookup(owner_user_id: str) -> list[dict[str, Any]]:
     """Read discoverable scope metadata only; never materialized information."""
     from hushh_mcp.consent.scope_generator import DynamicScopeGenerator
@@ -212,12 +227,16 @@ class ConnectionsService:
         directory_visible: Callable[[str, str], bool] | None = None,
         scope_entries_lookup: Callable[[str], list[dict[str, Any]]] | None = None,
         notifier: Callable[..., Any] | None = None,
+        cancel_notifier: Callable[..., Any] | None = None,
     ) -> None:
         self._directory_lookup = directory_lookup or _default_directory_lookup
         self._directory_search = directory_search or _default_directory_search
         self._directory_visible = directory_visible or _default_directory_visible
         self._scope_entries_lookup = scope_entries_lookup or _default_scope_entries_lookup
         self._notifier = notifier if notifier is not None else _default_notifier
+        self._cancel_notifier = (
+            cancel_notifier if cancel_notifier is not None else _default_cancel_notifier
+        )
 
     # ---- DB seam ----
     def _execute_one(self, sql: str, params: dict[str, Any] | None = None) -> dict[str, Any] | None:
@@ -1459,6 +1478,29 @@ class ConnectionsService:
         except Exception as exc:  # noqa: BLE001
             logger.warning("connections.notify_failed error=%s", exc)
 
+    def _notify_request_cancelled(
+        self,
+        addressee_user_id: str,
+        requester_user_id: str,
+        connection_request_id: str | None = None,
+    ) -> None:
+        """Fire the (best-effort) addressee nudge when a request is withdrawn.
+
+        Never raises, and always called after the transaction commits -- a
+        broken notifier must never unwind the cancellation itself.
+        """
+        notifier = getattr(self, "_cancel_notifier", None)
+        if notifier is None:
+            return
+        try:
+            notifier(
+                addressee_user_id=addressee_user_id,
+                requester_user_id=requester_user_id,
+                connection_request_id=str(connection_request_id or "").strip() or None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("connections.notify_cancelled_failed error=%s", exc)
+
     def _load_request(self, request_id: str, *, for_update: bool = False) -> dict[str, Any]:
         lock_clause = " FOR UPDATE" if for_update else ""
         row = self._execute_one(
@@ -2478,7 +2520,7 @@ class ConnectionsService:
                 raise ConnectionsError(
                     "CONNECTION_NOT_REQUESTER", "Only the requester can cancel.", status_code=403
                 )
-            self._execute_one(
+            cancelled_row = self._execute_one(
                 """
                 UPDATE connection_requests
                 SET status = 'cancelled', responded_at = NOW(), updated_at = NOW()
@@ -2492,6 +2534,12 @@ class ConnectionsService:
                 status="declined",
                 actor_user_id=user_id,
                 reason="connection_cancelled",
+            )
+        if cancelled_row:
+            self._notify_request_cancelled(
+                str(req.get("addressee_user_id") or ""),
+                user_id,
+                connection_request_id=str(req.get("id") or ""),
             )
         return {"status": "cancelled", "requestId": req.get("id")}
 

--- a/consent-protocol/hushh_mcp/services/push_notifications.py
+++ b/consent-protocol/hushh_mcp/services/push_notifications.py
@@ -267,6 +267,80 @@ def send_connection_request_push(
     )
 
 
+def send_connection_request_cancelled_push(
+    addressee_user_id: str,
+    requester_user_id: str,
+    *,
+    requester_display_name: str | None = None,
+    connection_request_id: str | None = None,
+) -> int:
+    """Tell the addressee that a pending request was withdrawn.
+
+    Cancelling used to write the DB and tell nobody: the request just sat in
+    the addressee's pending list, indistinguishable from one still awaiting a
+    reply, until their next reconcile.
+    """
+
+    from hushh_mcp.services.requester_identity import resolve_requester_label
+
+    requester_name = resolve_requester_label(
+        requester_user_id,
+        display_name=requester_display_name,
+    )
+    label = requester_name or "Someone"
+    body = f"{label} withdrew their connection request."
+    deep_link = CONNECTION_REQUEST_LIST_LINK
+    request_id = str(connection_request_id or "").strip()
+
+    client_data = {
+        "message_id": f"connection-request-cancelled:{request_id}" if request_id else "",
+        "requester_label": requester_name,
+        "request_id": request_id,
+    }
+
+    try:
+        import asyncio
+
+        from api.consent_listener import _push_to_consent_queue
+
+        sse_payload = {
+            "type": "connection_request_cancelled",
+            "action": "CANCELLED",
+            "request_id": request_id or f"conn_req:{requester_user_id}",
+            "user_id": addressee_user_id,
+            "requester_user_id": requester_user_id,
+            "requester_label": requester_name,
+            "title": "Connection request withdrawn",
+            "body": body,
+            "deep_link": deep_link,
+            "request_url": deep_link,
+        }
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_push_to_consent_queue(addressee_user_id, sse_payload))
+        except RuntimeError:
+            from api.consent_listener import push_to_consent_queue_threadsafe
+
+            push_to_consent_queue_threadsafe(addressee_user_id, sse_payload)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("push.sse_queue_failed error=%s", exc)
+
+    return send_user_data_push(
+        addressee_user_id,
+        notification_type="connection_request_cancelled",
+        title="Connection request withdrawn",
+        body=body,
+        deep_link=deep_link,
+        notification_tag=(
+            f"connection-request-cancelled:{request_id}"
+            if request_id
+            else "connection-request-cancelled"
+        ),
+        notification_category="ONE_CONNECTIONS",
+        data=client_data,
+    )
+
+
 def send_circle_code_joined_push(
     *,
     inviter_user_id: str,

--- a/consent-protocol/tests/services/test_connections_service.py
+++ b/consent-protocol/tests/services/test_connections_service.py
@@ -1095,6 +1095,96 @@ def test_cancel_marks_request_and_pending_scope_proposals_declined():
     }
 
 
+def test_cancel_notifies_the_addressee_not_the_requester():
+    # Cancelling used to write the DB and tell nobody -- the addressee's
+    # pending request just sat there, indistinguishable from one still
+    # awaiting a reply, until their next reconcile.
+    svc = _svc()
+    db = _RecordingDB(
+        [
+            [
+                {
+                    "id": "req-1",
+                    "requester_user_id": "user-a",
+                    "addressee_user_id": "user-b",
+                    "status": "pending",
+                }
+            ],
+            [{"id": "req-1"}],
+            [],
+            [],
+        ]
+    )
+    notify_calls: list[dict] = []
+    svc._cancel_notifier = lambda **kwargs: notify_calls.append(kwargs)
+    with patch("hushh_mcp.services.connections_service.get_db", lambda: db):
+        out = svc.cancel_request("user-a", "req-1")
+
+    assert out == {"status": "cancelled", "requestId": "req-1"}
+    assert notify_calls == [
+        {
+            "addressee_user_id": "user-b",
+            "requester_user_id": "user-a",
+            "connection_request_id": "req-1",
+        }
+    ]
+
+
+def test_cancel_does_not_notify_when_the_request_was_already_resolved():
+    # A race: the addressee accepted/declined right before the cancel
+    # arrived, so the guarded UPDATE affects no row. Nothing to tell them.
+    svc = _svc()
+    db = _RecordingDB(
+        [
+            [
+                {
+                    "id": "req-1",
+                    "requester_user_id": "user-a",
+                    "addressee_user_id": "user-b",
+                    "status": "pending",
+                }
+            ],
+            [],
+            [],
+            [],
+        ]
+    )
+    notify_calls: list[dict] = []
+    svc._cancel_notifier = lambda **kwargs: notify_calls.append(kwargs)
+    with patch("hushh_mcp.services.connections_service.get_db", lambda: db):
+        svc.cancel_request("user-a", "req-1")
+
+    assert notify_calls == []
+
+
+def test_cancel_notify_failure_does_not_break_the_write():
+    svc = _svc()
+    db = _RecordingDB(
+        [
+            [
+                {
+                    "id": "req-1",
+                    "requester_user_id": "user-a",
+                    "addressee_user_id": "user-b",
+                    "status": "pending",
+                }
+            ],
+            [{"id": "req-1"}],
+            [],
+            [],
+        ]
+    )
+
+    def _boom(**_kwargs):
+        raise RuntimeError("fcm is down")
+
+    svc._cancel_notifier = _boom
+    with patch("hushh_mcp.services.connections_service.get_db", lambda: db):
+        out = svc.cancel_request("user-a", "req-1")
+
+    assert out == {"status": "cancelled", "requestId": "req-1"}
+
+
 def test_reject_rejected_when_not_addressee():
     svc = _svc()
     db = _RecordingDB(

--- a/consent-protocol/tests/services/test_push_notifications.py
+++ b/consent-protocol/tests/services/test_push_notifications.py
@@ -5,6 +5,7 @@ from hushh_mcp.services import push_notifications as push_module
 from hushh_mcp.services.push_notifications import (
     _GENERIC_CONNECTION_REQUEST_BODY,
     _connection_request_body,
+    send_connection_request_cancelled_push,
     send_connection_request_push,
 )
 from hushh_mcp.services.requester_identity import (
@@ -420,3 +421,89 @@ def test_the_email_handle_rung_is_a_privacy_switch_not_a_default():
     # the person.
     named = {"user_id": "u1", "display_name": "Neelesh", "email": "n@example.com"}
     assert label_from_identity_row(named, allow_email_handle=False) == "Neelesh"
+
+
+# ---------------------------------------------------------------------------
+# Connect: the requester withdrawing their own request -- same gap, the
+# addressee previously heard nothing until their next reconcile.
+# ---------------------------------------------------------------------------
+
+
+def test_connection_request_cancelled_push_names_the_requester_and_targets_the_addressee(
+    monkeypatch,
+):
+    captured = _capture_push(monkeypatch)
+
+    send_connection_request_cancelled_push(
+        "addressee-1",
+        "requester-1",
+        requester_display_name="Ankit Sharma",
+        connection_request_id="req-42",
+    )
+
+    assert captured["user_id"] == "addressee-1"
+    assert captured["body"] == "Ankit Sharma withdrew their connection request."
+    assert captured["data"]["requester_label"] == "Ankit Sharma"
+
+
+def test_connection_request_cancelled_push_falls_back_when_name_is_missing(monkeypatch):
+    captured = _capture_push(monkeypatch)
+
+    send_connection_request_cancelled_push(
+        "addressee-1", "requester-1", requester_display_name="", connection_request_id="req-42"
+    )
+
+    assert captured["body"] == "Someone withdrew their connection request."
+
+
+def test_connection_request_cancelled_push_deep_links_to_the_connections_list(monkeypatch):
+    captured = _capture_push(monkeypatch)
+
+    send_connection_request_cancelled_push(
+        "addressee-1",
+        "requester-1",
+        requester_display_name="Ankit",
+        connection_request_id="req-42",
+    )
+
+    assert captured["deep_link"] == "/one/consent?tab=connections"
+
+
+def test_connection_request_cancelled_push_uses_distinct_request_scoped_tags(monkeypatch):
+    captured = _capture_push(monkeypatch)
+    send_connection_request_cancelled_push(
+        "addressee-1", "requester-1", requester_display_name="Ankit", connection_request_id="r1"
+    )
+    tag_1 = captured["notification_tag"]
+
+    captured = _capture_push(monkeypatch)
+    send_connection_request_cancelled_push(
+        "addressee-1", "requester-1", requester_display_name="Ankit", connection_request_id="r2"
+    )
+    tag_2 = captured["notification_tag"]
+
+    assert tag_1 != tag_2
+
+
+def test_connection_request_cancelled_push_reaches_sse_from_a_sync_handler(monkeypatch):
+    """Both production callers run on a sync FastAPI handler, off the event loop."""
+    _capture_push(monkeypatch)
+    sse_calls: list[tuple] = []
+    monkeypatch.setattr(
+        "api.consent_listener.push_to_consent_queue_threadsafe",
+        lambda user_id, payload: sse_calls.append((user_id, payload)),
+    )
+
+    send_connection_request_cancelled_push(
+        "addressee-1",
+        "requester-1",
+        requester_display_name="Ankit",
+        connection_request_id="req-42",
+    )
+
+    assert len(sse_calls) == 1
+    user_id, payload = sse_calls[0]
+    assert user_id == "addressee-1"
+    assert payload["type"] == "connection_request_cancelled"
+    assert payload["action"] == "CANCELLED"
+    assert payload["request_id"] == "req-42"

--- a/hushh-webapp/__tests__/consent-notification-provider-connections.test.tsx
+++ b/hushh-webapp/__tests__/consent-notification-provider-connections.test.tsx
@@ -147,6 +147,21 @@ function dispatchConnectionRequest(data: Record<string, string>) {
   return detail;
 }
 
+function dispatchConnectionRequestCancelled(data: Record<string, string>) {
+  const detail: {
+    data: Record<string, string>;
+    accepted?: boolean;
+  } = { data: { type: "connection_request_cancelled", ...data } };
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent("fcm-message", {
+        detail,
+      }),
+    );
+  });
+  return detail;
+}
+
 beforeEach(() => {
   window.localStorage.clear();
   window.sessionStorage.clear();
@@ -198,6 +213,39 @@ describe("connection-request Feed-first foreground policy", () => {
   it("drops a payload addressed to a different signed-in user", async () => {
     await renderProvider();
     const detail = dispatchConnectionRequest({
+      user_id: "someone-else",
+      request_id: "conn-req-1",
+    });
+
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(mocks.dispatchFeedStateChanged).not.toHaveBeenCalled();
+    expect(mocks.onConsentMutated).not.toHaveBeenCalled();
+    expect(detail.accepted).not.toBe(true);
+  });
+
+  it("refreshes on a cancelled request without a popup", async () => {
+    await renderProvider();
+
+    const detail = dispatchConnectionRequestCancelled({
+      user_id: "recipient-user",
+      requester_user_id: "requester-user",
+      requester_label: "Rohan",
+      request_id: "conn-req-1",
+    });
+
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(mocks.dispatchFeedStateChanged).toHaveBeenCalledOnce();
+    expect(mocks.onConsentMutated).toHaveBeenCalledWith("recipient-user");
+    expect(mocks.dispatchConsentStateChanged).toHaveBeenCalledWith({
+      source: "fcm_connection_request_cancelled",
+      reconcile: true,
+    });
+    expect(detail.accepted).toBe(true);
+  });
+
+  it("drops a cancelled-request payload addressed to a different signed-in user", async () => {
+    await renderProvider();
+    const detail = dispatchConnectionRequestCancelled({
       user_id: "someone-else",
       request_id: "conn-req-1",
     });

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -1581,6 +1581,17 @@ export function ConsentNotificationProvider({
           source: "fcm_connection_request",
           reconcile: true,
         });
+      } else if (msgType === "connection_request_cancelled") {
+        // The requester withdrew before the addressee acted on it. Without
+        // this the pending request just sat in their list until the next
+        // reconcile, indistinguishable from one still awaiting a reply.
+        if (user?.uid) {
+          CacheSyncService.onConsentMutated(user.uid);
+        }
+        dispatchConsentStateChanged({
+          source: "fcm_connection_request_cancelled",
+          reconcile: true,
+        });
       }
     };
 


### PR DESCRIPTION
## Summary

Same audit as #6511, widened from Connect's accept/decline (#6509) to every request/resolution flow in the app. `ConnectionsService.cancel_request` wrote `connection_requests.status = 'cancelled'` and resolved pending scope proposals, but called no notifier — the addressee's pending request just sat in their list, indistinguishable from one still awaiting a reply, until their next reconcile.

- Added `send_connection_request_cancelled_push` to `push_notifications.py`, mirroring `send_connection_request_push` (SSE dual-write included, for web clients without a push subscription).
- Added a `cancel_notifier` seam + `_notify_request_cancelled` to `ConnectionsService`, wired into `cancel_request` after the transaction commits, and only when the guarded UPDATE actually affected a row (skips the race where the addressee already resolved the request).
- `notification-provider.tsx` gets a `connection_request_cancelled` branch mirroring the existing `connection_request` one.

Fixes #6512.

## Test plan
- `pytest tests/services/test_connections_service.py tests/services/test_push_notifications.py` — 125/125 pass (3 new service-wiring tests, 5 new push-body tests)
- `npx vitest run __tests__/consent-notification-provider-connections.test.tsx` — 14/14 pass (2 new)
- `ruff check` / `tsc --noEmit` / `eslint` clean on all touched files
- `mypy` — same pre-existing unrelated error confirmed present without these changes (none introduced)