### PR TITLE
revert(location): restore original Now screen

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -999,7 +999,7 @@ async function switchLocationTab(
 
 async function openSharePersonStep() {
   fireEvent.click(
-    screen.queryByRole("button", { name: /^Share (?:my )?location$/i }) ??
+    screen.queryByRole("button", { name: /^Share location$/i }) ??
       screen.getByRole("button", { name: /^Share with more$/i }),
   );
   expect(
@@ -1507,17 +1507,10 @@ describe("OneLocationAgentPage", () => {
     ).toBeNull();
     expect(screen.queryByText("Advisor meetup")).toBeNull();
     expect(screen.queryByRole("button", { name: "Your Map" })).toBeNull();
-    fireEvent.keyDown(screen.getByTestId("one-location-now-more"), {
-      key: "Enter",
-    });
+    expect(screen.getByRole("button", { name: /^Map$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Settings$/i })).toBeTruthy();
     expect(
-      await screen.findByTestId("one-location-now-more-item-map"),
-    ).toBeTruthy();
-    expect(
-      screen.getByTestId("one-location-now-more-item-settings"),
-    ).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: /^Share (?:my )?location$/i }),
+      screen.getByRole("button", { name: /^Share location$/i }),
     ).toBeTruthy();
     expect(screen.queryByText(/8012|9911/)).toBeNull();
     expect(mockRegisterKey).toHaveBeenCalledWith({
@@ -1769,50 +1762,72 @@ describe("OneLocationAgentPage", () => {
 
     const primary = await screen.findByTestId("one-location-now-primary");
     expect(
-      within(primary).getByRole("button", { name: "Share my location" }),
+      within(primary).getByRole("button", { name: "Share location" }),
     ).toBeTruthy();
-    expect(within(primary).getByText("Private")).toBeTruthy();
+    expect(within(primary).getByText("You're not sharing")).toBeTruthy();
     expect(
-      within(primary).getByText("No one can see your location"),
-    ).toBeTruthy();
-    expect(
-      within(primary).getByText("Share only when you choose."),
+      within(primary).getByText("Choose a Circle or contact."),
     ).toBeTruthy();
 
+    const actions = await screen.findByTestId("one-location-now-actions");
+    expect(actions.className).toContain("pt-1");
+    expect(actions.className).not.toContain("max-w-[282px]");
     expect(
-      within(primary).getByRole("button", { name: "Ask for location" }),
-    ).toBeTruthy();
-    const actions = screen.getByTestId("one-location-now-actions");
-    expect(
-      within(actions).getByRole("button", { name: "Check in" }),
-    ).toBeTruthy();
-    expect(
-      within(actions).getByRole("button", { name: "Save My Soul" }),
-    ).toBeTruthy();
-    expect(
-      within(primary).getByRole("button", { name: "More actions" }),
-    ).toBeTruthy();
-
-    const more = screen.getByTestId("one-location-now-more");
-    expect(more.className).toContain("min-h-[50px]");
-    fireEvent.keyDown(more, { key: "Enter" });
-    expect(
-      await screen.findByTestId("one-location-now-more-item-map"),
-    ).toBeTruthy();
-    expect(
-      screen.getByTestId("one-location-now-more-item-settings"),
-    ).toBeTruthy();
-    expect(
-      screen.queryByTestId("one-location-now-more-item-arrival-confirm"),
+      within(actions).queryByRole("heading", { name: "Actions" }),
     ).toBeNull();
     expect(
-      screen.queryByTestId("one-location-now-more-item-save-my-soul"),
-    ).toBeNull();
-
+      within(actions).getByRole("button", { name: "Ask for location" }),
+    ).toBeTruthy();
+    expect(
+      within(actions).getByRole("button", {
+        name: "Save My Soul emergency alert",
+      }),
+    ).toBeTruthy();
+    expect(within(actions).getByText("Ask for location")).toBeTruthy();
+    expect(within(actions).getByText("Check in")).toBeTruthy();
     const retiredActionLabel = ["Their", "Location"].join(" ");
-    expect(primary.textContent).not.toContain(retiredActionLabel);
-    expect(primary.textContent).not.toContain("Emergency alert");
-    expect(primary.textContent).not.toContain("Quick actions");
+    expect(actions.textContent).not.toContain(retiredActionLabel);
+    expect(within(actions).queryByText("Confirm Arrival")).toBeNull();
+    expect(within(actions).getByText("Save My Soul")).toBeTruthy();
+    expect(within(actions).getByText("Emergency alert")).toBeTruthy();
+
+    const actionGrid = actions.querySelector("[data-one-location-action-grid]");
+    expect(actionGrid?.className).toContain("grid-cols-1");
+    expect(actionGrid?.className).toContain("min-[360px]:grid-cols-2");
+
+    const actionCells = actionGrid?.querySelectorAll(
+      "[data-one-location-action-cell]",
+    );
+    expect(actionCells).toHaveLength(2);
+    actionCells?.forEach((cell) => {
+      expect(cell.className).toContain("items-center");
+      expect(cell.className).toContain("text-center");
+      expect(cell.className).toContain("rounded-[16px]");
+      expect(cell.className).toContain("min-h-[96px]");
+      expect(cell.className).toContain("px-5");
+    });
+    expect(
+      actionGrid?.querySelector("[data-one-location-action-icon]")?.className,
+    ).toContain("text-[color:var(--app-accent)]");
+    expect(
+      actionGrid?.querySelector("[data-one-location-action-icon]")?.className,
+    ).toContain("[&>svg]:h-8");
+    expect(
+      actionGrid?.querySelectorAll("[data-one-location-action-icon] svg"),
+    ).toHaveLength(2);
+    expect(
+      actionGrid?.querySelector('[data-location-menu-icon="ask"]'),
+    ).toBeTruthy();
+    expect(
+      actionGrid?.querySelector('[data-location-menu-icon="checkIn"]'),
+    ).toBeTruthy();
+    expect(
+      actions.querySelector("[data-one-location-emergency-cell]"),
+    ).toBeTruthy();
+    expect(actions.textContent).not.toContain("near_me");
+    expect(actions.textContent).not.toContain("location_on");
+    expect(actions.textContent).not.toContain("where_to_vote");
+    expect(actions.querySelector("[data-one-location-sms-row]")).toBeTruthy();
 
     const activity = screen.getByTestId("one-location-now-activity");
     expect(within(activity).getByText("Sharing with you")).toBeTruthy();
@@ -1820,48 +1835,16 @@ describe("OneLocationAgentPage", () => {
     expect(within(activity).queryByText("Active shares")).toBeNull();
 
     expect(within(activity).queryByText("Share")).toBeNull();
+    const more = screen.getByTestId("one-location-now-more");
+    expect(within(more).getByText("Map")).toBeTruthy();
+    expect(within(more).getByText("Settings")).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Activity" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "More" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Your Map" })).toBeNull();
+    expect(screen.getByRole("button", { name: /^Map$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Settings$/i })).toBeTruthy();
     expect(screen.queryByText("Check-In")).toBeNull();
-  });
-
-  it("keeps the core Now actions visible while sharing is live", async () => {
-    const base = locationState();
-    mockGetState.mockResolvedValue({
-      ...base,
-      ownerGrants: [
-        {
-          ...base.ownerGrants[0],
-          expiresAt: "2099-05-20T08:00:00.000Z",
-        },
-      ],
-      receivedGrants: [],
-      requests: [],
-    });
-
-    render(<OneLocationAgentPage />);
-    await skipLocationEntryFlow();
-    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-
-    expect(await screen.findByTestId("one-location-live-share")).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "Share with more" }),
-    ).toBeTruthy();
-
-    const actions = screen.getByTestId("one-location-now-actions");
-    expect(
-      within(actions).getByRole("button", { name: "Ask for location" }),
-    ).toBeTruthy();
-    expect(
-      within(actions).getByRole("button", { name: "Check in" }),
-    ).toBeTruthy();
-    expect(
-      within(actions).getByRole("button", { name: "Save My Soul" }),
-    ).toBeTruthy();
-    expect(
-      within(actions).getByRole("button", { name: "More actions" }),
-    ).toBeTruthy();
+    expect(screen.queryByText("Quick actions")).toBeNull();
   });
 
   it("keeps the heading and location toggle inline as the only header action", async () => {
@@ -2947,7 +2930,7 @@ describe("OneLocationAgentPage", () => {
       "Investor",
     );
     fireEvent.click(screen.getByRole("button", { name: "Now" }));
-    fireEvent.click(screen.getByRole("button", { name: /^Share (?:my )?location$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^Share location$/i }));
     expect(
       await screen.findByRole("heading", { name: "Who can see you?" }),
     ).toBeTruthy();
@@ -3005,7 +2988,7 @@ describe("OneLocationAgentPage", () => {
     expect(screen.queryByText("0/140")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    fireEvent.click(screen.getByRole("button", { name: /^Share (?:my )?location$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^Share location$/i }));
     expect(
       await screen.findByRole("heading", { name: "Who can see you?" }),
     ).toBeTruthy();
@@ -3127,7 +3110,9 @@ describe("OneLocationAgentPage", () => {
     const envelopeWritesBeforeOpen = mockStoreEnvelope.mock.calls.length;
 
     fireEvent.click(
-      await screen.findByRole("button", { name: "Save My Soul" }),
+      screen.getByRole("button", {
+        name: "Save My Soul emergency alert",
+      }),
     );
 
     expect(
@@ -3177,7 +3162,9 @@ describe("OneLocationAgentPage", () => {
     );
 
     fireEvent.click(
-      await screen.findByRole("button", { name: "Save My Soul" }),
+      screen.getByRole("button", {
+        name: "Save My Soul emergency alert",
+      }),
     );
 
     expect(
@@ -3714,7 +3701,7 @@ describe("OneLocationAgentPage", () => {
     render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
 
-    fireEvent.click(screen.getByRole("button", { name: "Manage sharing" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
     expect(
       await screen.findByRole("heading", { name: "Manage sharing" }),
     ).toBeTruthy();
@@ -4245,7 +4232,7 @@ describe("OneLocationAgentPage", () => {
 
     await waitFor(() =>
       expect(
-        screen.getByRole("button", { name: /^Share (?:my )?location$/i }),
+        screen.getByRole("button", { name: /^Share location$/i }),
       ).toBeTruthy(),
     );
   });
@@ -4842,7 +4829,7 @@ describe("OneLocationAgentPage", () => {
     );
     // After a successful share the flow closes and returns to the main hub.
     await waitFor(() =>
-      expect(screen.getByTestId("one-location-now-primary")).toBeTruthy(),
+      expect(screen.getByTestId("one-location-now-actions")).toBeTruthy(),
     );
     expect(
       screen.queryByRole("heading", { name: "Ready to share?" }),
@@ -6681,15 +6668,11 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    const primary = await screen.findByTestId("one-location-now-primary");
-    expect(within(primary).getByText("Location unavailable")).toBeTruthy();
-    expect(within(primary).getByText("Location access is off")).toBeTruthy();
-    expect(
-      within(primary).getByRole("button", { name: "Turn on Location" }),
-    ).toBeTruthy();
-    expect(
-      screen.queryByRole("button", { name: /^Share (?:my )?location$/i }),
-    ).toBeNull();
+    await openShareConfirmStep();
+    const shareButton = screen.getByRole("button", {
+      name: /Start sharing/i,
+    }) as HTMLButtonElement;
+    expect(shareButton.disabled).toBe(true);
     expect(mockCreateGrant).not.toHaveBeenCalled();
   });
 

--- a/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-location-settings-placement.contract.test.ts
@@ -25,63 +25,51 @@ describe("One Location settings placement", () => {
     expect(nowSource).not.toContain('title="Privacy"');
   });
 
-  it("keeps Now private-first while core actions stay directly visible", () => {
-    // Now answers who can see the user first, but the daily actions must not be
-    // hidden behind overflow because that makes the page look empty on UAT.
+  it("offers Ask for location inside the compact Now actions", () => {
+    // Request location is an action, not status or utility. The compact Now
+    // tab shows Ask, Check in, SMS, count-backed Activity rows, and the quiet
+    // More rows without dashboard section labels or the old active-shares row.
     const nowStart = HUB_SOURCE.indexOf("function NowHub");
     const nowEnd = HUB_SOURCE.indexOf("function LocationDetailFlow", nowStart);
     const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
 
-    expect(nowSource).toContain("LocationNowStatePanel");
-    expect(nowSource).toContain("LocationNowActionSuite");
-    expect(nowSource).toContain('"Private"');
-    expect(nowSource).toContain('"No one can see your location"');
-    expect(nowSource).toContain('"Share only when you choose."');
-    expect(nowSource).toContain('"Share my location"');
-    expect(nowSource).toContain('data-testid="one-location-request-row"');
     expect(nowSource).toContain('data-testid="one-location-now-actions"');
-    expect(nowSource).toContain('label="Check in"');
-    expect(nowSource).toContain('label="Save My Soul"');
-    expect(nowSource).toContain('label="More actions"');
-    expect(nowSource).not.toContain('id: "arrival-confirm"');
-    expect(nowSource).not.toContain('id: "save-my-soul"');
+    expect(nowSource).toContain('testId: "one-location-request-row"');
+    expect(nowSource).toContain('title: "Ask for location"');
+    expect(nowSource).toContain('title: "Save My Soul"');
 
-    const primaryIndex = nowSource.indexOf("LocationNowStatePanel");
-    const requestIndex = nowSource.indexOf(
-      "onRequestLocation={onRequestLocation}",
-      primaryIndex,
-    );
-    const visibleActionsIndex = nowSource.indexOf("one-location-now-actions");
-    const liveShareIndex = nowSource.indexOf("LiveShareStatusCard");
-    const activeActionsIndex = nowSource.indexOf("LocationNowActionSuite");
-    expect(primaryIndex).toBeGreaterThan(-1);
-    expect(liveShareIndex).toBeGreaterThan(-1);
-    expect(activeActionsIndex).toBeGreaterThan(liveShareIndex);
-    expect(requestIndex).toBeGreaterThan(primaryIndex);
-    expect(visibleActionsIndex).toBeGreaterThan(requestIndex);
+    const actionsIndex = nowSource.indexOf("LocationActionGrid");
+    const requestIndex = nowSource.indexOf('title: "Ask for location"');
+    const activityIndex = nowSource.indexOf("one-location-now-activity");
+    const moreIndex = nowSource.indexOf("one-location-now-more");
+    expect(actionsIndex).toBeGreaterThan(-1);
+    expect(requestIndex).toBeGreaterThan(actionsIndex);
+    expect(activityIndex).toBeGreaterThan(requestIndex);
+    expect(moreIndex).toBeGreaterThan(activityIndex);
+    expect(nowSource).toContain('title: "Map"');
+    expect(nowSource).toContain('title: "Settings"');
     expect(nowSource).not.toContain('title: "Active shares"');
-    expect(nowSource).not.toContain("LocationActionGrid");
     expect(nowSource).not.toContain("LocationNowGroupLabel");
 
     // Reuses the existing ask flow rather than introducing a second one, so
     // voice and the search bar keep naming a single control.
-    expect(nowSource).toContain('data-voice-control-id="one-location-action-ask"');
+    expect(nowSource).toContain('controlId: "one-location-action-ask"');
     expect(HUB_SOURCE).toContain('onRequestLocation={() => openFlow("ask")}');
   });
 
-  it("keeps Location unavailable as a dominant Now state, not a global tab warning", () => {
+  it("gives Ask for location an icon distinct from Share location", () => {
+    // These two actions are opposites -- give a location out, ask for one in.
+    // They sit in one grid now, so the glyphs must be distinct at a glance.
     const nowStart = HUB_SOURCE.indexOf("function NowHub");
     const nowEnd = HUB_SOURCE.indexOf("function LocationDetailFlow", nowStart);
     const nowSource = HUB_SOURCE.slice(nowStart, nowEnd);
-    const hubStart = HUB_SOURCE.indexOf("/* Hub (Now | People | Links)");
-    const hubEnd = HUB_SOURCE.indexOf("<TopShellTabs", hubStart);
-    const headerSource = HUB_SOURCE.slice(hubStart, hubEnd);
 
-    expect(nowSource).toContain('"Location unavailable"');
-    expect(nowSource).toContain('"Location access is off"');
-    expect(nowSource).toContain('"Turn it on to share your location."');
-    expect(nowSource).toContain('"Turn on Location"');
-    expect(headerSource).not.toContain("LocationPermissionRecoveryCard");
+    const requestIndex = nowSource.indexOf('title: "Ask for location"');
+    const requestItem = nowSource.slice(requestIndex, requestIndex + 240);
+
+    expect(requestIndex).toBeGreaterThan(-1);
+    expect(requestItem).toContain('<LocationMenuGlyph name="ask"');
+    expect(nowSource).toContain('data-location-share-pulse-icon=""');
   });
 
   it("owns Saved Locations and does not duplicate it in Profile preferences", () => {

--- a/hushh-webapp/components/one-location/redesign/__tests__/live-share-status-card.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/live-share-status-card.test.tsx
@@ -163,7 +163,7 @@ describe("LiveShareStatusCard", () => {
     expect(screen.getByText("Different end times")).toBeTruthy();
   });
 
-  it("offers Stop sharing for a single share and Manage sharing for several", () => {
+  it("offers Stop for a single share and Manage for several", () => {
     const onStop = vi.fn();
     const onManage = vi.fn();
     const { rerender } = render(
@@ -174,7 +174,7 @@ describe("LiveShareStatusCard", () => {
       />,
     );
 
-    screen.getByRole("button", { name: "Stop sharing" }).click();
+    screen.getByRole("button", { name: "Stop" }).click();
     expect(onStop).toHaveBeenCalledTimes(1);
 
     rerender(
@@ -188,7 +188,7 @@ describe("LiveShareStatusCard", () => {
         onManage={onManage}
       />,
     );
-    screen.getByRole("button", { name: "Manage sharing" }).click();
+    screen.getByRole("button", { name: "Manage" }).click();
     expect(onManage).toHaveBeenCalledTimes(1);
   });
 
@@ -209,12 +209,12 @@ describe("LiveShareStatusCard", () => {
 
     expect(screen.getByText("Sharing with Rohan Mehta")).toBeTruthy();
     expect(screen.getByText("2 active shares")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Stop sharing" })).toBeNull();
-    screen.getByRole("button", { name: "Manage sharing" }).click();
+    expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+    screen.getByRole("button", { name: "Manage" }).click();
     expect(onManage).toHaveBeenCalledTimes(1);
   });
 
-  it("offers Change time on a single share after the share-more action", () => {
+  it("offers Change end time on a single share after the primary share action", () => {
     // The reported bug: a 30-minute share could be stopped and nothing else.
     // The control has to be there, but the compact Now card keeps it below the
     // primary "Share with more" CTA instead of exposing the duration editor on
@@ -230,7 +230,7 @@ describe("LiveShareStatusCard", () => {
       />,
     );
 
-    const change = screen.getByRole("button", { name: "Change time" });
+    const change = screen.getByRole("button", { name: "Change end time" });
     change.click();
     expect(onChangeDuration).toHaveBeenCalledTimes(1);
     expect(onChangeDuration).toHaveBeenCalledWith(change);
@@ -274,11 +274,11 @@ describe("LiveShareStatusCard", () => {
     expect(
       screen.queryByRole("button", { name: "Your live location share" }),
     ).toBeNull();
-    fireEvent.keyDown(screen.getByRole("button", { name: "Stop sharing" }), {
+    fireEvent.keyDown(screen.getByRole("button", { name: "Stop" }), {
       key: "Enter",
     });
     fireEvent.keyDown(
-      screen.getByRole("button", { name: "Change time" }),
+      screen.getByRole("button", { name: "Change end time" }),
       {
         key: " ",
       },
@@ -290,7 +290,7 @@ describe("LiveShareStatusCard", () => {
     expect(onManage).not.toHaveBeenCalled();
   });
 
-  it("hides Change time when there is no single share to change", () => {
+  it("hides Change end time when there is no single share to change", () => {
     // Same gate as Stop. With three shares running "change the time" has no
     // referent, and the card must not offer to act on an unnamed one.
     render(
@@ -306,7 +306,7 @@ describe("LiveShareStatusCard", () => {
     );
 
     expect(
-      screen.queryByRole("button", { name: "Change time" }),
+      screen.queryByRole("button", { name: "Change end time" }),
     ).toBeNull();
     expect(screen.getByText("Different end times")).toBeTruthy();
   });
@@ -342,7 +342,7 @@ describe("LiveShareStatusCard", () => {
     expect(screen.getByText(/^All end at /)).toBeTruthy();
   });
 
-  it("offers Set end time on an open-ended ordinary share", () => {
+  it("offers Set an end time on an open-ended ordinary share", () => {
     // "Until you stop" is the footer here, not an end time. The action still
     // belongs: giving an open share a finite end is exactly a time change.
     const onChangeDuration = vi.fn();
@@ -355,7 +355,7 @@ describe("LiveShareStatusCard", () => {
       />,
     );
 
-    screen.getByRole("button", { name: "Set end time" }).click();
+    screen.getByRole("button", { name: "Set an end time" }).click();
     expect(onChangeDuration).toHaveBeenCalledTimes(1);
     expect(screen.getByText("Until you stop")).toBeTruthy();
   });

--- a/hushh-webapp/components/one-location/redesign/live-share-status-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/live-share-status-card.tsx
@@ -316,17 +316,16 @@ export function LiveShareStatusCard({
       role={cardManageEnabled ? "button" : undefined}
       tabIndex={cardManageEnabled ? 0 : undefined}
       onClick={cardManageEnabled ? onManage : undefined}
-      onKeyDown={handleCardKeyDown}
-      className={cn(CARD_SURFACE, LIVE_SHARE_CARD_CLASSNAME)}
+      onKeyDown={handleCardKeyDown}      className={cn(CARD_SURFACE, LIVE_SHARE_CARD_CLASSNAME)}
     >
       <div className={LIVE_SHARE_HEADER_CLASSNAME}>
         <span className="inline-flex min-w-0 items-center gap-2">
           <span
             aria-hidden="true"
-            className="h-2 w-2 shrink-0 rounded-full bg-emerald-500"
+            className="h-2 w-2 shrink-0 rounded-full bg-emerald-500 motion-safe:animate-pulse"
           />
           <span className="text-[13px] font-semibold uppercase tracking-[0.06em] text-emerald-700 dark:text-emerald-300">
-            Sharing
+            Live
           </span>
         </span>
 
@@ -347,7 +346,7 @@ export function LiveShareStatusCard({
             {stopBusy ? (
               <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
             ) : null}
-            Stop sharing
+            Stop
           </Button>
         ) : (
           <Button
@@ -362,7 +361,7 @@ export function LiveShareStatusCard({
             data-ui-role="control"
             data-ui-id="location-live-share-manage"
           >
-            Manage sharing
+            Manage
           </Button>
         )}
       </div>
@@ -441,7 +440,7 @@ export function LiveShareStatusCard({
         <Button
           type="button"
           onClick={runChildAction(onShareMore)}
-          className="mt-4 min-h-[48px] w-full rounded-[14px] bg-[color:var(--app-secondary-surface)] px-5 font-[family-name:var(--font-app-body)] text-[16px] font-semibold leading-[22px] tracking-normal text-[color:var(--app-primary-label)] ring-1 ring-inset ring-[color:var(--app-separator)] transition-[background-color,transform] hover:bg-[color:var(--app-neutral-fill)] active:scale-[0.99]"
+          className="mt-4 min-h-[48px] w-full rounded-[16px] bg-[color:var(--app-accent)] px-5 font-[family-name:var(--font-app-body)] text-[17px] font-semibold leading-[22px] tracking-[-0.02em] text-white transition-[background-color,transform] hover:bg-[color:var(--app-accent)]/90 active:scale-[0.99]"
           data-ui-contract="occlusion-sensitive"
           data-ui-role="control"
           data-ui-id="location-live-share-more"
@@ -469,7 +468,7 @@ export function LiveShareStatusCard({
             data-ui-id="location-live-share-duration"
             data-testid="one-location-live-share-change-time"
           >
-            {openEnded ? "Set end time" : "Change time"}
+            {openEnded ? "Set an end time" : "Change end time"}
           </Button>
         </div>
       ) : null}

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -41,7 +41,6 @@ import {
   Share2,
   Check,
   ShieldCheck,
-  Settings,
   UserRoundPlus,
   UsersRound,
   ChevronRight,
@@ -87,9 +86,11 @@ import { LocationPermissionRecoveryCard } from "@/components/one-location/locati
 import { PageHeader } from "@/components/app-ui/page-sections";
 import {
   ButtonLabel,
+  CardTitle,
   FormLabel,
   MediumRowLabel,
   PageTitle,
+  PageSubtitle,
   RowDescription,
   RowLabel,
   SectionLabel,
@@ -1660,6 +1661,20 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
         className="[&>div:first-child]:!gap-3.5 [&_[data-slot=page-header-actions]]:!self-center [&_[data-slot=page-header-row]]:!items-center"
       />
 
+      {/*
+        Directly under the header, above the tabs, because a blocked permission
+        is not a detail of one tab — it is the reason every Location feature
+        below is inert. It used to be announced only by the word "blocked" in
+        the header status and a toast that had already gone, which is how
+        someone ended up on this screen with nothing to act on.
+      */}
+      <LocationPermissionRecoveryCard
+        blocked={vm.locationBlocked}
+        busy={vm.locationAcquiring}
+        onRetry={vm.onShowMyLocation}
+        onOpenSettings={vm.onOpenLocationSettings}
+      />
+
       <TopShellTabs
         tabSet={{
           ...LOCATION_TAB_DEFINITION,
@@ -1888,6 +1903,24 @@ function NowHub({
       voiceActionId: "location.open_needs_review",
     },
   ].filter((row) => row.value > 0);
+  const moreRows = [
+    {
+      leading: <LocationMenuListIcon name="map" />,
+      title: "Map",
+      ariaLabel: "Map",
+      onClick: onOpenMap,
+      voiceControlId: "one-location-action-map",
+      voiceActionId: "location.open_map",
+    },
+    {
+      leading: <LocationMenuListIcon name="settings" />,
+      title: "Settings",
+      ariaLabel: "Settings",
+      onClick: onOpenSettings,
+      voiceControlId: "one-location-action-settings",
+      voiceActionId: "location.open_settings",
+    },
+  ];
   return (
     <div className="space-y-3" data-testid="one-location-now-hub">
       {/* Sharing is the one thing on this screen that keeps running after you
@@ -1923,29 +1956,46 @@ function NowHub({
           onEnded={vm.onLiveShareEnded}
         />
       ) : null}
-      {vm.liveShare ? (
-        <LocationNowActionSuite
-          onRequestLocation={onRequestLocation}
-          onCheckIn={onCheckIn}
-          onSos={onSos}
-          onOpenMap={onOpenMap}
-          onOpenSettings={onOpenSettings}
-        />
-      ) : null}
+      {/* Every row and cell below carries the `control_ids` / `action_id` pair
+          it was authored with in the Location voice action contract, so One and
+          the search bar can name the individual control a person is asking for
+          rather than only the screen it lives on. */}
       {!vm.liveShare ? (
-        <LocationNowStatePanel
-          blocked={vm.locationBlocked}
-          busy={vm.locationAcquiring}
-          onPrimaryAction={
-            vm.locationBlocked ? vm.onOpenLocationSettings : onStartShare
-          }
-          onRequestLocation={onRequestLocation}
-          onCheckIn={onCheckIn}
-          onSos={onSos}
-          onOpenMap={onOpenMap}
-          onOpenSettings={onOpenSettings}
-        />
+        <LocationPrimaryShareCard onClick={onStartShare} />
       ) : null}
+      <LocationActionGrid
+        items={[
+          {
+            title: "Ask for location",
+            ariaLabel: "Ask for location",
+            icon: <LocationMenuGlyph name="ask" size={34} />,
+            tone: "blue",
+            onClick: onRequestLocation,
+            controlId: "one-location-action-ask",
+            actionId: "location.open_ask",
+            testId: "one-location-request-row",
+          },
+          {
+            title: "Check in",
+            ariaLabel: "Check in",
+            icon: <LocationMenuGlyph name="checkIn" size={34} />,
+            tone: "blue",
+            onClick: onCheckIn,
+            controlId: "one-location-action-check-in",
+            actionId: "location.open_check_in",
+          },
+          {
+            title: "Save My Soul",
+            subtitle: "Emergency alert",
+            ariaLabel: "Save My Soul emergency alert",
+            icon: <SmsTextIcon />,
+            tone: "red",
+            onClick: onSos,
+            controlId: "one-location-action-sos",
+            actionId: "location.open_sos",
+          },
+        ]}
+      />
 
       {activityRows.length ? (
         <div className="pt-1">
@@ -1965,6 +2015,21 @@ function NowHub({
           </LocationMenuListGroup>
         </div>
       ) : null}
+      <div className="pt-1">
+        <LocationMenuListGroup testId="one-location-now-more">
+          {moreRows.map((row) => (
+            <LocationMenuListRow
+              key={row.voiceControlId}
+              leading={row.leading}
+              title={row.title}
+              ariaLabel={row.ariaLabel}
+              onClick={row.onClick}
+              voiceControlId={row.voiceControlId}
+              voiceActionId={row.voiceActionId}
+            />
+          ))}
+        </LocationMenuListGroup>
+      </div>
     </div>
   );
 }
@@ -2038,273 +2103,40 @@ function LocationMenuListRow({
   );
 }
 
-function LocationNowStatePanel({
-  blocked,
-  busy,
-  onPrimaryAction,
-  onRequestLocation,
-  onCheckIn,
-  onSos,
-  onOpenMap,
-  onOpenSettings,
-}: {
-  blocked: boolean;
-  busy: boolean;
-  onPrimaryAction: () => void;
-  onRequestLocation: () => void;
-  onCheckIn: () => void;
-  onSos: () => void;
-  onOpenMap: () => void;
-  onOpenSettings: () => void;
-}) {
-  const stateLabel = blocked ? "Location unavailable" : "Private";
-  const headline = blocked
-    ? "Location access is off"
-    : "No one can see your location";
-  const support = blocked
-    ? "Turn it on to share your location."
-    : "Share only when you choose.";
-  const primaryLabel = blocked ? "Turn on Location" : "Share my location";
-  const primaryVoiceControlId = blocked
-    ? "one-location-action-location-settings"
-    : "one-location-action-share";
-  const primaryVoiceActionId = blocked
-    ? "location.open_settings"
-    : "location.open_share";
-
+function LocationPrimaryShareCard({ onClick }: { onClick: () => void }) {
   return (
-    <section
-      aria-label={blocked ? "Location access" : "Location sharing status"}
-      data-testid="one-location-now-primary"
-      data-now-state={blocked ? "unavailable" : "private"}
-      className={cn(
-        LOCATION_INTERACTIVE_SURFACE,
-        "mx-auto w-full max-w-[720px] rounded-[20px] px-5 py-7 text-center sm:px-8 sm:py-8",
-      )}
-    >
-      <p
-        data-ui-contract="required-copy"
-        data-ui-id="location-now-state"
-        className="text-[13px] font-semibold uppercase leading-4 tracking-[0.06em] text-[color:var(--app-secondary-label)]"
-      >
-        {stateLabel}
-      </p>
-      <h2
-        data-ui-contract="required-copy"
-        data-ui-id="location-now-headline"
-        data-ui-truncation="forbid"
-        className="mx-auto mt-2 max-w-[440px] text-[28px] font-semibold leading-[34px] tracking-normal text-[color:var(--app-primary-label)]"
-      >
-        {headline}
-      </h2>
-      <p
-        data-ui-contract="required-copy"
-        data-ui-id="location-now-support"
-        className="mx-auto mt-2 max-w-[360px] text-[16px] font-normal leading-[22px] text-[color:var(--app-secondary-label)]"
-      >
-        {support}
-      </p>
-
-      <div className="mx-auto mt-6 grid w-full max-w-[440px] gap-2.5 sm:grid-cols-2">
-        <button
-          type="button"
-          data-voice-control-id={primaryVoiceControlId}
-          data-voice-action-id={primaryVoiceActionId}
-          data-voice-label={primaryLabel}
-          aria-label={primaryLabel}
-          onClick={onPrimaryAction}
-          disabled={busy}
-          className="inline-flex min-h-[50px] w-full items-center justify-center rounded-[14px] bg-[color:var(--app-accent)] px-5 text-[color:var(--app-accent-fg)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-accent-hover)] active:scale-[0.99] disabled:cursor-wait disabled:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
-        >
-          {busy ? (
-            <Loader2 aria-hidden="true" className="mr-2 h-4 w-4 animate-spin" />
-          ) : null}
-          <ButtonLabel as="span">{primaryLabel}</ButtonLabel>
-        </button>
-        <button
-          type="button"
-          data-testid="one-location-request-row"
-          data-voice-control-id="one-location-action-ask"
-          data-voice-action-id="location.open_ask"
-          data-voice-label="Ask for location"
-          aria-label="Ask for location"
-          onClick={onRequestLocation}
-          className="inline-flex min-h-[48px] w-full items-center justify-center rounded-[14px] bg-[color:var(--app-secondary-surface)] px-5 text-[color:var(--app-primary-label)] ring-1 ring-inset ring-[color:var(--app-separator)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-neutral-fill)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
-        >
-          <ButtonLabel as="span">Ask for location</ButtonLabel>
-        </button>
-      </div>
-
+    <section aria-label="Share location" data-testid="one-location-now-primary">
       <div
-        data-testid="one-location-now-actions"
-        className="mx-auto mt-3 grid w-full max-w-[440px] gap-2.5 sm:grid-cols-2"
+        data-testid="one-location-share-row"
+        className={cn(
+          LOCATION_INTERACTIVE_SURFACE,
+          "grid w-full gap-4 rounded-[20px] px-5 py-5 text-left sm:grid-cols-[auto_minmax(0,1fr)_194px] sm:items-center sm:gap-5 sm:px-6 sm:py-5",
+        )}
       >
-        <LocationNowSecondaryAction
-          icon="checkIn"
-          label="Check in"
-          voiceControlId="one-location-action-check-in"
-          voiceActionId="location.open_check_in"
-          onClick={onCheckIn}
-        />
-        <LocationNowSecondaryAction
-          icon="active"
-          label="Save My Soul"
-          voiceControlId="one-location-action-sos"
-          voiceActionId="location.open_sos"
-          onClick={onSos}
-        />
-      </div>
-
-      <div className="mx-auto mt-4 w-full max-w-[440px]">
-        <LocationNowMoreActions
-          onOpenMap={onOpenMap}
-          onOpenSettings={onOpenSettings}
-        />
+        <div className="flex min-w-0 items-center gap-4">
+          <LocationSharePulseIcon />
+          <span className="min-w-0 space-y-1">
+            <CardTitle as="span" className="block">
+              You&apos;re not sharing
+            </CardTitle>
+            <PageSubtitle as="span" className="block">
+              Choose a Circle or contact.
+            </PageSubtitle>
+          </span>
+        </div>
+        <button
+          type="button"
+          data-voice-control-id="one-location-action-share"
+          data-voice-action-id="location.open_share"
+          data-voice-label="Share location"
+          aria-label="Share location"
+          onClick={onClick}
+          className="inline-flex min-h-[47px] w-full items-center justify-center rounded-[15px] bg-[color:var(--app-accent)] px-5 text-[color:var(--app-accent-fg)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-accent-hover)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] sm:col-start-3"
+        >
+          <ButtonLabel as="span">Share location</ButtonLabel>
+        </button>
       </div>
     </section>
-  );
-}
-
-function LocationNowSecondaryAction({
-  icon,
-  label,
-  voiceControlId,
-  voiceActionId,
-  onClick,
-}: {
-  icon: LocationMenuGlyphName;
-  label: string;
-  voiceControlId: string;
-  voiceActionId: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      data-testid={`one-location-now-action-${voiceActionId.replace(
-        "location.open_",
-        "",
-      )}`}
-      data-voice-control-id={voiceControlId}
-      data-voice-action-id={voiceActionId}
-      data-voice-label={label}
-      aria-label={label}
-      onClick={onClick}
-      className="inline-flex min-h-[48px] w-full items-center justify-center gap-2.5 rounded-[14px] bg-[color:var(--app-secondary-surface)] px-4 text-[color:var(--app-primary-label)] ring-1 ring-inset ring-[color:var(--app-separator)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-neutral-fill)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
-    >
-      <span
-        aria-hidden="true"
-        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] bg-[color:var(--app-neutral-fill)] text-[color:var(--app-secondary-label)]"
-      >
-        <LocationMenuGlyph name={icon} size={17} />
-      </span>
-      <ButtonLabel as="span">{label}</ButtonLabel>
-    </button>
-  );
-}
-
-function LocationNowActionSuite({
-  onRequestLocation,
-  onCheckIn,
-  onSos,
-  onOpenMap,
-  onOpenSettings,
-}: {
-  onRequestLocation: () => void;
-  onCheckIn: () => void;
-  onSos: () => void;
-  onOpenMap: () => void;
-  onOpenSettings: () => void;
-}) {
-  return (
-    <div
-      data-testid="one-location-now-actions"
-      className="mx-auto grid w-full max-w-[720px] gap-2.5 sm:grid-cols-2"
-    >
-      <LocationNowSecondaryAction
-        icon="ask"
-        label="Ask for location"
-        voiceControlId="one-location-action-ask"
-        voiceActionId="location.open_ask"
-        onClick={onRequestLocation}
-      />
-      <LocationNowSecondaryAction
-        icon="checkIn"
-        label="Check in"
-        voiceControlId="one-location-action-check-in"
-        voiceActionId="location.open_check_in"
-        onClick={onCheckIn}
-      />
-      <LocationNowSecondaryAction
-        icon="active"
-        label="Save My Soul"
-        voiceControlId="one-location-action-sos"
-        voiceActionId="location.open_sos"
-        onClick={onSos}
-      />
-      <LocationNowMoreActions
-        onOpenMap={onOpenMap}
-        onOpenSettings={onOpenSettings}
-      />
-    </div>
-  );
-}
-
-function LocationNowMoreActions({
-  onOpenMap,
-  onOpenSettings,
-}: {
-  onOpenMap: () => void;
-  onOpenSettings: () => void;
-}) {
-  return (
-    <ActionMenu
-      label="More actions"
-      title="More actions"
-      testId="one-location-now-more"
-      trigger={
-        <button
-          type="button"
-          data-testid="one-location-now-more"
-          aria-label="More actions"
-          className="flex min-h-[50px] w-full items-center justify-between rounded-[14px] bg-transparent px-1 text-left text-[color:var(--app-primary-label)] transition-colors hover:bg-[color:var(--app-neutral-fill)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]"
-        >
-          <span className="flex min-w-0 items-center gap-3">
-            <span
-              aria-hidden="true"
-              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-neutral-fill)] text-[color:var(--app-secondary-label)]"
-            >
-              <Plus className="h-4 w-4" />
-            </span>
-            <RowLabel as="span" className="min-w-0">
-              More actions
-            </RowLabel>
-          </span>
-          <ChevronRight
-            aria-hidden="true"
-            className="h-5 w-5 shrink-0 text-[color:var(--app-tertiary-label)]"
-          />
-        </button>
-      }
-      items={[
-        {
-          id: "map",
-          label: "Map",
-          icon: MapPin,
-          onSelect: onOpenMap,
-          voiceControlId: "one-location-action-map",
-          voiceActionId: "location.open_map",
-        },
-        {
-          id: "settings",
-          label: "Settings",
-          icon: Settings,
-          onSelect: onOpenSettings,
-          voiceControlId: "one-location-action-settings",
-          voiceActionId: "location.open_settings",
-        },
-      ]}
-    />
   );
 }
 
@@ -2317,6 +2149,121 @@ function LocationHeaderIconTile() {
     >
       <MapPin className="h-6 w-6" strokeWidth={2} />
     </span>
+  );
+}
+
+function LocationSharePulseIcon() {
+  return (
+    <span
+      aria-hidden="true"
+      data-location-share-pulse-icon=""
+      className="relative inline-flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-accent-tint)] shadow-[inset_0_0_0_1px_rgba(0,122,255,0.025)] dark:shadow-none sm:h-16 sm:w-16"
+    >
+      <span className="absolute inset-[13%] rounded-full bg-[color:var(--app-accent-surface)]" />
+      <span className="absolute inset-[28%] rounded-full bg-[color:var(--app-accent)]/20" />
+      <span className="relative h-[25%] w-[25%] rounded-full bg-[color:var(--app-accent)] shadow-[0_0_0_4px_var(--app-primary-surface),0_8px_16px_rgba(0,122,255,0.18)] dark:shadow-[0_0_0_4px_var(--app-primary-surface)]" />
+    </span>
+  );
+}
+
+type LocationActionGridItem = {
+  title: string;
+  subtitle?: string;
+  ariaLabel: string;
+  icon: ReactNode;
+  tone: "blue" | "red";
+  onClick: () => void;
+  controlId: string;
+  actionId: string;
+  testId?: string;
+};
+
+function LocationActionGrid({ items }: { items: LocationActionGridItem[] }) {
+  const regularItems = items.filter((item) => item.tone !== "red");
+  const emergencyItem = items.find((item) => item.tone === "red");
+
+  return (
+    <section
+      aria-label="Actions"
+      className="pt-1"
+      data-testid="one-location-now-actions"
+    >
+      <div
+        data-one-location-action-grid=""
+        className="grid w-full grid-cols-1 gap-3 min-[360px]:grid-cols-2 sm:gap-4"
+      >
+        {regularItems.map((item) => (
+          <button
+            key={item.controlId}
+            type="button"
+            data-testid={item.testId}
+            data-one-location-action-cell=""
+            data-voice-control-id={item.controlId}
+            data-voice-action-id={item.actionId}
+            data-voice-label={item.ariaLabel}
+            aria-label={item.ariaLabel}
+            onClick={item.onClick}
+            className={cn(
+              LOCATION_INTERACTIVE_SURFACE,
+              "group flex min-h-[96px] min-w-0 flex-col items-center justify-center gap-2.5 rounded-[16px] px-5 py-4 text-center transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-secondary-surface)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-accent-ring)]",
+            )}
+          >
+            <span
+              aria-hidden
+              data-one-location-action-icon=""
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center text-[color:var(--app-accent)] transition-transform group-active:scale-95 [&>svg]:h-8 [&>svg]:w-8"
+            >
+              {item.icon}
+            </span>
+            <span className="min-w-0">
+              <ButtonLabel as="span" className="block min-w-0">
+                {item.title}
+              </ButtonLabel>
+            </span>
+          </button>
+        ))}
+      </div>
+      {emergencyItem ? (
+        <button
+          key={emergencyItem.controlId}
+          type="button"
+          data-testid={emergencyItem.testId}
+          data-one-location-sms-row=""
+          data-one-location-emergency-cell=""
+          data-voice-control-id={emergencyItem.controlId}
+          data-voice-action-id={emergencyItem.actionId}
+          data-voice-label={emergencyItem.ariaLabel}
+          aria-label={emergencyItem.ariaLabel}
+          onClick={emergencyItem.onClick}
+          className="group mt-3 flex min-h-[68px] w-full items-center justify-between gap-4 rounded-[16px] bg-[color:var(--app-destructive-tint)] px-5 py-3 text-left ring-1 ring-inset ring-[color:var(--app-destructive-border)] transition-[background-color,transform] [-webkit-tap-highlight-color:transparent] hover:bg-[color:var(--app-destructive-surface)] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--app-destructive-border)]"
+        >
+          <span className="flex min-w-0 items-center gap-4">
+            <span
+              aria-hidden
+              data-one-location-action-icon=""
+              className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-destructive)] text-[color:var(--app-destructive-fg)] transition-transform group-active:scale-95"
+            >
+              {emergencyItem.icon}
+            </span>
+            <span className="min-w-0">
+              <RowLabel as="span" className="block min-w-0 font-semibold">
+                {emergencyItem.title}
+              </RowLabel>
+              <RowDescription
+                as="span"
+                className="mt-0.5 block min-w-0 !text-[color:var(--app-destructive)]"
+              >
+                {emergencyItem.subtitle}
+              </RowDescription>
+            </span>
+          </span>
+          <ChevronRight
+            aria-hidden="true"
+            className="h-5 w-5 shrink-0 text-[color:var(--app-destructive)]/45"
+          />
+        </button>
+      ) : null}
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary
- rollback the Location Now redesign chain that changed the screen after the morning baseline
- revert PR #6534, PR #6538, and PR #6541 only
- keep unrelated Connect/contact/circle changes from latest main

## Validation
- git diff --check origin/main..HEAD
- attempted focused local vitest/eslint; local temp worktree tool resolution failed before executing tests because npx could not resolve linked node_modules
- PR CI is required before merge