### PR TITLE
fix(voice): let a spoken share/request target a Circle by name

### DIFF
--- a/consent-protocol/hushh_mcp/one_adk/action_tools.py
+++ b/consent-protocol/hushh_mcp/one_adk/action_tools.py
@@ -637,6 +637,59 @@ def _resolve_named_circle(
     return resolved
 
 
+def _expand_unresolved_via_circles(
+    unresolved: list[UnresolvedPersonName[Any]],
+    candidates: list[dict[str, Any]],
+    circle_service: OneLocationCircleService,
+    user_id: str,
+) -> tuple[list[dict[str, Any]], list[UnresolvedPersonName[Any]]]:
+    """Let a share/request recipient name also be a Circle name.
+
+    ``location.share_selected`` and ``location.send_request`` resolve
+    recipients only against individual connections -- a spoken name that
+    matches no person falls through here to try the user's Circles instead.
+    A Circle match expands to its members, intersected with ``candidates``
+    (the already-eligibility-checked recipient pool ``list_verified_recipients``
+    returned) rather than the Circle's raw roster, so this can never grant
+    access to someone the existing connection/Circle-membership predicate
+    would not already have offered by name.
+
+    Only entries still unresolved after person-matching are tried here, and
+    only ``not_found`` ones -- an ``ambiguous`` person match is a real
+    person-name collision and saying the same word also names a Circle would
+    not resolve it.
+    """
+    circles: list[dict[str, Any]] | None = None
+    expanded: list[dict[str, Any]] = []
+    still_unresolved: list[UnresolvedPersonName[Any]] = []
+    seen_user_ids: set[str] = set()
+    for entry in unresolved:
+        if entry.kind != "not_found":
+            still_unresolved.append(entry)
+            continue
+        if circles is None:
+            circles = circle_service.list_circles(user_id=user_id)
+        match = match_circle_by_name(circles, entry.spoken_text, lambda c: str(c.get("name") or ""))
+        if match.match is None:
+            still_unresolved.append(entry)
+            continue
+        circle_id = str(match.match.get("id") or "")
+        detail = circle_service.get_circle(user_id=user_id, circle_id=circle_id)
+        member_ids = {str(m.get("userId") or "") for m in (detail.get("members") or [])}
+        for candidate in candidates:
+            candidate_id = str(candidate.get("userId") or "")
+            if candidate_id in member_ids and candidate_id not in seen_user_ids:
+                expanded.append(candidate)
+                seen_user_ids.add(candidate_id)
+        if not any(str(c.get("userId") or "") in member_ids for c in candidates):
+            # The Circle exists but nobody in it is an eligible recipient --
+            # same "not found" outcome a person search would have given, not
+            # a new error, since raising a Circle-specific message here would
+            # imply the Circle itself was the problem rather than who is in it.
+            still_unresolved.append(entry)
+    return expanded, still_unresolved
+
+
 def _unresolved_people_note(
     unresolved: list[UnresolvedPersonName[Any]], name_of: Callable[[Any], str], noun: str
 ) -> str:
@@ -926,6 +979,10 @@ async def _execute_backend_direct_mutation(
         candidates = agent_service.list_verified_recipients(owner_user_id=user_id)
         name_of = lambda c: str(c.get("displayName") or "")  # noqa: E731
         resolution = resolve_spoken_names(candidates, raw_people, name_of)
+        expanded, resolution.unresolved = _expand_unresolved_via_circles(
+            resolution.unresolved, candidates, OneLocationCircleService(), user_id
+        )
+        resolution.resolved.extend(expanded)
         if not resolution.resolved:
             ambiguous = next((u for u in resolution.unresolved if u.kind == "ambiguous"), None)
             if ambiguous is not None:
@@ -1013,6 +1070,10 @@ async def _execute_backend_direct_mutation(
         candidates = agent_service.list_verified_recipients(owner_user_id=user_id)
         name_of = lambda c: str(c.get("displayName") or "")  # noqa: E731
         resolution = resolve_spoken_names(candidates, raw_people, name_of)
+        expanded, resolution.unresolved = _expand_unresolved_via_circles(
+            resolution.unresolved, candidates, OneLocationCircleService(), user_id
+        )
+        resolution.resolved.extend(expanded)
         if not resolution.resolved:
             ambiguous = next((u for u in resolution.unresolved if u.kind == "ambiguous"), None)
             if ambiguous is not None:

--- a/consent-protocol/tests/test_one_adk_action_tools_circle_share.py
+++ b/consent-protocol/tests/test_one_adk_action_tools_circle_share.py
@@ -1,0 +1,128 @@
+"""Unit coverage for the Circle fallback in backend-direct recipient resolution.
+
+Saying "share my location with Family" used to fail outright: the person-only
+resolver (resolve_spoken_names) never tried the user's Circles, and the
+Circle-only resolver (match_circle_by_name) never expanded a match into
+recipients. _expand_unresolved_via_circles is the seam that lets a name still
+unresolved after person-matching try Circles next, without ever offering a
+Circle member the person-search pool itself would not already have offered.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hushh_mcp.one_adk.action_tools import _expand_unresolved_via_circles
+from hushh_mcp.services.spoken_name_resolver import UnresolvedPersonName
+
+
+class _FakeCircleService:
+    def __init__(self, circles: list[dict[str, Any]], members_by_circle: dict[str, list[dict[str, Any]]]):
+        self._circles = circles
+        self._members_by_circle = members_by_circle
+
+    def list_circles(self, *, user_id: str) -> list[dict[str, Any]]:
+        return self._circles
+
+    def get_circle(self, *, user_id: str, circle_id: str) -> dict[str, Any]:
+        return {"id": circle_id, "members": self._members_by_circle.get(circle_id, [])}
+
+
+def _not_found(spoken: str) -> UnresolvedPersonName[Any]:
+    return UnresolvedPersonName(spoken_text=spoken, kind="not_found")
+
+
+def _ambiguous(spoken: str) -> UnresolvedPersonName[Any]:
+    return UnresolvedPersonName(spoken_text=spoken, kind="ambiguous", matches=[{"userId": "x"}])
+
+
+def test_a_circle_name_expands_to_its_members_in_the_recipient_pool():
+    circles = [{"id": "circle-1", "name": "Family"}]
+    members = {"circle-1": [{"userId": "alice"}, {"userId": "bob"}]}
+    circle_service = _FakeCircleService(circles, members)
+    candidates = [
+        {"userId": "alice", "displayName": "Alice"},
+        {"userId": "bob", "displayName": "Bob"},
+        {"userId": "carol", "displayName": "Carol"},
+    ]
+
+    expanded, still_unresolved = _expand_unresolved_via_circles(
+        [_not_found("Family")], candidates, circle_service, "owner"
+    )
+
+    assert {c["userId"] for c in expanded} == {"alice", "bob"}
+    assert still_unresolved == []
+
+
+def test_a_circle_match_never_offers_a_member_outside_the_recipient_pool():
+    # The Circle's own roster can include someone who is not (or no longer) an
+    # eligible recipient -- list_verified_recipients is the sole authority on
+    # who this owner may share with; the Circle only supplies which of those
+    # already-eligible people are the ones meant by the spoken name.
+    circles = [{"id": "circle-1", "name": "Family"}]
+    members = {"circle-1": [{"userId": "alice"}, {"userId": "not-eligible"}]}
+    circle_service = _FakeCircleService(circles, members)
+    candidates = [{"userId": "alice", "displayName": "Alice"}]
+
+    expanded, still_unresolved = _expand_unresolved_via_circles(
+        [_not_found("Family")], candidates, circle_service, "owner"
+    )
+
+    assert [c["userId"] for c in expanded] == ["alice"]
+    assert "not-eligible" not in {c["userId"] for c in expanded}
+    assert still_unresolved == []
+
+
+def test_a_circle_with_no_eligible_members_stays_unresolved_not_an_error():
+    circles = [{"id": "circle-1", "name": "Family"}]
+    members = {"circle-1": [{"userId": "not-eligible"}]}
+    circle_service = _FakeCircleService(circles, members)
+    candidates = [{"userId": "alice", "displayName": "Alice"}]
+
+    expanded, still_unresolved = _expand_unresolved_via_circles(
+        [_not_found("Family")], candidates, circle_service, "owner"
+    )
+
+    assert expanded == []
+    assert [entry.spoken_text for entry in still_unresolved] == ["Family"]
+
+
+def test_a_name_matching_no_circle_and_no_person_stays_unresolved():
+    circle_service = _FakeCircleService([{"id": "circle-1", "name": "Family"}], {})
+    candidates = [{"userId": "alice", "displayName": "Alice"}]
+
+    expanded, still_unresolved = _expand_unresolved_via_circles(
+        [_not_found("Nobody")], candidates, circle_service, "owner"
+    )
+
+    assert expanded == []
+    assert [entry.spoken_text for entry in still_unresolved] == ["Nobody"]
+
+
+def test_an_ambiguous_person_entry_is_left_untouched():
+    # Ambiguity between two people is a real name collision -- retrying it
+    # against Circles would not resolve it, so it passes through unexamined.
+    circle_service = _FakeCircleService([{"id": "circle-1", "name": "Family"}], {})
+    candidates: list[dict[str, Any]] = []
+    entry = _ambiguous("Sam")
+
+    expanded, still_unresolved = _expand_unresolved_via_circles(
+        [entry], candidates, circle_service, "owner"
+    )
+
+    assert expanded == []
+    assert still_unresolved == [entry]
+
+
+def test_two_spoken_names_can_mix_a_circle_and_a_still_missing_person():
+    circles = [{"id": "circle-1", "name": "Family"}]
+    members = {"circle-1": [{"userId": "alice"}]}
+    circle_service = _FakeCircleService(circles, members)
+    candidates = [{"userId": "alice", "displayName": "Alice"}]
+
+    expanded, still_unresolved = _expand_unresolved_via_circles(
+        [_not_found("Family"), _not_found("Ghost")], candidates, circle_service, "owner"
+    )
+
+    assert [c["userId"] for c in expanded] == ["alice"]
+    assert [entry.spoken_text for entry in still_unresolved] == ["Ghost"]

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5489,7 +5489,7 @@
     "cache_manifest": "c7a177decdb319d8a8b673ae16f6acdad5aedee5fc98329d2d58470e1726b4e8",
     "data_plane": "d2706bc9683b88a5e34015bc6bc5fd6f0c1c90618342e62da7ff560f2bc8daf2",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
-    "one_specialist_tools": "f91a213f8eda5ce9d17b9fed0062e77e0c3e8faca7786f1a7a7b9810ebe6002f",
+    "one_specialist_tools": "29626329f6ac56570178881b1a4aa22735b0a4ce605e09f023add28014c56951",
     "route_index": "e6408b8d2cc074a7ea1c5ae916ffee357ce41d8007d4631002bb46c87e460399",
     "route_layout": "b66933c7083fd755f1a8e4a16262996fc7ae6124a4c550725bfdc7144332355f",
     "surface_map": "f5fffd96f19e2c2e949c47840a815f87c0fa0936eff7a50cc9c7a180590ba7b3",

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -10372,6 +10372,56 @@ export function OneLocationAgentPageContent({
           };
         }
       }
+      // A recipient name can also be a Circle name -- try any name that still
+      // did not match a person (even after the fresh server-side retry above)
+      // against the user's Circles, and on a match, add that Circle's
+      // location-ready members the same way a tap on the Circle button would
+      // (handleResolveNamedCircleRecipients, "location" purpose -- no phone
+      // requirement, self and key-less members already excluded there).
+      // Appended, never replacing: a person who already matched earlier in
+      // the same turn ("share with Bob and Family") keeps their spot.
+      const stillUnnamed = unresolved.filter(
+        (entry) => entry.kind === "not_found",
+      );
+      const matchedCircleNames: string[] = [];
+      if (stillUnnamed.length > 0 && namedCircles.length > 0) {
+        const remaining: typeof unresolved = unresolved.filter(
+          (entry) => entry.kind !== "not_found",
+        );
+        for (const entry of stillUnnamed) {
+          const { match: circleMatch } = matchCircleByName(
+            namedCircles,
+            entry.spokenText,
+          );
+          if (!circleMatch) {
+            remaining.push(entry);
+            continue;
+          }
+          try {
+            const selection = await handleResolveNamedCircleRecipients(
+              circleMatch.id,
+              "location",
+            );
+            if (!selection.ready.length) {
+              remaining.push(entry);
+              continue;
+            }
+            matchedCircleNames.push(selection.circle.name);
+            for (const target of selection.ready) {
+              if (
+                !resolved.some(
+                  (existing) => existing.userId === target.recipient.userId,
+                )
+              ) {
+                resolved = [...resolved, target.recipient];
+              }
+            }
+          } catch {
+            remaining.push(entry);
+          }
+        }
+        unresolved = remaining;
+      }
       if (resolved.length === 0) {
         // Never guess between people. Two colleagues sharing a first name is
         // ordinary, and picking the wrong one here is not recoverable once the
@@ -10958,6 +11008,49 @@ export function OneLocationAgentPageContent({
               "Location is still loading your connections. Please try that name again in a moment.",
           };
         }
+      }
+      // A named Circle asks every location-ready member the same way naming
+      // one asks that one person -- see location.select_share_recipient's own
+      // Circle fallback just above, which this mirrors exactly.
+      const stillUnnamedToAsk = unresolved.filter(
+        (entry) => entry.kind === "not_found",
+      );
+      if (stillUnnamedToAsk.length > 0 && namedCircles.length > 0) {
+        const remaining: typeof unresolved = unresolved.filter(
+          (entry) => entry.kind !== "not_found",
+        );
+        for (const entry of stillUnnamedToAsk) {
+          const { match: circleMatch } = matchCircleByName(
+            namedCircles,
+            entry.spokenText,
+          );
+          if (!circleMatch) {
+            remaining.push(entry);
+            continue;
+          }
+          try {
+            const selection = await handleResolveNamedCircleRecipients(
+              circleMatch.id,
+              "location",
+            );
+            if (!selection.ready.length) {
+              remaining.push(entry);
+              continue;
+            }
+            for (const target of selection.ready) {
+              if (
+                !resolved.some(
+                  (existing) => existing.userId === target.recipient.userId,
+                )
+              ) {
+                resolved = [...resolved, target.recipient];
+              }
+            }
+          } catch {
+            remaining.push(entry);
+          }
+        }
+        unresolved = remaining;
       }
       if (resolved.length === 0) {
         const ambiguous = unresolved.find(


### PR DESCRIPTION
## Summary
Closes #6514. "Share my location with Family" (or asking a Circle to share back) failed outright: the share/request pathway resolves spoken names only against individual connections, Circle-management actions resolve only against Circles, and nothing ever expanded a matched Circle name into its members for a share/request. Not a disambiguation bug -- two parallel resolvers that were each deaf to the other's namespace.

## Fix
- **Backend** (`action_tools.py`): new `_expand_unresolved_via_circles` tries a still-unresolved spoken name against the user's Circles, and on a match expands to the Circle's members intersected with the already-eligibility-checked recipient pool (`list_verified_recipients`) -- never the Circle's raw roster, so it can't grant beyond what the existing connection/Circle-membership predicate already offers by name. Wired into `location.share_selected` and `location.send_request`.
- **Frontend** (`page.tsx`): same fallback in `select_share_recipient`/`select_ask_recipient`, reusing the already-shipped `handleResolveNamedCircleRecipients("location")` (the same resolver the tap-driven "select a Circle to share with" button already uses). Appends to whatever already matched by name in the same turn -- "share with Bob and Family" keeps Bob.
- The documented privacy boundary (model never receives a searchable contact list; matching stays client-side) is unaffected -- Circle matching already happened client-side elsewhere in this file.

## Test plan
- [x] New backend unit tests: `consent-protocol/tests/test_one_adk_action_tools_circle_share.py` (6 cases: expansion, pool-intersection safety, no-eligible-members, no-match, ambiguous-person passthrough, mixed circle+person turn) -- all pass
- [x] Existing backend suites unaffected: `test_spoken_name_resolver.py`, `test_one_adk_live_protocol.py`, `test_one_location_circle_service.py` (171 passed), plus a full keyword-filtered pass (297 passed, 1 pre-existing unrelated failure confirmed on unmodified main)
- [x] `npm run typecheck` clean
- [x] Existing frontend suites unaffected: `one-location-agent-page.test.tsx`, `location-acting-actions.test.ts`, `circle-recipient-selection-avatar.test.ts` (162 passed)
- [x] `ruff check` / `eslint` clean on changed files