### PR TITLE
Governance sync converges instead of reporting drift forever

### DIFF
--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -255,6 +255,16 @@ trace in this repo — the same bypass the eight-person `protected_pipeline_edit
 ring exists to prevent. The script previously created every member at
 `role=maintainer`, so this was live.
 
+Organization owners are the exception, and the sync skips them. GitHub reports an
+owner as a maintainer of every team they belong to and refuses to demote them
+there, so attempting it would make `apply-governance.py` report drift on every run
+and never converge — and a governance tool that always cries drift is one people
+learn to scroll past. It costs nothing in safety: an owner can edit branch
+protection and team membership directly, so the team role grants them nothing they
+did not already hold. The demotion therefore applies to exactly the population it
+matters for — org *members* who would otherwise gain a grant path they should not
+have.
+
 ### Rule: deploy-actor lists are governance, not routine config
 
 Changes to `manual_dispatch_users` (UAT or production) and to the maintainer

--- a/scripts/ci/apply-governance.py
+++ b/scripts/ci/apply-governance.py
@@ -178,6 +178,20 @@ def current_review_bypass(branch: str) -> list[str]:
     return sorted(u["login"] for u in users if u.get("login"))
 
 
+_OWNERS_CACHE: set[str] | None = None
+
+
+def organization_owners() -> set[str]:
+    """Logins with org-owner (admin) rights, lowercased. Queried once per run."""
+    global _OWNERS_CACHE
+    if _OWNERS_CACHE is None:
+        members = gh_json(
+            ["api", f"orgs/{ORG}/members?role=admin", "--paginate"]
+        ) or []
+        _OWNERS_CACHE = {str(m.get("login", "")).lower() for m in members if m.get("login")}
+    return _OWNERS_CACHE
+
+
 def team_exists(slug: str) -> bool:
     code, _, _ = gh(["api", f"orgs/{ORG}/teams/{slug}"], check=False)
     return code == 0
@@ -250,9 +264,20 @@ def apply_team_membership(slug: str, desired: list[str], *, apply: bool) -> bool
     # A member sitting at role=maintainer can add people to the team, which is a
     # grant path that never touches this repo. Demote as part of every sync, not
     # only when the membership set itself changed.
+    #
+    # Org owners are excluded because GitHub reports them as a maintainer of every
+    # team they belong to and refuses to demote them there. Trying anyway would
+    # make this sync claim drift on every single run and never converge, and a
+    # governance tool that always cries drift is one people learn to scroll past
+    # -- which is how the UAT cohort sat wrong in the advisory lane for as long as
+    # it did. It costs nothing in safety either: an org owner can edit branch
+    # protection and team membership directly, so their team role grants them no
+    # authority they did not already hold.
+    owners = organization_owners()
     over_privileged = sorted(
         login for login in (want & cur)
-        if (gh_json(["api", f"orgs/{ORG}/teams/{slug}/memberships/{login}"]) or {})
+        if login.lower() not in owners
+        and (gh_json(["api", f"orgs/{ORG}/teams/{slug}/memberships/{login}"]) or {})
         .get("role") != TEAM_MEMBER_ROLE
     )
 

--- a/scripts/ci/test_apply_governance_teams.py
+++ b/scripts/ci/test_apply_governance_teams.py
@@ -119,6 +119,53 @@ def test_the_maintainer_set_is_the_union_of_both_governed_branches(module) -> No
         assert set(policy[key]["merge_queue_bypass_users"]) <= maintainers
 
 
+def test_org_owners_are_never_demoted(module) -> None:
+    """An org owner must not appear in the demotion set, or the sync never converges.
+
+    GitHub reports an organization owner as a maintainer of every team they are in
+    and refuses to demote them there. Attempting it anyway made apply-governance
+    print a demotion plan on every run forever -- a governance tool that always
+    claims drift is one people learn to scroll past, which is precisely how the
+    UAT cohort stayed wrong in the advisory lane. Excluding owners costs nothing:
+    they can edit branch protection and team membership directly regardless.
+    """
+    calls = {"role_lookups": []}
+
+    def fake_gh(args, check=True):  # team_exists -> exists
+        return 0, "", ""
+
+    def fake_gh_json(args):
+        joined = " ".join(args)
+        # Order matters: "/members" is a substring of "/memberships/".
+        if "/memberships/" in joined:
+            login = joined.rsplit("/", 1)[-1]
+            calls["role_lookups"].append(login)
+            return {"role": "maintainer"}
+        if "/members" in joined:
+            return [{"login": "owner-person"}, {"login": "regular-person"}]
+        return []
+
+    original = (module.gh, module.gh_json, module.organization_owners)
+    try:
+        module.gh, module.gh_json = fake_gh, fake_gh_json
+        module.organization_owners = lambda: {"owner-person"}
+        changed = module.apply_team_membership(
+            "some-team", ["owner-person", "regular-person"], apply=False
+        )
+    finally:
+        module.gh, module.gh_json, module.organization_owners = original
+
+    assert "owner-person" not in calls["role_lookups"], (
+        "an org owner's team role was inspected for demotion; GitHub will never "
+        "let it change, so the sync would report drift on every run"
+    )
+    assert "regular-person" in calls["role_lookups"], (
+        "a non-owner at role=maintainer must still be demoted -- that is the "
+        "grant path this closes"
+    )
+    assert changed is True
+
+
 def main() -> int:
     module = _module()
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]


### PR DESCRIPTION
Follow-up to #6520, found by running `--apply` against live GitHub and then
checking the result rather than trusting the success output.

## The bug

`apply-governance.py` demoted every managed-team member found at `role=maintainer`.
Against live GitHub that can never finish: **7 of the 14 are organization owners**,
GitHub reports an owner as a maintainer of every team they belong to, and refuses to
demote them there.

So each run planned the same seven demotions, applied them, achieved nothing, and
planned them again. Measured after the first `--apply`: **5 phantom demotion plans**
across the managed teams, on a tree that was otherwise fully in sync.

A governance tool that reports drift on every run is one people learn to scroll past.
That is not hypothetical in this repo — it is exactly how `uat.manual_dispatch_users`
sat five names short of the merge cohort while the advisory verifier printed the
failure on every single run.

## The fix

Skip org owners when computing the demotion set, queried once per run and cached.

This costs nothing in safety: an owner can edit branch protection and team membership
directly, so their team role grants them no authority they did not already hold. The
demotion still does its job for the population it was written for — org **members**,
4 of whom really were at `role=maintainer` on a team wired into `main`'s
branch-protection `bypass_teams`, and who are now `role=member`.

## Verified live

- `apply-governance.py` dry-run: 5 phantom demotion plans → `✅ Live GitHub state already matches config/ci-governance.json`
- `scripts/ci/orchestrate.sh governance`: exit 0
- `./bin/hushh docs verify`: 0 errors
- `scripts/ci/test_apply_governance_teams.py`: 7 tests — the new one asserts an owner's
  role is never even *inspected*, while a non-owner's still is