### PR TITLE
fix(location): restore visible Now actions

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1782,24 +1782,32 @@ describe("OneLocationAgentPage", () => {
     expect(
       within(primary).getByRole("button", { name: "Ask for location" }),
     ).toBeTruthy();
+    const actions = screen.getByTestId("one-location-now-actions");
+    expect(
+      within(actions).getByRole("button", { name: "Check in" }),
+    ).toBeTruthy();
+    expect(
+      within(actions).getByRole("button", { name: "Save My Soul" }),
+    ).toBeTruthy();
     expect(
       within(primary).getByRole("button", { name: "More actions" }),
     ).toBeTruthy();
-    expect(screen.queryByTestId("one-location-now-actions")).toBeNull();
 
     const more = screen.getByTestId("one-location-now-more");
     expect(more.className).toContain("min-h-[50px]");
     fireEvent.keyDown(more, { key: "Enter" });
     expect(
-      await screen.findByTestId("one-location-now-more-item-arrival-confirm"),
+      await screen.findByTestId("one-location-now-more-item-map"),
     ).toBeTruthy();
-    expect(
-      screen.getByTestId("one-location-now-more-item-save-my-soul"),
-    ).toBeTruthy();
-    expect(screen.getByTestId("one-location-now-more-item-map")).toBeTruthy();
     expect(
       screen.getByTestId("one-location-now-more-item-settings"),
     ).toBeTruthy();
+    expect(
+      screen.queryByTestId("one-location-now-more-item-arrival-confirm"),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId("one-location-now-more-item-save-my-soul"),
+    ).toBeNull();
 
     const retiredActionLabel = ["Their", "Location"].join(" ");
     expect(primary.textContent).not.toContain(retiredActionLabel);
@@ -3080,11 +3088,8 @@ describe("OneLocationAgentPage", () => {
     mockCaptureCurrentPosition.mockClear();
     const envelopeWritesBeforeOpen = mockStoreEnvelope.mock.calls.length;
 
-    fireEvent.keyDown(screen.getByTestId("one-location-now-more"), {
-      key: "Enter",
-    });
     fireEvent.click(
-      await screen.findByTestId("one-location-now-more-item-save-my-soul"),
+      await screen.findByRole("button", { name: "Save My Soul" }),
     );
 
     expect(
@@ -3133,11 +3138,8 @@ describe("OneLocationAgentPage", () => {
         }),
     );
 
-    fireEvent.keyDown(screen.getByTestId("one-location-now-more"), {
-      key: "Enter",
-    });
     fireEvent.click(
-      await screen.findByTestId("one-location-now-more-item-save-my-soul"),
+      await screen.findByRole("button", { name: "Save My Soul" }),
     );
 
     expect(

--- a/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
@@ -25,9 +25,9 @@ describe("One Location settings placement", () => {
     expect(nowSource).not.toContain('title="Privacy"');
   });
 
-  it("keeps Now private-first with More actions behind the shared action menu", () => {
-    // Now answers who can see the user first. Extra actions still exist, but
-    // they sit behind one quiet More actions row instead of a dashboard grid.
+  it("keeps Now private-first while core actions stay directly visible", () => {
+    // Now answers who can see the user first, but the daily actions must not be
+    // hidden behind overflow because that makes the page look empty on UAT.
     const nowStart = HUB_SOURCE.indexOf("function NowHub");
     const nowEnd = HUB_SOURCE.indexOf("function LocationDetailFlow", nowStart);
     const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
@@ -38,16 +38,19 @@ describe("One Location settings placement", () => {
     expect(nowSource).toContain('"Share only when you choose."');
     expect(nowSource).toContain('"Share my location"');
     expect(nowSource).toContain('data-testid="one-location-request-row"');
+    expect(nowSource).toContain('data-testid="one-location-now-actions"');
+    expect(nowSource).toContain('label="Check in"');
+    expect(nowSource).toContain('label="Save My Soul"');
     expect(nowSource).toContain('label="More actions"');
-    expect(nowSource).toContain('id: "arrival-confirm"');
-    expect(nowSource).toContain('label: "Save My Soul"');
+    expect(nowSource).not.toContain('id: "arrival-confirm"');
+    expect(nowSource).not.toContain('id: "save-my-soul"');
 
     const primaryIndex = nowSource.indexOf("LocationNowStatePanel");
     const requestIndex = nowSource.indexOf("onRequestLocation={onRequestLocation}");
-    const activityIndex = nowSource.indexOf("one-location-now-activity");
+    const visibleActionsIndex = nowSource.indexOf("one-location-now-actions");
     expect(primaryIndex).toBeGreaterThan(-1);
     expect(requestIndex).toBeGreaterThan(primaryIndex);
-    expect(activityIndex).toBeGreaterThan(requestIndex);
+    expect(visibleActionsIndex).toBeGreaterThan(requestIndex);
     expect(nowSource).not.toContain('title: "Active shares"');
     expect(nowSource).not.toContain("LocationActionGrid");
     expect(nowSource).not.toContain("LocationNowGroupLabel");

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2126,10 +2126,28 @@ function LocationNowStatePanel({
         </button>
       </div>
 
-      <div className="mx-auto mt-5 w-full max-w-[440px]">
+      <div
+        data-testid="one-location-now-actions"
+        className="mx-auto mt-3 grid w-full max-w-[440px] gap-2.5 sm:grid-cols-2"
+      >
+        <LocationNowSecondaryAction
+          icon="checkIn"
+          label="Check in"
+          voiceControlId="one-location-action-check-in"
+          voiceActionId="location.open_check_in"
+          onClick={onCheckIn}
+        />
+        <LocationNowSecondaryAction
+          icon="active"
+          label="Save My Soul"
+          voiceControlId="one-location-action-sos"
+          voiceActionId="location.open_sos"
+          onClick={onSos}
+        />
+      </div>
+
+      <div className="mx-auto mt-4 w-full max-w-[440px]">
         <LocationNowMoreActions
-          onCheckIn={onCheckIn}
-          onSos={onSos}
           onOpenMap={onOpenMap}
           onOpenSettings={onOpenSettings}
         />
@@ -2138,14 +2156,48 @@ function LocationNowStatePanel({
   );
 }
 
+function LocationNowSecondaryAction({
+  icon,
+  label,
+  voiceControlId,
+  voiceActionId,
+  onClick,
+}: {
+  icon: LocationMenuGlyphName;
+  label: string;
+  voiceControlId: string;
+  voiceActionId: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={`one-location-now-action-${voiceActionId.replace(
+        "location.open_",
+        "",
+      )}`}
+      data-voice-control-id={voiceControlId}
+      data-voice-action-id={voiceActionId}
+      data-voice-label={label}
+      aria-label={label}
+      onClick={onClick}
+      className="inline-flex min-h-[48px] w-full items-center justify-center gap-2.5 rounded-[14px] bg-[color:var(--app-secondary-surface)] px-4 text-[color:var(--app-primary-label)] ring-1 ring-inset ring-[color:var(--app-separator)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-neutral-fill)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
+    >
+      <span
+        aria-hidden="true"
+        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] bg-[color:var(--app-neutral-fill)] text-[color:var(--app-secondary-label)]"
+      >
+        <LocationMenuGlyph name={icon} size={17} />
+      </span>
+      <ButtonLabel as="span">{label}</ButtonLabel>
+    </button>
+  );
+}
+
 function LocationNowMoreActions({
-  onCheckIn,
-  onSos,
   onOpenMap,
   onOpenSettings,
 }: {
-  onCheckIn: () => void;
-  onSos: () => void;
   onOpenMap: () => void;
   onOpenSettings: () => void;
 }) {
@@ -2179,22 +2231,6 @@ function LocationNowMoreActions({
         </button>
       }
       items={[
-        {
-          id: "arrival-confirm",
-          label: "Arrival confirm",
-          icon: Check,
-          onSelect: onCheckIn,
-          voiceControlId: "one-location-action-check-in",
-          voiceActionId: "location.open_check_in",
-        },
-        {
-          id: "save-my-soul",
-          label: "Save My Soul",
-          icon: ShieldCheck,
-          onSelect: onSos,
-          voiceControlId: "one-location-action-sos",
-          voiceActionId: "location.open_sos",
-        },
         {
           id: "map",
           label: "Map",


### PR DESCRIPTION
## Summary
- restore visible Check in and Save My Soul actions on the Location Now private state
- keep Map and Settings in the existing More actions overflow
- update focused tests so core actions cannot be hidden behind overflow again

## Validation
- npx vitest run __tests__/components/one-location-settings-placement.contract.test.ts
- npx vitest run __tests__/components/one-location-agent-page.test.tsx -t "Now private-first|emergency number|location services are off"
- npx eslint components/one-location/redesign/location-redesign-hub.tsx __tests__/components/one-location-agent-page.test.tsx __tests__/components/one-location-settings-placement.contract.test.ts
- npm run verify:design-system
- npm run typecheck
- npm run build (blocked locally by missing hosted Firebase build env; compile and TypeScript phases passed after setting UAT backend origin, then page-data collection stopped on auth/invalid-api-key)

## Scope note
Dashboard/root-launcher preview work remains local-only and is not included in this PR.