### PR TITLE
UAT: pin the emoji brand mark, and reword the RIA onboarding intro

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -177,8 +177,19 @@ textarea {
   --font-family-product:
     -apple-system, BlinkMacSystemFont, "InterVariable", "Inter", system-ui,
     sans-serif;
-  --font-app-display: var(--font-family-product);
-  --font-app-body: var(--font-family-product);
+  /* Emoji tier, appended to the text stack rather than folded into
+     --font-family-product so the product typeface stack stays exactly as it
+     is. The text faces above carry no emoji glyphs, so without an emoji tier
+     every emoji codepoint fell through to the browser's last-resort matching,
+     which has no defined priority — on a Mac with Noto Color Emoji installed
+     (Google Fonts, Docker and design tooling all ship it) Chrome could pick
+     the Android artwork, and the winner could change between paints as
+     InterVariable swapped in. Naming the platform emoji fonts in order pins
+     it: Apple on macOS/iOS, Segoe on Windows, Noto elsewhere. Emoji fonts
+     carry only emoji, so Latin text still resolves as before. */
+  --font-app-emoji: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji";
+  --font-app-display: var(--font-family-product), var(--font-app-emoji);
+  --font-app-body: var(--font-family-product), var(--font-app-emoji);
   --font-app-text: var(--font-app-body);
   --font-app-heading: var(--font-app-display);
   --font-app-mono: var(--font-app-body);
@@ -1873,6 +1884,20 @@ html.kb-open .ambient-chrome-mask--bottom {
 
 
 
+
+/* The 🤫 brand mark. Every surface that renders it — top bar, sidebar, intro
+   gate, onboarding — goes through this class so the glyph is chosen the same
+   way everywhere instead of per-component inline stacks (only the top bar had
+   one) or the ambient product font. Pinning it here also survives a component
+   that sets its own font-family on the mark's ancestor. Note the artwork is
+   still the platform's: Apple's shushing face on macOS/iOS, Segoe's on
+   Windows, Noto's elsewhere. Identical artwork on every OS would need a drawn
+   asset — Apple Color Emoji itself is not redistributable. */
+.hushh-brand-mark {
+  font-family: var(--font-app-emoji), emoji;
+  /* Emoji are presentational here; keep them from being read as text. */
+  font-variant-emoji: emoji;
+}
 
 .app-page-shell {
   width: 100%;

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -11,7 +11,6 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
-import Image from "next/image";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   ArrowLeft,
@@ -3840,15 +3839,20 @@ export function AgentChatWorkspace({
                 </ShellActionSurface>
               ) : null}
               <div className="grid h-8 w-8 shrink-0 place-items-center overflow-hidden rounded-md border border-border bg-muted max-sm:h-11 max-sm:w-11 max-sm:rounded-[13px] max-sm:border-[color:var(--app-accent-border)]">
-                <Image
-                  src="/one-quiet-emoji.png"
-                  alt="One"
-                  width={762}
-                  height={766}
-                  unoptimized
-                  draggable={false}
-                  className="h-6 w-6 object-contain max-sm:h-8 max-sm:w-8"
-                />
+                {/* The mark, as text, exactly like the top bar / sidebar /
+                    intro gate. This slot used to render /one-quiet-emoji.png,
+                    which is Noto (Android) artwork baked into a raster — so it
+                    stayed Android on a Mac no matter what the font stack said,
+                    and it was the one brand mark in the app that could not
+                    follow the platform. .hushh-brand-mark pins the emoji font
+                    the same way every other mark does. */}
+                <span
+                  aria-label="One"
+                  role="img"
+                  className="hushh-brand-mark select-none text-[22px] leading-none max-sm:text-[30px]"
+                >
+                  🤫
+                </span>
               </div>
               <div className="min-w-0">
                 <div className="truncate text-base font-medium leading-5 text-foreground">

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -983,11 +983,7 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
                     >
                       <span
                         aria-hidden
-                        className="flex h-7 w-7 shrink-0 items-center justify-center overflow-visible text-[23px] leading-none"
-                        style={{
-                          fontFamily:
-                            '"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", emoji',
-                        }}
+                        className="hushh-brand-mark flex h-7 w-7 shrink-0 items-center justify-center overflow-visible text-[23px] leading-none"
                       >
                         🤫
                       </span>

--- a/hushh-webapp/components/dashboard/app-sidebar.tsx
+++ b/hushh-webapp/components/dashboard/app-sidebar.tsx
@@ -35,7 +35,7 @@ export function AppSidebar() {
     <Sidebar>
       <SidebarHeader className="h-16 flex items-center justify-start border-b px-4">
         <div className="flex items-center gap-2">
-          <span className="text-2xl">🤫</span>
+          <span className="hushh-brand-mark text-2xl">🤫</span>
           <div>
             <h2 className="font-semibold">Hussh PDA</h2>
             <p className="text-xs text-muted-foreground">Memory Agent</p>

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -1067,7 +1067,7 @@ export function AuthStep({
               aria-hidden="true"
             >
               <span className="pointer-events-none absolute h-28 w-28 rounded-full bg-accent/20 blur-2xl" />
-              <span className="relative select-none text-[56px] leading-none drop-shadow-[0_6px_14px_rgba(0,0,0,0.25)]">
+              <span className="hushh-brand-mark relative select-none text-[56px] leading-none drop-shadow-[0_6px_14px_rgba(0,0,0,0.25)]">
                 🤫
               </span>
             </div>

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -98,7 +98,7 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
 
           <span
             aria-hidden="true"
-            className={styles.emoji}
+            className={`hushh-brand-mark ${styles.emoji}`}
           >
             🤫
           </span>

--- a/hushh-webapp/lib/morphy-ux/ui/brand-mark.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/brand-mark.tsx
@@ -35,7 +35,7 @@ export function BrandMark({
         className,
       )}
     >
-      <span className="leading-none">{label}</span>
+      <span className="hushh-brand-mark leading-none">{label}</span>
     </div>
   );
 }

--- a/hushh-webapp/lib/onboarding/capability-setup-copy.ts
+++ b/hushh-webapp/lib/onboarding/capability-setup-copy.ts
@@ -155,9 +155,8 @@ const SETUP_COPY_BY_ID: Record<
       "Create and verify your advisor profile so One can open the right professional workspace for you.",
     actionLabel: "Verify RIA",
     resumeActionLabel: "Finish RIA",
-    introPremise: "A professional workspace shaped around your practice.",
-    introPromise:
-      "You review every detail before it becomes part of your advisor profile.",
+    introPremise: "A custom workspace built for you",
+    introPromise: "You review every detail.",
     setupBullets: [
       "Verify your advisor or firm credentials.",
       "Choose the services you offer and review your profile.",


### PR DESCRIPTION
Cherry-picks the fixes behind #6067 and #6070 onto `uat` for UAT, without dragging main in with them.

`uat` is ~2300 commits behind `main`, so merging those PR branches directly would have pulled three weeks of unrelated work into the UAT baseline. These are the three fix commits only.

## What's here

- **`fix(brand)`** — adds a `--font-app-emoji` tier (Apple / Segoe / Noto, in that order) and appends it to the display and body stacks. Without it, emoji codepoints fell through to the browser's last-resort matching, so a Mac with Noto Color Emoji installed could render the Android artwork. Closes the root cause behind #6068.
- **`fix(agent)`** — the agent chat header rendered `/one-quiet-emoji.png`, a raster of the Noto glyph, so it stayed Android on a Mac regardless of the font stack. Now renders as text through `.hushh-brand-mark` like every other mark. Closes #6131.
- **`copy(ria)`** — the RIA onboarding premise/promise pair. Closes #6098.

## Resolutions worth reviewing

`uat` predates a lot of this code, so two conflicts needed adapting rather than taking either side:

- **`globals.css`** — `uat`'s `--font-family-product` leads with `-apple-system, BlinkMacSystemFont`, which `main`'s does not. Kept uat's stack and appended the emoji tier to it, rather than overwriting it with main's Inter-only version.
- **`HushhIntroGate.tsx`** — does not exist on `uat` (introduced on main after the branches diverged). Dropped from the cherry-pick.
- **`capability-setup-copy.ts`** — uat carried different baseline RIA copy than main. Took the reworded target strings from the commit.

The chat header keeps its `22px / 30px` glyph sizing here, matching uat's original avatar container — main's restyled 36px box needed a different value, which is why this differs slightly from #6067.

## Verification

- `tsc --noEmit` clean
- `verify:design-system`, `verify-accent-tokens`, `verify-apple-hierarchy` all pass

Note: `/one-quiet-emoji.png` is now unreferenced in code but still present in `public/` — deleting it is #6132 and deliberately not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)