### PR TITLE
fix(one-location): Circle count includes the owner everywhere, plus two UI/copy defects

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -2721,7 +2721,7 @@ describe("OneLocationAgentPage", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Select the Family Circle, 2 members",
+        name: "Select the Family Circle, 3 members",
       }),
     );
 

--- a/hushh-webapp/__tests__/lib/one-location/circle-member-count.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/circle-member-count.test.ts
@@ -4,48 +4,46 @@ import { join } from "node:path";
 
 import {
   circleMemberCountLabel,
-  circleOtherMemberCount,
   circleOthersLabel,
-  othersCountLabel,
+  circleTotalMemberCount,
+  totalCountLabel,
 } from "@/lib/one-location/circle-member-count";
 
 /**
- * A Circle's count, from the reader's point of view.
+ * A Circle's count, owner included.
  *
- * The server counts every active membership and the reader is always one of
- * them, so the raw number reads as that many OTHER people until you work out
- * that one of them is you. Four screens rendered it raw and three subtracted
- * the reader, so the same Circle said "5 members" on the share picker and
- * "4 members" one tap away in its own detail.
+ * The server counts every active membership, and the owner always holds one
+ * of them -- so `memberCount` already includes them. List rows used to
+ * subtract the owner back out while the Circle's own detail screen kept the
+ * raw count, so the same Circle said "4 members" on the share picker and
+ * "5 members" one tap away in its own detail.
  */
-describe("a Circle's count never includes the reader", () => {
-  it("counts others", () => {
-    expect(circleOtherMemberCount(5)).toBe(4);
-    expect(circleOtherMemberCount(2)).toBe(1);
-    expect(circleOtherMemberCount(1)).toBe(0);
+describe("a Circle's count always includes the owner", () => {
+  it("counts everyone", () => {
+    expect(circleTotalMemberCount(5)).toBe(5);
+    expect(circleTotalMemberCount(2)).toBe(2);
+    expect(circleTotalMemberCount(1)).toBe(1);
   });
 
   it("never goes negative on a transient zero", () => {
     // A Circle read mid-write can report 0, and "-1 members" is worse than
     // being briefly wrong in the safe direction.
-    expect(circleOtherMemberCount(0)).toBe(0);
-    expect(circleOtherMemberCount(null)).toBe(0);
-    expect(circleOtherMemberCount(undefined)).toBe(0);
+    expect(circleTotalMemberCount(0)).toBe(0);
+    expect(circleTotalMemberCount(null)).toBe(0);
+    expect(circleTotalMemberCount(undefined)).toBe(0);
   });
 
   it("says members in a list and people in a detail, for the same set", () => {
-    expect(circleMemberCountLabel(5)).toBe("4 members");
-    expect(circleMemberCountLabel(2)).toBe("1 member");
-    expect(circleOthersLabel(5)).toBe("4 people");
-    expect(circleOthersLabel(2)).toBe("1 person");
+    expect(circleMemberCountLabel(5)).toBe("5 members");
+    expect(circleMemberCountLabel(1)).toBe("1 member");
+    expect(circleOthersLabel(5)).toBe("5 people");
+    expect(circleOthersLabel(2)).toBe("2 people");
   });
 
-  it("says a Circle of one is empty rather than counting the reader", () => {
-    // This is the row the reporter saw: their own SMS Circle, holding nobody,
-    // announcing "1 member".
-    expect(circleMemberCountLabel(1)).toBe("0 members");
-    expect(circleOthersLabel(1)).toBe("No members yet");
-    expect(othersCountLabel(0)).toBe("No members yet");
+  it("says a Circle holding only the owner is 'Only you', not a count of zero", () => {
+    expect(circleMemberCountLabel(1)).toBe("1 member");
+    expect(circleOthersLabel(1)).toBe("Only you");
+    expect(totalCountLabel(1)).toBe("Only you");
   });
 });
 
@@ -56,12 +54,13 @@ describe("every screen that shows a Circle count uses the shared rule", () => {
     "components/one-location/redesign/contact-picker/circle-member-picker.tsx",
     "app/one/location/page.tsx",
     "components/one-location/redesign/circles/named-circle-flows.tsx",
+    "components/connect/circles/connect-circles-tab.tsx",
   ];
 
   it("renders no raw memberCount anywhere", () => {
     // The rule is only worth having if nothing routes around it. Each of these
     // interpolated the server number directly, and each disagreed with the
-    // Circle's own detail screen by exactly one.
+    // Circle's own detail screen.
     for (const file of files) {
       const source = readFileSync(join(process.cwd(), file), "utf8")
         .split("\r\n")

--- a/hushh-webapp/components/connect/circles/__tests__/connect-circles-tab.test.tsx
+++ b/hushh-webapp/components/connect/circles/__tests__/connect-circles-tab.test.tsx
@@ -164,12 +164,11 @@ beforeEach(() => {
 });
 
 describe("circleRowDescription", () => {
-  it("counts everyone except the viewer", () => {
-    // "3 people" reading as two others and yourself is the answer to a question
-    // nobody asked. The Location list already excludes the viewer; these two
-    // now agree.
-    expect(circleRowDescription(circle("c", "K Family", 4))).toBe("3 people");
-    expect(circleRowDescription(circle("c", "K Family", 2))).toBe("1 person");
+  it("counts everyone in the Circle, owner included", () => {
+    // The Circle's own detail screen counts everyone including the owner;
+    // this row now agrees with it instead of disagreeing by exactly one.
+    expect(circleRowDescription(circle("c", "K Family", 4))).toBe("4 people");
+    expect(circleRowDescription(circle("c", "K Family", 2))).toBe("2 people");
     expect(circleRowDescription(circle("c", "K Family", 1))).toBe(
       "No members yet",
     );
@@ -181,10 +180,10 @@ describe("circleRowDescription", () => {
     // never asked. These lines answer the question a Circle you did not create
     // actually raises.
     expect(circleRowDescription(circle("t", "Trusted", 8, "trusted"))).toBe(
-      "Everyone you're connected to · 7 people",
+      "Everyone you're connected to · 8 people",
     );
     expect(circleRowDescription(circle("s", "SMS Circle", 4, "sms"))).toBe(
-      "Gets your SMS · 3 people",
+      "Gets your SMS · 4 people",
     );
   });
 
@@ -216,7 +215,7 @@ describe("circleRowDescription", () => {
 
   it("still recognises an SMS Circle from a server that predates systemKind", () => {
     const legacy = { ...circle("s", "SMS Circle", 3, "sms"), systemKind: null };
-    expect(circleRowDescription(legacy)).toBe("Gets your SMS · 2 people");
+    expect(circleRowDescription(legacy)).toBe("Gets your SMS · 3 people");
   });
 });
 

--- a/hushh-webapp/components/connect/circles/connect-circles-tab.tsx
+++ b/hushh-webapp/components/connect/circles/connect-circles-tab.tsx
@@ -118,21 +118,20 @@ function systemKindOf(circle: OneLocationCircleSummary): string | null {
  * person was never asked, so the row opened by naming a category they had not
  * picked ahead of the only number on the line that was true.
  *
- * The viewer is excluded from the count for the same reason the Location list
- * excludes them: "3 people" reading as two others and yourself is the answer
- * to a question nobody asked.
+ * The count includes the owner, matching Circle Detail -- excluding them made
+ * this row disagree with the screen one tap away over the same Circle.
  */
 export function circleRowDescription(circle: OneLocationCircleSummary): string {
-  const others = Math.max(0, Number(circle.memberCount || 0) - 1);
+  const count = Math.max(0, Number(circle.memberCount || 0));
   const kind = systemKindOf(circle);
   const owns = circle.role === "owner";
-  const people = others === 1 ? "1 person" : `${others} people`;
+  const people = count === 1 ? "1 person" : `${count} people`;
 
   // Trusted is owner-scoped by the server, so the only viewer who can reach
   // this line is its owner. Guarded anyway: "Everyone you're connected to" on
   // somebody else's roster would be a false statement about the reader.
   if (kind === "trusted" && owns) {
-    return others === 0
+    return count <= 1
       ? SYSTEM_CIRCLE_COPY.trusted.description
       : `${SYSTEM_CIRCLE_COPY.trusted.description} · ${people}`;
   }
@@ -144,9 +143,9 @@ export function circleRowDescription(circle: OneLocationCircleSummary): string {
       ? SYSTEM_CIRCLE_COPY.sms.description
       : "You'll get their SMS";
     if (!owns) return lead;
-    return others === 0 ? `${lead} · no one yet` : `${lead} · ${people}`;
+    return count <= 1 ? `${lead} · no one yet` : `${lead} · ${people}`;
   }
-  return others === 0 ? "No members yet" : people;
+  return count <= 1 ? "No members yet" : people;
 }
 
 /** Circles you own first, with product-managed circles pinned above named ones. */

--- a/hushh-webapp/components/one-location/redesign/__tests__/circles-section-subtitle.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/circles-section-subtitle.test.tsx
@@ -77,13 +77,13 @@ describe("the circle row's second line", () => {
     }
   });
 
-  it("still counts everyone but the viewer, and says person once", () => {
+  it("counts everyone in the Circle, owner included", () => {
     renderCircles([
       circle({ id: "c_two", name: "Two", memberCount: 2 }),
       circle({ id: "c_four", name: "Four", memberCount: 4 }),
     ]);
-    expect(screen.getByText("1 person")).toBeTruthy();
-    expect(screen.getByText("3 people")).toBeTruthy();
+    expect(screen.getByText("2 people")).toBeTruthy();
+    expect(screen.getByText("4 people")).toBeTruthy();
   });
 
   it("uses the red SMS identity for the Save My Soul system Circle", () => {
@@ -98,7 +98,7 @@ describe("the circle row's second line", () => {
     ]);
 
     expect(screen.getByText("SMS")).toBeTruthy();
-    expect(screen.getByText("Save My Soul · 1 person")).toBeTruthy();
+    expect(screen.getByText("Save My Soul · 2 people")).toBeTruthy();
     expect(screen.queryByTestId("siren")).toBeNull();
 
     // 36px here, because these rows are 60px tall with their own padding

--- a/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
@@ -252,8 +252,8 @@ describe("SmsContactsFlow", () => {
       expect(
         screen.queryByRole("button", { name: "Add Family" }),
       ).not.toBeInTheDocument();
-      // Circle counts consistently exclude the person viewing the Circle.
-      expect(screen.getByText("2 members")).toBeInTheDocument();
+      // Circle counts include everyone in the Circle, owner included.
+      expect(screen.getByText("3 members")).toBeInTheDocument();
 
       fireEvent.click(
         screen.getByRole("button", { name: "Choose people from Family" }),

--- a/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
+++ b/hushh-webapp/components/one-location/redesign/circles/named-circle-flows.tsx
@@ -102,7 +102,6 @@ import { ContactSourceBadge } from "@/components/connections/contact-source-badg
 import { ConnectionPersonAvatar } from "@/components/connections/connection-person-avatar";
 import { LOCATION_SEARCH_INPUT_CLASSNAME } from "@/components/one-location/redesign/selectors";
 import { relationshipCta } from "@/lib/connections/relationship-label";
-import { othersCountLabel } from "@/lib/one-location/circle-member-count";
 import { ActionMenu } from "@/components/app-ui/action-menu";
 import { cn } from "@/lib/utils";
 import {
@@ -156,13 +155,11 @@ function circleInitials(value: string): string {
 }
 
 /**
- * Subtitle for the "Your circles" list row, e.g. "2 members".
+ * Subtitle for the "Your circles" list row, e.g. "3 people".
  *
- * Counts OTHER members (everyone except the viewer) so it matches the Circle
- * Detail subtitle, which filters out the current user. The backend
- * `memberCount` includes the viewer — always a member of a circle shown in
- * their own list — so subtracting one yields the same number both places.
- * `Math.max(0, ...)` guards a transient zero.
+ * Counts everyone in the Circle, owner included — matching the Circle Detail
+ * subtitle, which does the same. The backend `memberCount` already includes
+ * the owner (they always hold a membership row), so this is the raw count.
  *
  * The kind used to lead this line — "Family · 0 members". Reported from QA:
  * the circle created during onboarding is filed under Family by default and
@@ -171,15 +168,10 @@ function circleInitials(value: string): string {
  * There are three kinds and nothing on this screen acts on any of them, so
  * the word was decoration in front of the fact. The count stands alone.
  */
-/** Re-exported so existing importers keep working; the rule itself now lives
- *  in `lib/one-location/circle-member-count`, because four other screens were
- *  rendering the raw server count and disagreeing with this one. */
-export { othersCountLabel };
-
 function circleListPeopleLabel(memberCount: number | null | undefined): string {
-  const others = Math.max(0, Number(memberCount || 0) - 1);
-  if (others <= 0) return "Only you";
-  return `${others} ${others === 1 ? "person" : "people"}`;
+  const count = Math.max(0, Number(memberCount || 0));
+  if (count <= 1) return "Only you";
+  return `${count} people`;
 }
 
 type CircleListGroupKey = "owned" | "joined";

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2577,15 +2577,7 @@ function LocationDetailFlow({
 
   return (
     <div className="space-y-5" data-testid={`one-location-${kind}`}>
-      <TaskFlowHeader
-        eyebrow={
-          kind === "active-shares" || kind === "needs-review"
-            ? undefined
-            : "Location"
-        }
-        title={copy.title}
-        description={copy.description}
-      />
+      <TaskFlowHeader title={copy.title} description={copy.description} />
       {kind === "active-shares" ? (
         ownerGrantGroups.length ? (
           <SettingsGroup separatorInset>
@@ -5401,6 +5393,14 @@ function ShareFlow({
           ) : null}
           {notSharing.length ? (
             <SettingsGroup
+              title={
+                <span className="flex w-full items-center justify-between gap-4">
+                  <span>Not sharing</span>
+                  <span className="font-normal text-muted-foreground">
+                    {notSharing.length}
+                  </span>
+                </span>
+              }
               testId="one-location-share-people"
               separatorInset
               className="[&>div:first-child]:mt-0"

--- a/hushh-webapp/lib/one-location/circle-member-count.ts
+++ b/hushh-webapp/lib/one-location/circle-member-count.ts
@@ -1,22 +1,21 @@
 /**
- * How many people are in a Circle, from the reader's point of view.
+ * How many people are in a Circle.
  *
- * The server's `memberCount` counts every active membership, and the viewer is
- * always one of them on any Circle they can see. So the raw number answers a
- * question nobody asked: "3 members" on a Circle you share with two friends
- * reads as three OTHER people until you work out that one of them is you.
+ * The server's `memberCount` counts every active membership, and the owner
+ * always holds one of those memberships -- so it already includes them. A
+ * previous version of this module subtracted the owner back out for list
+ * rows ("N other people") while the Circle's own detail screen kept the raw,
+ * inclusive count ("N people") -- the same Circle showing two different
+ * numbers one tap apart, which is the kind of disagreement a person notices
+ * and cannot explain.
  *
- * Four screens rendered the raw number and three subtracted the viewer, so the
- * same Circle showed "5 members" on the share picker and "4 members" one tap
- * away in its own detail. That is the kind of disagreement a person notices and
- * cannot explain, and it was reported from exactly there.
- *
- * One rule, one module: every Circle row counts OTHERS.
+ * One rule, one module: every Circle row shows the same inclusive count
+ * Detail does.
  */
 
-/** Everyone in the Circle except the reader. `Math.max` guards a transient 0. */
-export function circleOtherMemberCount(memberCount: number | null | undefined): number {
-  return Math.max(0, Number(memberCount || 0) - 1);
+/** Everyone in the Circle, owner included. `Math.max` guards a transient 0. */
+export function circleTotalMemberCount(memberCount: number | null | undefined): number {
+  return Math.max(0, Number(memberCount || 0));
 }
 
 /**
@@ -29,19 +28,19 @@ export function circleOtherMemberCount(memberCount: number | null | undefined): 
 export function circleMemberCountLabel(
   memberCount: number | null | undefined,
 ): string {
-  const others = circleOtherMemberCount(memberCount);
-  return `${others} ${others === 1 ? "member" : "members"}`;
+  const count = circleTotalMemberCount(memberCount);
+  return `${count} ${count === 1 ? "member" : "members"}`;
 }
 
-/** "2 people", or "No members yet" for a Circle holding only the reader. */
+/** "2 people", or "Only you" for a Circle holding just the owner. */
 export function circleOthersLabel(
   memberCount: number | null | undefined,
 ): string {
-  return othersCountLabel(circleOtherMemberCount(memberCount));
+  return totalCountLabel(circleTotalMemberCount(memberCount));
 }
 
-/** Wording for a count that has ALREADY excluded the viewer. */
-export function othersCountLabel(others: number): string {
-  if (others <= 0) return "No members yet";
-  return `${others} ${others === 1 ? "person" : "people"}`;
+/** Wording for an inclusive Circle member count. */
+export function totalCountLabel(count: number): string {
+  if (count <= 1) return "Only you";
+  return `${count} people`;
 }


### PR DESCRIPTION
## Summary

- Circle member count now includes the owner everywhere, matching Circle Detail's already-correct behavior. Fixes the Circles list and the Save My Soul (SOS) row, both of which subtracted the owner via a shared "others only" convention that disagreed with Detail by exactly one on the same Circle. Backend `memberCount` already included the owner — this is a frontend-only fix, applied to every consuming screen: Location's Circles list, Connect's Circles tab, both SMS/SOS rows, the check-in circle picker, the share-recipient circle picker, and the share flow's circle picker.
- Removes the "Location" eyebrow from the Shared with me header.
- Labels the not-yet-sharing section of the share-location menu "Not sharing" — it sat unlabeled next to the labeled "Already sharing" section.

Fixes #6522.

## Test plan
- `npx vitest run` across every touched test file — 149/149 pass (including a full rewrite of `circle-member-count.test.ts` for the new inclusive semantics, and updated expectations in `circles-section-subtitle.test.tsx`, `connect-circles-tab.test.tsx`, `sms-contacts-flow.test.tsx`)
- Confirmed 4 pre-existing, unrelated failures in `share-circle-sections.test.ts` and `profile-people-links-consistency.contract.test.ts` are present on `main` before this change too (not introduced here)
- `tsc --noEmit` / `eslint` clean on all touched files