### PR TITLE
fix(email-agent): introduce the sample draft once, not on every open

### DIFF
--- a/hushh-webapp/__tests__/lib/agent/email-agent-intro.test.ts
+++ b/hushh-webapp/__tests__/lib/agent/email-agent-intro.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   buildEmailAgentIntroPrompt,
+  hasSeenEmailAgentIntro,
+  markEmailAgentIntroSeen,
 } from "@/lib/agent/email-agent-intro";
 
 describe("buildEmailAgentIntroPrompt", () => {
@@ -9,5 +11,45 @@ describe("buildEmailAgentIntroPrompt", () => {
     expect(buildEmailAgentIntroPrompt(" me@example.com ")).toBe(
       "Can you send an email to 'me@example.com', In the email explain features of the email agent.",
     );
+  });
+});
+
+describe("email agent intro gate", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("reports unseen for a user who has never opened the agent", () => {
+    expect(hasSeenEmailAgentIntro("user-1")).toBe(false);
+  });
+
+  it("reports seen only after the intro has been marked", () => {
+    markEmailAgentIntroSeen("user-1");
+    expect(hasSeenEmailAgentIntro("user-1")).toBe(true);
+  });
+
+  it("keeps the flag per user so a second account still gets introduced", () => {
+    markEmailAgentIntroSeen("user-1");
+    expect(hasSeenEmailAgentIntro("user-2")).toBe(false);
+  });
+
+  it("survives a reload, which is the whole point of persisting it", () => {
+    markEmailAgentIntroSeen("user-1");
+    // A fresh page would read the same backing store rather than fresh state.
+    expect(
+      window.localStorage.getItem("one_email_agent_intro_seen_v1:user-1"),
+    ).toBe("1");
+    expect(hasSeenEmailAgentIntro("user-1")).toBe(true);
+  });
+
+  it("treats a missing user id as unseen rather than writing a shared key", () => {
+    markEmailAgentIntroSeen(null);
+    expect(hasSeenEmailAgentIntro(null)).toBe(false);
+    expect(window.localStorage.length).toBe(0);
+  });
+
+  it("ignores surrounding whitespace in the user id", () => {
+    markEmailAgentIntroSeen(" user-1 ");
+    expect(hasSeenEmailAgentIntro("user-1")).toBe(true);
   });
 });

--- a/hushh-webapp/app/one/email/email-agent-page-client.tsx
+++ b/hushh-webapp/app/one/email/email-agent-page-client.tsx
@@ -6,7 +6,11 @@ import { useRouter } from "next/navigation";
 
 import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { useOneConversationSession } from "@/lib/agent/one-conversation-session";
-import { buildEmailAgentIntroPrompt } from "@/lib/agent/email-agent-intro";
+import {
+  buildEmailAgentIntroPrompt,
+  hasSeenEmailAgentIntro,
+  markEmailAgentIntroSeen,
+} from "@/lib/agent/email-agent-intro";
 import {
   AppPageContentRegion,
   AppPageHeaderRegion,
@@ -50,23 +54,40 @@ export function EmailAgentPageClient() {
       : "unavailable-valid";
 
   const openOneForDraft = useCallback(() => {
-    const createdAtMs = Date.now();
-    createHandoff({
-      id: `email-agent-prompt-${createdAtMs}`,
-      reason: "user_requested",
-      transcript: emailAgentIntroRecipient
-        ? buildEmailAgentIntroPrompt(emailAgentIntroRecipient)
-        : "Please help me draft an email. I will review it before anything is sent.",
-      createdAtMs,
-    });
+    // The intro prompt asks One to compose a sample email about itself. That
+    // is a first-run demonstration, not what someone arriving to write a real
+    // email wants: queuing it on every open started a fresh sample draft each
+    // time, because every handoff carried a new id and so was never de-duped
+    // against the previous one. Queue it only until this user has seen it;
+    // afterwards the agent opens on an empty composer awaiting a real
+    // instruction.
+    const userId = user?.uid || null;
+    if (!hasSeenEmailAgentIntro(userId)) {
+      const createdAtMs = Date.now();
+      markEmailAgentIntroSeen(userId);
+      createHandoff({
+        id: `email-agent-prompt-${createdAtMs}`,
+        reason: "user_requested",
+        transcript: emailAgentIntroRecipient
+          ? buildEmailAgentIntroPrompt(emailAgentIntroRecipient)
+          : "Please help me draft an email. I will review it before anything is sent.",
+        createdAtMs,
+      });
+    }
     if (agentPopover) {
       agentPopover.openAgent();
       return;
     }
-    // The handoff remains in the shared in-memory session for the legacy
-    // dedicated chat route too.
+    // Any queued handoff remains in the shared in-memory session for the
+    // legacy dedicated chat route too.
     router.push(ROUTES.AGENT);
-  }, [agentPopover, createHandoff, emailAgentIntroRecipient, router]);
+  }, [
+    agentPopover,
+    createHandoff,
+    emailAgentIntroRecipient,
+    router,
+    user?.uid,
+  ]);
 
   return (
     <AppPageShell

--- a/hushh-webapp/lib/agent/email-agent-intro.ts
+++ b/hushh-webapp/lib/agent/email-agent-intro.ts
@@ -16,3 +16,69 @@ export function buildGmailAgentHandoffPrompt(recipient: string): string {
   }
   return `Send an email to '${normalizedRecipient}' explaining all the features of the Gmail agent in detail. Prepare the draft for my review and do not send it without my explicit approval.`;
 }
+
+// ---------------------------------------------------------------------------
+// One-time intro gate
+// ---------------------------------------------------------------------------
+// The intro prompt above is a demonstration: it asks One to compose a sample
+// email explaining the agent. It is worth showing once, and only once — every
+// later visit should open an empty composer waiting for a real instruction.
+//
+// The handoff id cannot carry that memory: each open mints a new
+// `email-agent-prompt-${Date.now()}` id, so the consumed-handoff ref in the
+// chat workspace only ever de-dupes a single handoff against itself. The
+// "already introduced" fact has to outlive the page, so it is persisted per
+// user, matching how one-location persists its seen-notification set.
+
+const EMAIL_AGENT_INTRO_KEY_PREFIX = "one_email_agent_intro_seen_v1";
+
+function safeLocalStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    // Private browser settings can deny storage entirely.
+    return null;
+  }
+}
+
+function emailAgentIntroStorageKey(userId: string): string {
+  return `${EMAIL_AGENT_INTRO_KEY_PREFIX}:${userId}`;
+}
+
+/**
+ * True once this user has been shown the sample-email introduction.
+ *
+ * Keyed by user so a second account on the same device still gets its own
+ * introduction. When storage is unavailable this reports false and the intro
+ * runs again — a repeated demonstration is a far smaller failure than
+ * suppressing it for someone who has never seen it.
+ */
+export function hasSeenEmailAgentIntro(
+  userId: string | null | undefined,
+): boolean {
+  const normalizedUserId = String(userId || "").trim();
+  if (!normalizedUserId) return false;
+  const storage = safeLocalStorage();
+  if (!storage) return false;
+  try {
+    return storage.getItem(emailAgentIntroStorageKey(normalizedUserId)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Record that the introduction has been shown. */
+export function markEmailAgentIntroSeen(
+  userId: string | null | undefined,
+): void {
+  const normalizedUserId = String(userId || "").trim();
+  if (!normalizedUserId) return;
+  const storage = safeLocalStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(emailAgentIntroStorageKey(normalizedUserId), "1");
+  } catch {
+    // Never let a storage failure block entry into the agent.
+  }
+}


### PR DESCRIPTION
Opening the Email Agent and pressing **"Try Email Agent with One"** started One drafting the sample email *every* time. Anyone coming back to actually send mail got the demo again instead of an empty composer.

## Why the existing guard never caught it

`app/one/email/email-agent-page-client.tsx` queued `buildEmailAgentIntroPrompt` as a handoff transcript on every click — the prompt that asks One to *"send an email … explain features of the email agent"*.

The chat workspace does de-dupe handoffs, but only against `consumedHandoffIdRef`, and each open minted a fresh `email-agent-prompt-${Date.now()}` id. So every visit looked like a brand-new handoff. Nothing in the repo recorded that the introduction had already happened — there was no persisted first-run flag for this anywhere.

## The fix

Record that the intro has been shown, keyed by user, and queue it only while unseen. Later opens create no handoff at all and land on an empty composer.

Persistence follows the `one-location` seen-notification pattern already in the codebase: a versioned localStorage key suffixed with the user id (`one_email_agent_intro_seen_v1:<uid>`), read and written through guarded accessors.

- **Per user**, so a second account on a shared device still gets its own introduction.
- **Storage denied → intro runs again.** Repeating a demonstration is a much smaller failure than withholding it from someone who has never seen it, so the gate fails open.

## Scope

Left the Gmail workspace's own "Open One Chat" button (`gmail-receipts-page.tsx`) alone — it sits inside a dismissible onboarding card that already owns its own lifecycle. Say the word if you want that gated too.

## Verification

- `tsc --noEmit` and `eslint --max-warnings=0` clean
- 6 new tests covering the gate: unseen by default, seen only after marking, per-user isolation, survives reload, no shared key when the user id is missing, whitespace-normalised
- `gmail-email-agent-handoff` and `agent-chat-email-draft-layout` contracts still pass
- Full suite: **20 pre-existing failures, identical to `origin/main`** (verified by running the suite on a clean checkout) — passing count rises 6177 → 6183, exactly the new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)