### PR TITLE
fix(deploy): repair pinned backend image rollout logging

### DIFF
--- a/consent-protocol/tests/test_account_deletion_release_workflow.py
+++ b/consent-protocol/tests/test_account_deletion_release_workflow.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -87,6 +90,52 @@ def test_uat_backend_deploy_consumes_the_pinned_digest_without_rebuilding() -> N
         (ROOT / "deploy" / "backend-image.cloudbuild.yaml").read_text(encoding="utf-8")
     )
     assert image_build["timeout"] == "1800s"
+
+
+@pytest.mark.parametrize(
+    ("skip_build", "image_reference", "expected_code", "expected_message"),
+    [
+        ("true", "example.invalid/backend@sha256:" + "a" * 64, 0, "Using prebuilt"),
+        ("true", "", 1, "requires an immutable _IMAGE_REFERENCE digest"),
+        ("true", "example.invalid/backend:latest", 1, "requires an immutable"),
+        ("invalid", "example.invalid/backend@sha256:" + "a" * 64, 1, "must be true or false"),
+    ],
+)
+def test_prebuilt_backend_step_runs_without_substitution_environment(
+    skip_build: str, image_reference: str, expected_code: int, expected_message: str
+) -> None:
+    cloudbuild = yaml.safe_load(
+        (ROOT / "deploy" / "backend.cloudbuild.yaml").read_text(encoding="utf-8")
+    )
+    step = next(step for step in cloudbuild["steps"] if step["id"] == "build-backend-image")
+    assert step["entrypoint"] == "bash"
+    assert step["args"][0] == "-c"
+    # Cloud Build replaces simple substitutions; it does not export them as shell
+    # variables. Leave Bash parameter operators untouched to exercise strict mode.
+    script = step["args"][1].replace("${_SKIP_IMAGE_BUILD}", skip_build)
+    script = script.replace("${_IMAGE_REFERENCE}", image_reference)
+    environment = os.environ.copy()
+    environment.pop("_SKIP_IMAGE_BUILD", None)
+    environment.pop("_IMAGE_REFERENCE", None)
+    # Never build or touch cloud resources if the production step regresses.
+    guards = (
+        "docker() { echo UNEXPECTED_BUILD_COMMAND >&2; return 95; }; "
+        "gcloud() { echo UNEXPECTED_CLOUD_COMMAND >&2; return 96; };\n"
+    )
+    bash = shutil.which("bash")
+    assert bash is not None, "Bash is required to verify the Cloud Build runtime contract"
+    result = subprocess.run(  # noqa: S603 - trusted repo script, fixed inputs, guarded commands
+        [bash, "-c", guards + script],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == expected_code, output
+    assert expected_message in output
+    assert "UNEXPECTED_" not in output
 
 
 def test_uat_activation_retires_legacy_revisions_before_removing_fence() -> None:

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -25,7 +25,7 @@ steps:
             echo "_SKIP_IMAGE_BUILD=true requires an immutable _IMAGE_REFERENCE digest." >&2
             exit 1
           fi
-          echo "Using prebuilt immutable backend image ${_IMAGE_REFERENCE%%@*}@sha256:<pinned>."
+          echo "Using prebuilt immutable backend image (digest verified)."
           exit 0
         fi
         if [[ "${_SKIP_IMAGE_BUILD}" != "false" ]]; then


### PR DESCRIPTION
# Description

Recover the UAT rollout for #6537 by fixing the pinned-image success log in the existing backend Cloud Build step. Track remaining cross-device acceptance in #6490 (keep the issue open).

UAT run [33990441683](https://github.com/hushh-labs/hushh-research/actions/runs/33990441683) failed before traffic promotion: `_IMAGE_REFERENCE: unbound variable`. Cloud Build replaces simple substitutions but the log used Bash parameter expansion on a variable not exported into the shell. Only the log message changes; the immutable-image check, skip-build validation, candidate/no-traffic rollout, schema checks, and account-deletion fence are unchanged.

## 📌 Impact Map (Required)

- Routes, API/schema/types, cache keys, runtime DB data plane, world-model summaries: no changes.
- Mobile parity: no bundled web, Swift, Kotlin, or native changes in this follow-up; original implementation is #6537.
- Docs: no canonical contract change; release evidence and UAT/native test matrix are maintained in #6490.
- Config: `deploy/backend.cloudbuild.yaml`, attached to the existing `Deploy backend using Cloud Build` step in `deploy-uat.yml`.
- Trust boundary: deployment. No authority, credentials, dependencies, migration, traffic or security-gate changes.
- Caller/proxy/backend pairing: not applicable; deployment logging only.
- Safe failure: invalid skip flags and empty/mutable image references still fail before any build/cloud command. The UAT deletion fence stays installed until the existing compatible-rollout activation succeeds.
- Browser proof: not applicable to this two-file logging/test diff. Public UAT login-recovery checks follow the successful combined release; authenticated native acceptance remains explicitly unclaimed.

## ✅ Review-Ready Contract

- [x] Title, diff and tests describe the same reachable deployment defect.
- [x] Existing implementation and related PRs inspected; this extends #6537, not a parallel deployment path.
- [x] Production attach point: `build-backend-image` Bash body in `deploy/backend.cloudbuild.yaml`.
- [x] Regression executes that actual YAML script, not a copied implementation; bounded subprocess and guards prevent Docker/gcloud execution.
- [x] Characterization reproduced the original unbound-variable failure before the log fix.
- [x] Independent read-only review found no concrete defect in the follow-up.
- [x] Commits signed off; maintained on the existing developer branch.
- [x] Exact-head CI is green at `3c95fcd807ad7bcec3fea0aafcc2d7b93d25aebe`; fresh against main `194bede3e72c801260b578d313019ad9e17ba376`, mergeable, no unresolved review threads.

## 🛑 Tri-Flow Architecture Check

Web, iOS and Android product code: not applicable to this deployment-only follow-up; no contract changes on those surfaces.

## 🧪 Testing

- RED: the new actual-Bash regression failed on the original pinned-image log (1 failed, 3 passed).
- GREEN twice: 42 tests across `test_account_deletion_release_workflow.py`, `test_cloudbuild_step_arg_limit.py`, and `test_uat_deploy_no_traffic_contract.py`.
- Ruff check and format check pass; changed diff passes whitespace validation.
- Managed Vertex manifest collection passes for the UAT text-model setting without invoking a provider.
- After refreshing main: 44 release/Cloud Build/readiness tests pass; DCO and full repository governance checks pass. Existing architecture-debt and skill-routing advisories are unchanged.
- Refreshed integration: 262 account/session tests (17 files), 165 incoming Location tests (3 files), and TypeScript checking pass. Independent read-only review found no incoming-main auth/session conflict.
- [Exact-head CI run 33991214525](https://github.com/hushh-labs/hushh-research/actions/runs/33991214525) succeeded: Protocol 2,193 passed / 2 skipped, integration, MCP, governance, DCO, secret scan and CI Status Gate green. Web Core, Web Targeted and iOS Native are intentional path-selector skips for this deployment-only delta; original #6537 carries its own native/browser CI evidence.
- Full local repository governance passed again on the refreshed head.

### Landing status

The user explicitly approved the Admin SOP for this PR. After rechecking actor authority, live branch protection, exact-head green CI, freshness, DCO, mergeability and zero unresolved threads, the reviewed head `3c95fcd807ad7bcec3fea0aafcc2d7b93d25aebe` landed via Admin queue bypass at main `0f3126ea47219a551525cf91ac6fc2e20cd0fecb` on 2026-09-05 at 21:02 UTC. No Queue Validation or independent human review is claimed. The landed tree matches the CI-tested tree exactly. [Main post-merge smoke 33991871818](https://github.com/hushh-labs/hushh-research/actions/runs/33991871818) passed. [UAT recovery run 33991970377](https://github.com/hushh-labs/hushh-research/actions/runs/33991970377) resolved `auto` to `all` and failed at candidate exact-image readiness after both Cloud Builds succeeded. This confirms the logging repair but exposes an OCI index versus executable digest mismatch, tracked in [#6546](https://github.com/hushh-labs/hushh-research/pull/6546). Known-good revisions are serving, account deletion remains fenced, and successful UAT release is not claimed. Production and native distribution remain out of scope.

## 📸 Screenshots / Video

Not applicable: no rendered UI changes. The regression reproduces the exact failed deployment shell path.

## 🛡️ Privacy & Consent

No user information accessed by these tests: fixed `example.invalid` image inputs, no credentials, cloud commands guarded, timeout bounded. Existing deployment authority and account-deletion safety fence remain unchanged. No production deployment or native upload is included.

## 📜 Licensing

First-party changes remain Apache-2.0 compatible; no dependency or third-party notice changes.
