### PR TITLE
fix(connect): bound the My connections roster on phones too

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -1707,10 +1707,15 @@ describe("Connect — the phone-width geometry QA reported", () => {
     expect(classes.has("justify-end")).toBe(true);
   });
 
-  it("keeps one page scroll on phones and caps My connections on larger screens", async () => {
-    // A nested roster scroller traps touch gestures on phones and lets the
-    // fixed bottom chrome obscure whichever row owns the gesture. Phones use
-    // the app scroll root; larger screens can keep the bounded roster.
+  it("caps My connections on every viewport, phones included", async () => {
+    // Phones were once left uncapped because an earlier bound trapped touch
+    // gestures in the inner scroller and let the fixed bottom chrome cover the
+    // row owning the gesture. Uncapped is its own bug though: a long roster
+    // pushes the directory section below it out of reach. The bound is back,
+    // and `overscroll-contain` is what keeps it safe -- it stops a scroll that
+    // reaches the roster's end from chaining into the page behind it. The cap
+    // is measured in `dvh` so it tracks the visible viewport rather than
+    // measuring a phone as though its browser chrome were absent.
     mocks.listConnections.mockResolvedValue(
       Array.from({ length: 12 }, (_, index) => ({
         connectionId: `c-${index}`,
@@ -1727,12 +1732,18 @@ describe("Connect — the phone-width geometry QA reported", () => {
       '[data-testid="connect-my-connections-group"] [data-inset-separators="true"]',
     );
     expect(list).toBeTruthy();
-    expect(list!.className).toContain("sm:max-h-[320px]");
-    expect(list!.className).toContain("sm:overflow-y-auto");
-    expect(list!.className).toContain("sm:overscroll-contain");
-    expect(list!.className).not.toMatch(/(?:^|\s)max-h-\[232px\](?:\s|$)/);
-    expect(list!.className).not.toMatch(/(?:^|\s)overflow-y-auto(?:\s|$)/);
-    expect(list!.className).not.toMatch(/(?:^|\s)overscroll-contain(?:\s|$)/);
+    // Unprefixed, so the bound applies on phones too.
+    expect(list!.className).toContain("max-h-[min(42dvh,18rem)]");
+    expect(list!.className).toContain("overflow-y-auto");
+    // The mitigation the phone bound depends on. Without it the roster chains
+    // its scroll into the page and the old gesture trap comes back.
+    expect(list!.className).toContain("overscroll-contain");
+    // Not re-introduced behind a breakpoint: the cap is unconditional now.
+    expect(list!.className).not.toMatch(/(?:^|\s)sm:max-h-\[320px\](?:\s|$)/);
+    expect(list!.className).not.toMatch(/(?:^|\s)sm:overflow-y-auto(?:\s|$)/);
+    // A viewport unit that ignores browser chrome would let the list run under
+    // the fixed bottom bars on a phone.
+    expect(list!.className).not.toMatch(/max-h-\[[^\]]*\bvh\b/);
   });
 
   it("asks for the search field in two words", async () => {

--- a/hushh-webapp/app/connect/connect-surface-layout.ts
+++ b/hushh-webapp/app/connect/connect-surface-layout.ts
@@ -33,7 +33,26 @@ export const CONNECT_WRAPPING_TEXT_CLASSNAME =
 export const CONNECT_WRAPPING_TITLE_ROW_CLASSNAME =
   "flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5";
 
-/** Phones keep one natural page scroller. A bounded inner roster is useful on
- * larger screens, where wheel/trackpad input does not create a gesture trap. */
-export const CONNECT_DESKTOP_CONNECTION_LIST_CLASSNAME =
-  "sm:max-h-[320px] sm:overflow-y-auto sm:overscroll-contain sm:[-webkit-overflow-scrolling:touch]";
+/**
+ * The roster is bounded on every viewport, phones included.
+ *
+ * It was previously capped only from `sm` up, because an earlier phone cap (at
+ * 232px) let touch gestures get trapped in the inner scroller and let the fixed
+ * bottom chrome sit over whichever row owned the gesture. Leaving phones
+ * uncapped fixed those two problems by making the roster arbitrarily long
+ * instead, which is its own bug: a few hundred connections push the directory
+ * section below them out of reach.
+ *
+ * `overscroll-contain` is what makes the bound safe this time. It stops a
+ * scroll that reaches the roster's end from chaining into the page behind it,
+ * which is the gesture trap the original comment described; the finance
+ * holdings roster already relies on the same mitigation on phones. The cap is
+ * expressed against `dvh` so it shrinks with the visible viewport rather than
+ * measuring a phone as though its browser chrome were not there, which keeps
+ * the bottom of the list clear of the fixed bottom bars.
+ *
+ * The `min(42dvh, 18rem)` shape matches the RIA option lists, so the two read
+ * as the same control.
+ */
+export const CONNECT_CONNECTION_LIST_CLASSNAME =
+  "max-h-[min(42dvh,18rem)] overflow-y-auto overscroll-contain [-webkit-overflow-scrolling:touch]";

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -103,7 +103,7 @@ import { CONNECT_WEB_DIRECTORY_POPOVER_CLASSNAME } from "./connect-surface-layou
 import { cn } from "@/lib/utils";
 import { ContactSourceBadge } from "@/components/connections/contact-source-badge";
 import {
-  CONNECT_DESKTOP_CONNECTION_LIST_CLASSNAME,
+  CONNECT_CONNECTION_LIST_CLASSNAME,
   CONNECT_PAGE_CONTENT_CLASSNAME,
   CONNECT_WRAPPING_TEXT_CLASSNAME,
   CONNECT_WRAPPING_TITLE_ROW_CLASSNAME,
@@ -2514,7 +2514,7 @@ export default function ConnectPageClient() {
                       separatorInset
                       contentClassName={
                         sortedConnections.length > 0
-                          ? CONNECT_DESKTOP_CONNECTION_LIST_CLASSNAME
+                          ? CONNECT_CONNECTION_LIST_CLASSNAME
                           : undefined
                       }
                       testId="connect-my-connections-group"


### PR DESCRIPTION
The people list in Connect was capped only from `sm` up. On a phone it grew with the connection count, so the whole roster had to be scrolled past before the directory section beneath it could be reached.

## This reverses a deliberate decision — please read before approving

The phone cap was removed on purpose. An earlier bound at 232px let touch gestures get trapped in the inner scroller, and let the fixed bottom chrome sit over whichever row owned the gesture. Moving phones back to the single page scroll fixed both — and traded them for an unbounded list, which is the bug being fixed here.

**What makes the bound safe this time is `overscroll-contain`.** A scroll reaching the end of the roster no longer chains into the page behind it, which is the trap the original note described. The finance holdings roster (`holdings-mobile-list.tsx`) already depends on the same mitigation on phones, which is the evidence that this works.

The cap is measured against `dvh` rather than `vh`, so it tracks the visible viewport instead of measuring a phone as though its browser chrome were absent — that keeps the end of the list clear of the fixed bottom bars, the second of the two original failure modes.

```
sm:max-h-[320px] sm:overflow-y-auto sm:overscroll-contain   →
max-h-[min(42dvh,18rem)] overflow-y-auto overscroll-contain
```

`min(42dvh, 18rem)` is the shape the RIA option lists already use, so the two read as the same control. On `sm` and up this tightens the cap slightly, **320px → 288px**.

## The regression test is rewritten, not dropped

The guard that pinned the old behaviour now encodes the new intent: it pins the unprefixed cap, requires `overscroll-contain` **by name** as the mitigation the phone bound depends on, and fails if the cap is ever re-expressed in `vh`.

## Scope

**Connect only, deliberately.** The seven other bounded lists across RIA and Kai use six different values between them (`62vh`, `200px`, `60vh`, `60svh`, `min(28rem,calc(100vh-10rem))`, `min(42dvh,18rem)`). Unifying those was explicitly not part of this change and none of those files are touched.

## Verification

- `tsc --noEmit` and `eslint --max-warnings=0` clean
- All **78** Connect page tests pass
- Full suite failures unchanged from `origin/main` — 20, pre-existing, unrelated

## Worth a real-device check

The two original failure modes were touch behaviours that a jsdom test cannot reproduce. Please confirm on an actual phone that scrolling the roster to its end doesn't chain into the page, and that the bottom rows clear the fixed bottom bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)