### PR TITLE
fix(connect): page the People directory instead of growing it

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -706,19 +706,22 @@ describe("Connect — People", () => {
     expect(screen.getByText("Person 0")).toBeTruthy();
   });
 
-  it("offers in-list progressive loading rather than visible pagination", async () => {
-    // A bounded first screenful was the right instinct, but refusing to page
-    // left the rest of the directory unreachable. Both now hold: a screenful
-    // by default, and a way through it.
+  it("pages the directory instead of growing it", async () => {
+    // Appending each batch left every previous page on screen, so the list
+    // grew without limit and the sections under it moved further away with
+    // each load. One page at a time, with a way to walk between them.
     render(<ConnectPageClient />);
 
     expect(await screen.findByText("Search by name.")).toBeTruthy();
     expect(
-      await screen.findByRole("button", { name: "Load 20 more people" }),
+      await screen.findByRole("button", { name: "Show the next page of people" }),
     ).toBeTruthy();
-    expect(screen.queryByLabelText("People per page")).toBeNull();
-    expect(screen.queryByLabelText("Next page")).toBeNull();
-    expect(screen.queryByLabelText("Previous page")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Show the previous page of people" }),
+    ).toBeTruthy();
+    // The old append affordance is gone, not merely relabelled.
+    expect(screen.queryByRole("button", { name: "Load 20 more people" })).toBeNull();
+    expect(screen.queryByTestId("connect-load-more-row")).toBeNull();
   });
 
   it("reads heading, then instruction, then the field they describe", async () => {
@@ -750,16 +753,25 @@ describe("Connect — People", () => {
     ).toBeTruthy();
   });
 
-  it("keeps load-more inside the grouped list as a compact row", async () => {
+  it("keeps the pager inside the grouped list as a compact row", async () => {
     render(<ConnectPageClient />);
 
-    const row = await screen.findByTestId("connect-load-more-row");
+    const row = await screen.findByTestId("connect-pager-row");
     expect(row.className).not.toContain("flex-col");
     expect(row.className).toContain("min-h-14");
     expect(
-      within(row).getByRole("button", { name: "Load 20 more people" }),
+      within(row).getByRole("button", { name: "Show the next page of people" }),
     ).toBeTruthy();
-    expect(screen.queryByTestId("connect-pager-row")).toBeNull();
+    // Named, not counted: the directory endpoint reports `hasMore` and no
+    // total, so "Page 1 of N" would be a number nothing here knows.
+    expect(within(row).getByText("Page 1")).toBeTruthy();
+    expect(within(row).queryByText(/Page 1 of/)).toBeNull();
+    // Nowhere to go back to from the first page.
+    expect(
+      within(row)
+        .getByRole("button", { name: "Show the previous page of people" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
   });
 
   it("asks the server for the next batch the reader loads", async () => {
@@ -767,7 +779,7 @@ describe("Connect — People", () => {
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Load 20 more people" }),
+      screen.getByRole("button", { name: "Show the next page of people" }),
     );
 
     await waitFor(() => {
@@ -778,7 +790,39 @@ describe("Connect — People", () => {
       expect(latest).toMatchObject({ page: 2, limit: 20 });
     });
     expect(await screen.findByText("Person 20")).toBeTruthy();
-    expect(screen.getByText("Person 0")).toBeTruthy();
+    // Page two REPLACES page one. Keeping both is what made the list unbounded.
+    expect(screen.queryByText("Person 0")).toBeNull();
+    expect(screen.getByText("Page 2")).toBeTruthy();
+  });
+
+  it("walks back to the previous page and re-enables the first-page guard", async () => {
+    render(<ConnectPageClient />);
+    await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
+
+    const next = () =>
+      screen.getByRole("button", { name: "Show the next page of people" });
+    const previous = () =>
+      screen.getByRole("button", { name: "Show the previous page of people" });
+
+    fireEvent.click(next());
+    expect(await screen.findByText("Person 20")).toBeTruthy();
+    expect(screen.getByText("Page 2")).toBeTruthy();
+    expect(previous().hasAttribute("disabled")).toBe(false);
+
+    fireEvent.click(previous());
+
+    await waitFor(() => {
+      const latest =
+        mocks.searchDirectory.mock.calls[
+          mocks.searchDirectory.mock.calls.length - 1
+        ][0];
+      expect(latest).toMatchObject({ page: 1 });
+    });
+    expect(await screen.findByText("Person 0")).toBeTruthy();
+    expect(screen.queryByText("Person 20")).toBeNull();
+    expect(screen.getByText("Page 1")).toBeTruthy();
+    // Back at the start, so there is nowhere further back to go.
+    expect(previous().hasAttribute("disabled")).toBe(true);
   });
 
   it("keeps the visible directory stable while the next page loads", async () => {
@@ -805,12 +849,12 @@ describe("Connect — People", () => {
     expect(await screen.findByText("Person 0")).toBeTruthy();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Load 20 more people" }),
+      screen.getByRole("button", { name: "Show the next page of people" }),
     );
 
-    await waitFor(() =>
-      expect(screen.getByText("Loading more…")).toBeTruthy(),
-    );
+    await waitFor(() => expect(screen.getByText("Loading…")).toBeTruthy());
+    // The page being left stays put until its replacement arrives, so the list
+    // never blanks mid-step.
     expect(screen.getByText("Person 0")).toBeTruthy();
     expect(screen.queryByText("Finding people…")).toBeNull();
 
@@ -824,8 +868,8 @@ describe("Connect — People", () => {
     });
 
     expect(await screen.findByText("Person 20")).toBeTruthy();
-    expect(screen.getByText("Person 0")).toBeTruthy();
-    expect(screen.queryByText("Loading more…")).toBeNull();
+    expect(screen.queryByText("Person 0")).toBeNull();
+    expect(screen.queryByText("Loading…")).toBeNull();
   });
 
   it("opens the full directory once a name is typed", async () => {
@@ -1101,7 +1145,7 @@ describe("Connect — People", () => {
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(1));
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Load 20 more people" }),
+      screen.getByRole("button", { name: "Show the next page of people" }),
     );
     await waitFor(() => expect(mocks.searchDirectory).toHaveBeenCalledTimes(2));
     expect(mocks.searchDirectory.mock.calls[1][0]).toMatchObject({ page: 2 });

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -545,7 +545,6 @@ export default function ConnectPageClient() {
   const stickyPinSentinelRef = useRef<HTMLDivElement | null>(null);
   const directoryMenuRef = useRef<HTMLDivElement | null>(null);
   const directoryMenuButtonRef = useRef<HTMLButtonElement | null>(null);
-  const loadMoreDirectoryRef = useRef<HTMLDivElement | null>(null);
   const [directoryMenuOpen, setDirectoryMenuOpen] = useState(false);
   const useWebDirectoryPopover = !isNative();  const searchQueryParam = (searchParams.get(CONNECT_SEARCH_QUERY_PARAM) ?? "")
     .trim()
@@ -1021,16 +1020,11 @@ export default function ConnectPageClient() {
           audience: directoryAudience,
         });
         if (!cancelled) {
-          setPeople((current) => {
-            if (page.page <= 1) return page.items;
-            const merged = new Map(
-              current.map((person) => [person.userId, person]),
-            );
-            for (const person of page.items) {
-              merged.set(person.userId, person);
-            }
-            return Array.from(merged.values());
-          });
+          // A page replaces the rows rather than merging into them. While this
+          // list appended, every page left its predecessors on screen, so the
+          // directory grew without limit and the sections below it moved
+          // further out of reach with each batch.
+          setPeople(page.items);
           setHasMore(page.hasMore);
           // Selections deliberately survive this. They used to be pruned to
           // whoever the new page happened to show, on the reasoning that a
@@ -1107,32 +1101,11 @@ export default function ConnectPageClient() {
     setCurrentPage((page) => page + 1);
   }, [hasMore, loading, surface, tab]);
 
-  useEffect(() => {
-    const sentinel = loadMoreDirectoryRef.current;
-    if (
-      !sentinel ||
-      surface === "circles" ||
-      tab === "nearby" ||
-      !hasMore ||
-      loading ||
-      typeof IntersectionObserver === "undefined"
-    ) {
-      return;
-    }
-    const scrollRoot = document.querySelector<HTMLElement>(
-      '[data-app-scroll-root="true"]',
-    );
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          loadNextDirectoryBatch();
-        }
-      },
-      { root: scrollRoot, rootMargin: "240px 0px" },
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [hasMore, loadNextDirectoryBatch, loading, surface, tab]);
+  const loadPreviousDirectoryBatch = useCallback(() => {
+    if (surface === "circles" || tab === "nearby" || loading) return;
+    setCurrentPage((page) => Math.max(1, page - 1));
+  }, [loading, surface, tab]);
+
 
   const sendConnectionRequest = useCallback(
     async (
@@ -3086,35 +3059,55 @@ export default function ConnectPageClient() {
                             );
                           })
                         )}
-                        {people.length > 0 && hasMore ? (
+                        {people.length > 0 && (hasMore || currentPage > 1) ? (
                           <div
-                            ref={loadMoreDirectoryRef}
-                            className="flex min-h-14 items-center justify-center border-t border-[color:var(--app-card-border-standard)] px-4 py-2"
-                            data-testid="connect-load-more-row"
+                            className="flex min-h-14 items-center justify-between gap-2 border-t border-[color:var(--app-card-border-standard)] px-4 py-2"
+                            data-testid="connect-pager-row"
                             aria-live="polite"
                           >
+                            <Button
+                              type="button"
+                              variant="none"
+                              effect="fade"
+                              size="sm"
+                              showRipple={false}
+                              aria-label="Show the previous page of people"
+                              className={CONNECT_PAGER_BUTTON_CLASSNAME}
+                              disabled={currentPage <= 1 || isDirectoryRefreshing}
+                              onClick={loadPreviousDirectoryBatch}
+                            >
+                              Previous
+                            </Button>
+                            {/* The directory endpoint reports `hasMore` but no
+                                total, so this names the page the reader is on
+                                and stops there. "Page 3 of 12" would be a
+                                count nothing here actually knows. */}
                             {isDirectoryRefreshing ? (
                               <span className="inline-flex items-center gap-2 text-[14px] font-medium leading-5 text-[color:var(--app-secondary-label)]">
                                 <Loader2
                                   className="h-3.5 w-3.5 animate-spin"
                                   aria-hidden="true"
                                 />
-                                Loading more…
+                                Loading…
                               </span>
                             ) : (
-                              <Button
-                                type="button"
-                                variant="none"
-                                effect="fade"
-                                size="sm"
-                                showRipple={false}
-                                aria-label={`Load ${DEFAULT_PAGE_SIZE} more people`}
-                                className={CONNECT_PAGER_BUTTON_CLASSNAME}
-                                onClick={loadNextDirectoryBatch}
-                              >
-                                Load {DEFAULT_PAGE_SIZE} more
-                              </Button>
+                              <span className="text-[14px] font-medium leading-5 tabular-nums text-[color:var(--app-secondary-label)]">
+                                Page {currentPage}
+                              </span>
                             )}
+                            <Button
+                              type="button"
+                              variant="none"
+                              effect="fade"
+                              size="sm"
+                              showRipple={false}
+                              aria-label="Show the next page of people"
+                              className={CONNECT_PAGER_BUTTON_CLASSNAME}
+                              disabled={!hasMore || isDirectoryRefreshing}
+                              onClick={loadNextDirectoryBatch}
+                            >
+                              Next
+                            </Button>
                           </div>
                         ) : people.length > 0 ? (
                           <span className="sr-only">All people loaded</span>


### PR DESCRIPTION
The **People** list under the search box appended. Page one replaced, every page after it merged into what was already there, and an `IntersectionObserver` fetched the next twenty rows 240px before the sentinel came into view.

Scrolling therefore made the list longer indefinitely — pushing everything below it further out of reach, and running the last rows under the fixed bottom bars.

## What changed

- A page **replaces** the rows rather than merging into them.
- The auto-loading observer is gone.
- The row that said *"Load 20 more"* is now a pager: **Previous · Page N · Next**.

## Why it says "Page 3" and not "Page 3 of 12"

The directory endpoint does not report a total. `search_directory` returns `{items, page, hasMore, audience}` — no `totalCount` ([connections_service.py:2961](consent-protocol/hushh_mcp/services/connections_service.py#L2961)) — and the client fills the gap with `max(visibleUpperBound, payload.totalCount || 0)`, i.e. *the rows seen so far*.

Rendered through the shared `PaginatedListFooter`, that produces **"Page 1 of 1" next to a live Next button**, with the denominator growing as you walk. So the pager names the current page and stops there: **Next** is bound to `hasMore`, which the server does answer, and **Previous** to being past page one. Neither claims a number nothing here knows.

Giving the footer a real total means adding a `COUNT` to the directory query — a backend change, deliberately not in this PR.

Stepping between pages keeps the outgoing rows on screen until their replacement lands, so the list never blanks mid-step.

## Heads-up for @Jhumma-hushh

This reverses the load-more behaviour introduced in `3c26f649c` ("Refine Connect shell and loading experience"). That commit recorded no rationale beyond its title and nothing tested depended on the append, but you may have had a reason worth hearing.

## Tests

Five tests encoded the append model and are **rewritten, not deleted** — they now pin the pager, that page two replaces page one, and that the count is unqualified. One new test covers the Previous step and the first-page disabled guard. The unobserved sentinel ref is removed along with the observer that used it.

- `tsc --noEmit` and `eslint --max-warnings=0` clean
- **79** Connect page tests pass
- Full suite failures unchanged from `origin/main` — 20, pre-existing, unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)