### PR TITLE
fix(ios): let Siri share/ask-for-location intents target a Circle

### DIFF
--- a/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
+++ b/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
@@ -241,6 +241,70 @@ struct OneCircleEntityQuery: EntityStringQuery {
     }
 }
 
+/// A person or a Circle -- whichever "share my location with Family" or
+/// "share my location with Sarah" turns out to name. Share/ask intents used
+/// to accept only `OneContactEntity`, so a Circle name had nowhere to
+/// resolve: Siri's own entity matching failed before the app ever ran,
+/// independent of anything the backend already knows how to do with a
+/// Circle name in the `person` slot. One merged query over both pools is
+/// what lets Siri's picker (and free-speech matching) offer either.
+@available(iOS 16.0, *)
+struct OneShareRecipientEntity: AppEntity, Identifiable, Hashable {
+    enum Kind: String, Hashable {
+        case contact
+        case circle
+    }
+
+    let id: String
+    let name: String
+    let kind: Kind
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Agent One Recipient"
+    static let defaultQuery = OneShareRecipientEntityQuery()
+
+    var displayRepresentation: DisplayRepresentation {
+        switch kind {
+        case .contact:
+            return DisplayRepresentation(title: "\(name)")
+        case .circle:
+            return DisplayRepresentation(title: "\(name)", subtitle: "Circle")
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+struct OneShareRecipientEntityQuery: EntityStringQuery {
+    func entities(for identifiers: [OneShareRecipientEntity.ID]) async throws -> [OneShareRecipientEntity] {
+        let requested = Set(identifiers)
+        let coordinator = OneSystemActionInvocationCoordinator.shared
+        let contacts = coordinator.contacts()
+            .filter { requested.contains($0.id) }
+            .map { OneShareRecipientEntity(id: $0.id, name: $0.name, kind: .contact) }
+        let circles = coordinator.circles()
+            .filter { requested.contains($0.id) }
+            .map { OneShareRecipientEntity(id: $0.id, name: $0.name, kind: .circle) }
+        return contacts + circles
+    }
+
+    func entities(matching string: String) async throws -> [OneShareRecipientEntity] {
+        let coordinator = OneSystemActionInvocationCoordinator.shared
+        let contacts = coordinator.contacts(matching: string)
+            .map { OneShareRecipientEntity(id: $0.id, name: $0.name, kind: .contact) }
+        let circles = coordinator.circles(matching: string)
+            .map { OneShareRecipientEntity(id: $0.id, name: $0.name, kind: .circle) }
+        return contacts + circles
+    }
+
+    func suggestedEntities() async throws -> [OneShareRecipientEntity] {
+        let coordinator = OneSystemActionInvocationCoordinator.shared
+        let contacts = coordinator.contacts()
+            .map { OneShareRecipientEntity(id: $0.id, name: $0.name, kind: .contact) }
+        let circles = coordinator.circles()
+            .map { OneShareRecipientEntity(id: $0.id, name: $0.name, kind: .circle) }
+        return contacts + circles
+    }
+}
+
 @available(iOS 16.0, *)
 enum OneLocationDuration: String, AppEnum {
     case fifteenMinutes = "0.25"
@@ -418,7 +482,7 @@ struct TalkToHusshOneIntent: AppIntent {
 struct ShareLocationWithOneIntent: AppIntent {
     static let title: LocalizedStringResource = "Share Location"
     static let description = IntentDescription(
-        "Share your live location with an existing Agent One connection."
+        "Share your live location with an existing Agent One connection or Circle."
     )
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
@@ -427,8 +491,8 @@ struct ShareLocationWithOneIntent: AppIntent {
     @available(iOS 26.0, *)
     static let supportedModes: IntentModes = [.foreground(.immediate)]
 
-    @Parameter(title: "Person")
-    var recipient: OneContactEntity
+    @Parameter(title: "Person or Circle")
+    var recipient: OneShareRecipientEntity
 
     @Parameter(title: "Duration")
     var duration: OneLocationDuration
@@ -454,7 +518,7 @@ struct ShareLocationWithOneIntent: AppIntent {
 struct AskForLocationWithOneIntent: AppIntent {
     static let title: LocalizedStringResource = "Ask for Location"
     static let description = IntentDescription(
-        "Ask an existing Agent One connection to share their location."
+        "Ask an existing Agent One connection or Circle to share their location."
     )
     static let authenticationPolicy: IntentAuthenticationPolicy =
         .requiresLocalDeviceAuthentication
@@ -463,8 +527,8 @@ struct AskForLocationWithOneIntent: AppIntent {
     @available(iOS 26.0, *)
     static let supportedModes: IntentModes = [.foreground(.immediate)]
 
-    @Parameter(title: "Person")
-    var person: OneContactEntity
+    @Parameter(title: "Person or Circle")
+    var person: OneShareRecipientEntity
 
     @Parameter(title: "Duration")
     var duration: OneLocationDuration


### PR DESCRIPTION
## Summary
Follow-up to #6515. That PR fixed the web voice agent's circle-vs-person resolver gap, but the same symptom -- "share my location with Family" not working -- was also reported for Siri/App Intents, and it turned out to be a separate, more fundamental cause there.

`ShareLocationWithOneIntent.recipient` and `AskForLocationWithOneIntent.person` (added 2026-09-01) were declared as `OneContactEntity`, whose `EntityQuery` only searches individual contacts. A Circle name has no way to resolve there: **Siri's own OS-level entity matching fails before the app's code ever runs**, independent of anything the backend already does correctly with a Circle name in the `person` slot (confirmed: `ShareLocationWithOneIntent` maps to `location.share_selected`, which has resolved Circle names since #6515).

## Fix
Adds `OneShareRecipientEntity`, one `AppEntity` whose query merges `contacts(matching:)` and `circles(matching:)` into a single searchable pool, tagging Circle results with a "Circle" subtitle in Siri's picker. Both intents now use this type instead of `OneContactEntity`; `perform()` is unchanged since both entity types expose the same `id`/`name` and the request factories just forward those into slots regardless of kind.

`StopLocationSharingWithOneIntent` is deliberately left alone -- its description already scopes it to "one person," and its backend action (`location.stop_share`) doesn't have the Circle fallback wired (a separate scope call already made in #6515, not an oversight here).

## Verification
No Xcode toolchain available in this environment, so this is **untested on device/simulator**. Verified by static review only:
- [x] Brace/paren balance check on the changed file
- [x] Confirmed no other Swift file references `OneContactEntity` for these two intents (fully self-contained change)
- [x] Confirmed `verify-siri-action-contract.mjs` only checks the `OneSystemActionID` enum, not entity/parameter types -- unaffected

@parth please verify on a simulator/device before merging.