### PR TITLE
fix(location): keep Now actions visible during sharing

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1826,6 +1826,44 @@ describe("OneLocationAgentPage", () => {
     expect(screen.queryByText("Check-In")).toBeNull();
   });
 
+  it("keeps the core Now actions visible while sharing is live", async () => {
+    const base = locationState();
+    mockGetState.mockResolvedValue({
+      ...base,
+      ownerGrants: [
+        {
+          ...base.ownerGrants[0],
+          expiresAt: "2099-05-20T08:00:00.000Z",
+        },
+      ],
+      receivedGrants: [],
+      requests: [],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+
+    expect(await screen.findByTestId("one-location-live-share")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Share with more" }),
+    ).toBeTruthy();
+
+    const actions = screen.getByTestId("one-location-now-actions");
+    expect(
+      within(actions).getByRole("button", { name: "Ask for location" }),
+    ).toBeTruthy();
+    expect(
+      within(actions).getByRole("button", { name: "Check in" }),
+    ).toBeTruthy();
+    expect(
+      within(actions).getByRole("button", { name: "Save My Soul" }),
+    ).toBeTruthy();
+    expect(
+      within(actions).getByRole("button", { name: "More actions" }),
+    ).toBeTruthy();
+  });
+
   it("keeps the heading and location toggle inline as the only header action", async () => {
     mockGetState.mockResolvedValue({
       ...locationState(),

--- a/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
@@ -33,6 +33,7 @@ describe("One Location settings placement", () => {
     const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
 
     expect(nowSource).toContain("LocationNowStatePanel");
+    expect(nowSource).toContain("LocationNowActionSuite");
     expect(nowSource).toContain('"Private"');
     expect(nowSource).toContain('"No one can see your location"');
     expect(nowSource).toContain('"Share only when you choose."');
@@ -46,9 +47,16 @@ describe("One Location settings placement", () => {
     expect(nowSource).not.toContain('id: "save-my-soul"');
 
     const primaryIndex = nowSource.indexOf("LocationNowStatePanel");
-    const requestIndex = nowSource.indexOf("onRequestLocation={onRequestLocation}");
+    const requestIndex = nowSource.indexOf(
+      "onRequestLocation={onRequestLocation}",
+      primaryIndex,
+    );
     const visibleActionsIndex = nowSource.indexOf("one-location-now-actions");
+    const liveShareIndex = nowSource.indexOf("LiveShareStatusCard");
+    const activeActionsIndex = nowSource.indexOf("LocationNowActionSuite");
     expect(primaryIndex).toBeGreaterThan(-1);
+    expect(liveShareIndex).toBeGreaterThan(-1);
+    expect(activeActionsIndex).toBeGreaterThan(liveShareIndex);
     expect(requestIndex).toBeGreaterThan(primaryIndex);
     expect(visibleActionsIndex).toBeGreaterThan(requestIndex);
     expect(nowSource).not.toContain('title: "Active shares"');

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1923,6 +1923,15 @@ function NowHub({
           onEnded={vm.onLiveShareEnded}
         />
       ) : null}
+      {vm.liveShare ? (
+        <LocationNowActionSuite
+          onRequestLocation={onRequestLocation}
+          onCheckIn={onCheckIn}
+          onSos={onSos}
+          onOpenMap={onOpenMap}
+          onOpenSettings={onOpenSettings}
+        />
+      ) : null}
       {!vm.liveShare ? (
         <LocationNowStatePanel
           blocked={vm.locationBlocked}
@@ -2191,6 +2200,53 @@ function LocationNowSecondaryAction({
       </span>
       <ButtonLabel as="span">{label}</ButtonLabel>
     </button>
+  );
+}
+
+function LocationNowActionSuite({
+  onRequestLocation,
+  onCheckIn,
+  onSos,
+  onOpenMap,
+  onOpenSettings,
+}: {
+  onRequestLocation: () => void;
+  onCheckIn: () => void;
+  onSos: () => void;
+  onOpenMap: () => void;
+  onOpenSettings: () => void;
+}) {
+  return (
+    <div
+      data-testid="one-location-now-actions"
+      className="mx-auto grid w-full max-w-[720px] gap-2.5 sm:grid-cols-2"
+    >
+      <LocationNowSecondaryAction
+        icon="ask"
+        label="Ask for location"
+        voiceControlId="one-location-action-ask"
+        voiceActionId="location.open_ask"
+        onClick={onRequestLocation}
+      />
+      <LocationNowSecondaryAction
+        icon="checkIn"
+        label="Check in"
+        voiceControlId="one-location-action-check-in"
+        voiceActionId="location.open_check_in"
+        onClick={onCheckIn}
+      />
+      <LocationNowSecondaryAction
+        icon="active"
+        label="Save My Soul"
+        voiceControlId="one-location-action-sos"
+        voiceActionId="location.open_sos"
+        onClick={onSos}
+      />
+      <LocationNowMoreActions
+        onOpenMap={onOpenMap}
+        onOpenSettings={onOpenSettings}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- restore the direct Now action suite while a live share is active
- keep Ask for location, Check in, Save My Soul, and More actions visible instead of leaving only Share with more
- preserve existing share, manage, map, settings, check-in, and SOS handlers

## Validation
- git diff --check
- npx vitest run __tests__/components/one-location-agent-page.test.tsx -t "compact sharing-first|core Now actions"
- npx vitest run __tests__/components/one-location-settings-placement.contract.test.ts
- npx eslint components/one-location/redesign/location-redesign-hub.tsx __tests__/components/one-location-agent-page.test.tsx __tests__/components/one-location-settings-placement.contract.test.ts
- npm run typecheck
- npm run verify:design-system