### PR TITLE
fix(deploy): pin executable image before lifecycle migration

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -486,26 +486,17 @@ jobs:
             exit 1
           fi
           image_reference="${image_repository}@${image_digest}"
+          # Buildx attestations live in a parent index. Pin its executable child
+          # before the fence; Cloud Run must later report this exact digest.
+          gcloud auth configure-docker gcr.io --quiet
+          docker buildx imagetools inspect --raw "${image_reference}" \
+            > /tmp/uat-backend-image-manifest.json
+          image_reference="$(python3 scripts/ci/resolve-cloud-run-image.py \
+            --image-reference "${image_reference}" \
+            --manifest-json /tmp/uat-backend-image-manifest.json \
+            --sha "${{ steps.resolve-sha.outputs.sha }}" \
+            --json-output /tmp/uat-backend-image.json)"
           echo "image_reference=${image_reference}" >> "$GITHUB_OUTPUT"
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          Path("/tmp/uat-backend-image.json").write_text(
-              json.dumps(
-                  {
-                      "status": "pinned",
-                      "repository": "gcr.io/hushh-pda-uat/consent-protocol",
-                      "digest_algorithm": "sha256",
-                      "sha": "${{ steps.resolve-sha.outputs.sha }}",
-                  },
-                  indent=2,
-                  sort_keys=True,
-              ),
-              encoding="utf-8",
-          )
-          PY
 
       - name: Install Cloud SQL Auth Proxy
         if: steps.scope.outputs.deploy_backend == 'true'
@@ -1957,6 +1948,7 @@ jobs:
             /tmp/uat-db-migration-guard-predeploy.json
             /tmp/uat-db-migration-guard-postdeploy.json
             /tmp/uat-backend-image.json
+            /tmp/uat-backend-image-manifest.json
             /tmp/uat-backend-candidate.json
             /tmp/uat-backend-candidate-readiness.json
             /tmp/uat-backend-candidate-health.json

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -143,6 +143,7 @@ tests/test_firebase_auth_split.py
 tests/services/test_account_deletion_lifecycle_service.py
 tests/test_account_deletion_tombstone_migration.py
 tests/test_account_deletion_release_workflow.py
+tests/test_cloud_run_image_resolution.py
 
 # Contact discovery.
 #

--- a/consent-protocol/tests/test_account_deletion_release_workflow.py
+++ b/consent-protocol/tests/test_account_deletion_release_workflow.py
@@ -106,12 +106,14 @@ def test_uat_pins_executable_manifest_instead_of_attested_index(
                 {
                     "mediaType": "application/vnd.oci.image.manifest.v1+json",
                     "digest": "sha256:" + "b" * 64,
+                    "size": 1234,
                     "platform": {"os": "unknown", "architecture": "unknown"},
                     "annotations": {"vnd.docker.reference.type": "attestation-manifest"},
                 },
                 {
                     "mediaType": "application/vnd.oci.image.manifest.v1+json",
                     "digest": child_digest,
+                    "size": 1234,
                     "platform": {"os": "linux", "architecture": architecture},
                 },
             ],

--- a/consent-protocol/tests/test_account_deletion_release_workflow.py
+++ b/consent-protocol/tests/test_account_deletion_release_workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import os
@@ -90,6 +91,79 @@ def test_uat_backend_deploy_consumes_the_pinned_digest_without_rebuilding() -> N
         (ROOT / "deploy" / "backend-image.cloudbuild.yaml").read_text(encoding="utf-8")
     )
     assert image_build["timeout"] == "1800s"
+
+
+@pytest.mark.parametrize("architecture", ["amd64", "arm64"])
+def test_uat_pins_executable_manifest_instead_of_attested_index(
+    tmp_path: Path, architecture: str
+) -> None:
+    child_digest = "sha256:" + "a" * 64
+    manifest = json.dumps(
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": "sha256:" + "b" * 64,
+                    "platform": {"os": "unknown", "architecture": "unknown"},
+                    "annotations": {"vnd.docker.reference.type": "attestation-manifest"},
+                },
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": child_digest,
+                    "platform": {"os": "linux", "architecture": architecture},
+                },
+            ],
+        }
+    )
+    index_digest = "sha256:" + hashlib.sha256(manifest.encode()).hexdigest()
+    repository = "gcr.io/hushh-pda-uat/consent-protocol"
+    script = _step("Build and pin backend image before lifecycle migration")["run"]
+    script = script.replace("${{ env.GCP_PROJECT_ID }}", "hushh-pda-uat")
+    script = script.replace("${{ steps.resolve-sha.outputs.sha }}", "c" * 40)
+    for name in ("uat-backend-image.json", "uat-backend-image-manifest.json"):
+        script = script.replace(
+            f"/tmp/{name}",  # noqa: S108 - replace workflow paths with pytest isolation
+            (tmp_path / name).as_posix(),
+        )
+    assert "${{" not in script
+    # Execute the real workflow body but intercept every external build/registry
+    # command. Only the production digest resolver runs, with fixed public inputs.
+    guards = (
+        'gcloud() { case "$1 $2" in '
+        "'builds submit'|'auth configure-docker') return 0 ;; "
+        f"'container images') printf '%s' '{index_digest}' ;; "
+        "*) echo UNEXPECTED_CLOUD_COMMAND >&2; return 95 ;; esac; };\n"
+        "docker() { "
+        f"if [[ \"$*\" != *'{repository}@{index_digest}'* ]]; then "
+        "echo UNEXPECTED_MUTABLE_LOOKUP >&2; return 96; fi; "
+        f"printf '%s' '{manifest}'; }};\n"
+        f"python3() {{ '{Path(sys.executable).as_posix()}' \"$@\"; }};\n"
+    )
+    output_path = tmp_path / "github-output"
+    environment = os.environ.copy()
+    environment.pop("BASH_ENV", None)
+    environment["GITHUB_OUTPUT"] = output_path.as_posix()
+    bash = shutil.which("bash")
+    assert bash is not None, "Bash is required for the workflow behavior test"
+    result = subprocess.run(  # noqa: S603 - trusted workflow, fixed inputs, guarded cloud commands
+        [bash, "-c", guards + script],
+        cwd=ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert "UNEXPECTED_" not in result.stdout + result.stderr
+    if architecture != "amd64":
+        assert result.returncode != 0
+        assert "exactly one executable linux/amd64" in result.stderr
+        assert not output_path.exists()
+        return
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output_path.read_text().strip() == f"image_reference={repository}@{child_digest}"
 
 
 @pytest.mark.parametrize(

--- a/consent-protocol/tests/test_cloud_run_image_resolution.py
+++ b/consent-protocol/tests/test_cloud_run_image_resolution.py
@@ -48,6 +48,21 @@ def _encoded(payload):
     return raw, "sha256:" + hashlib.sha256(raw).hexdigest()
 
 
+def _direct(media_type=OCI_IMAGE, **overrides):
+    config_type = (
+        "application/vnd.oci.image.config.v1+json"
+        if media_type == OCI_IMAGE
+        else "application/vnd.docker.container.image.v1+json"
+    )
+    return {
+        "schemaVersion": 2,
+        "mediaType": media_type,
+        "config": {"mediaType": config_type, "digest": CHILD_DIGEST, "size": 123},
+        "layers": [],
+        **overrides,
+    }
+
+
 @pytest.mark.parametrize("reverse", [False, True])
 @pytest.mark.parametrize(
     "index_type,image_type", [(OCI_INDEX, OCI_IMAGE), (DOCKER_INDEX, DOCKER_IMAGE)]
@@ -72,7 +87,7 @@ def test_selects_amd64_not_attestation_or_array_position(reverse, index_type, im
 
 @pytest.mark.parametrize("media_type", [OCI_IMAGE, DOCKER_IMAGE])
 def test_direct_manifest_keeps_original_digest(media_type):
-    raw, digest = _encoded({"schemaVersion": 2, "mediaType": media_type, "layers": []})
+    raw, digest = _encoded(_direct(media_type))
     assert _resolver().resolve_manifest(raw, digest) == {
         "digest": digest,
         "selection": "direct_manifest",
@@ -92,11 +107,23 @@ def test_direct_manifest_keeps_original_digest(media_type):
         _index([_descriptor(annotations={"vnd.docker.reference.type": "attestation-manifest"})]),
         _index([_descriptor(artifactType="application/vnd.in-toto+json")]),
         _index([_descriptor(platform="linux/amd64")]),
+        _index([_descriptor(annotations=[])]),
+        _index([_descriptor(platform=[])]),
         _index([None]),
         _index(None),
         {"schemaVersion": 1, "mediaType": OCI_INDEX},
         {"schemaVersion": 2, "mediaType": "unsupported"},
         {"schemaVersion": 2, "mediaType": {}},
+        {"schemaVersion": 2, "mediaType": OCI_IMAGE},
+        _direct(artifactType="application/vnd.in-toto+json"),
+        _direct(annotations={"vnd.docker.reference.type": "attestation-manifest"}),
+        _direct(annotations=[]),
+        _direct(config=None),
+        _direct(config={"mediaType": OCI_IMAGE, "digest": CHILD_DIGEST, "size": 123}),
+        _direct(layers=None),
+        _direct(layers=[None]),
+        _direct(layers=[{"mediaType": "layer", "digest": "latest", "size": 123}]),
+        _direct(layers=[{"mediaType": "layer", "digest": CHILD_DIGEST, "size": True}]),
         [],
     ],
 )

--- a/consent-protocol/tests/test_cloud_run_image_resolution.py
+++ b/consent-protocol/tests/test_cloud_run_image_resolution.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+OCI_INDEX = "application/vnd.oci.image.index.v1+json"
+OCI_IMAGE = "application/vnd.oci.image.manifest.v1+json"
+DOCKER_INDEX = "application/vnd.docker.distribution.manifest.list.v2+json"
+DOCKER_IMAGE = "application/vnd.docker.distribution.manifest.v2+json"
+CHILD_DIGEST = "sha256:" + "a" * 64
+
+
+def _resolver():
+    spec = importlib.util.spec_from_file_location(
+        "resolve_cloud_run_image", ROOT / "scripts/ci/resolve-cloud-run-image.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _descriptor(**overrides):
+    return {
+        "mediaType": OCI_IMAGE,
+        "digest": CHILD_DIGEST,
+        "size": 1234,
+        "platform": {"os": "linux", "architecture": "amd64"},
+        **overrides,
+    }
+
+
+def _index(entries, media_type=OCI_INDEX):
+    return {"schemaVersion": 2, "mediaType": media_type, "manifests": entries}
+
+
+def _encoded(payload):
+    raw = json.dumps(payload).encode()
+    return raw, "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    "index_type,image_type", [(OCI_INDEX, OCI_IMAGE), (DOCKER_INDEX, DOCKER_IMAGE)]
+)
+def test_selects_amd64_not_attestation_or_array_position(reverse, index_type, image_type):
+    entries = [
+        _descriptor(mediaType=image_type),
+        _descriptor(
+            digest="sha256:" + "b" * 64,
+            platform={"os": "unknown", "architecture": "unknown"},
+            annotations={"vnd.docker.reference.type": "attestation-manifest"},
+        ),
+    ]
+    if reverse:
+        entries.reverse()
+    raw, digest = _encoded(_index(entries, index_type))
+    assert _resolver().resolve_manifest(raw, digest) == {
+        "digest": CHILD_DIGEST,
+        "selection": "linux/amd64",
+    }
+
+
+@pytest.mark.parametrize("media_type", [OCI_IMAGE, DOCKER_IMAGE])
+def test_direct_manifest_keeps_original_digest(media_type):
+    raw, digest = _encoded({"schemaVersion": 2, "mediaType": media_type, "layers": []})
+    assert _resolver().resolve_manifest(raw, digest) == {
+        "digest": digest,
+        "selection": "direct_manifest",
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        _index([]),
+        _index([_descriptor(platform={"os": "linux", "architecture": "arm64"})]),
+        _index([_descriptor(), _descriptor()]),
+        _index([_descriptor(digest="sha256:invalid")]),
+        _index([_descriptor(digest="latest")]),
+        _index([_descriptor(mediaType=OCI_INDEX)]),
+        _index([_descriptor(mediaType="unsupported")]),
+        _index([_descriptor(annotations={"vnd.docker.reference.type": "attestation-manifest"})]),
+        _index([_descriptor(artifactType="application/vnd.in-toto+json")]),
+        _index([_descriptor(platform="linux/amd64")]),
+        _index([None]),
+        _index(None),
+        {"schemaVersion": 1, "mediaType": OCI_INDEX},
+        {"schemaVersion": 2, "mediaType": "unsupported"},
+        {"schemaVersion": 2, "mediaType": {}},
+        [],
+    ],
+)
+def test_rejects_missing_ambiguous_or_malformed_executable(payload):
+    raw, digest = _encoded(payload)
+    with pytest.raises(ValueError):
+        _resolver().resolve_manifest(raw, digest)
+
+
+def test_rejects_bytes_not_bound_to_pinned_index():
+    raw, digest = _encoded(_index([_descriptor()]))
+    with pytest.raises(ValueError, match="do not match"):
+        _resolver().resolve_manifest(raw + b" ", digest)
+    with pytest.raises(ValueError, match="do not match"):
+        _resolver().resolve_manifest(raw, "sha256:" + "c" * 64)
+    with pytest.raises(ValueError, match="immutable"):
+        _resolver().resolve_manifest(raw, "latest")
+    assert _resolver().resolve_manifest(raw + b"\n", digest)["digest"] == CHILD_DIGEST
+
+
+@pytest.mark.parametrize("matches", [True, False])
+def test_actual_candidate_gate_keeps_exact_digest_equality(tmp_path: Path, matches: bool):
+    workflow = yaml.safe_load((ROOT / ".github/workflows/deploy-uat.yml").read_text())
+    step = next(
+        step
+        for step in workflow["jobs"]["deploy"]["steps"]
+        if step.get("name") == "Verify backend candidate readiness and exact-SHA provenance"
+    )
+    script = step["run"].split("python3 - <<'PY'\n", 1)[1].split("\nPY", 1)[0]
+    for name in ("uat-backend-candidate.json", "uat-backend-candidate-readiness.json"):
+        script = script.replace(
+            f"/tmp/{name}",  # noqa: S108 - redirect workflow fixtures to pytest isolation
+            (tmp_path / name).as_posix(),
+        )
+    image = "gcr.io/hushh-pda-uat/consent-protocol@" + CHILD_DIGEST
+    provenance = {
+        "HUSHH_DEPLOY_SHA": "c" * 40,
+        "HUSHH_DEPLOY_ENV": "uat",
+        "HUSHH_DEPLOY_SOURCE": "deploy-uat",
+        "HUSHH_DEPLOY_RUN_ID": "123",
+    }
+    revision = {
+        "metadata": {
+            "name": "candidate",
+            "labels": {
+                "deploy-sha": "c" * 40,
+                "deploy-env": "uat",
+                "deploy-source": "deploy-uat",
+                "account-deletion-contract": "v201",
+            },
+        },
+        "spec": {
+            "containers": [
+                {
+                    "image": image,
+                    "env": [{"name": name, "value": value} for name, value in provenance.items()],
+                }
+            ]
+        },
+        "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+    }
+    (tmp_path / "uat-backend-candidate.json").write_text(json.dumps(revision))
+    environment = {
+        **os.environ,
+        "BACKEND_REVISION": "candidate",
+        "EXPECTED_SHA": "c" * 40,
+        "GITHUB_RUN_ID": "123",
+        "EXPECTED_IMAGE_REFERENCE": image
+        if matches
+        else "gcr.io/hushh-pda-uat/consent-protocol@sha256:" + "b" * 64,
+    }
+    result = subprocess.run(  # noqa: S603 - extracted trusted Python gate, inert fixed fixtures
+        [sys.executable, "-c", script],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    report = json.loads((tmp_path / "uat-backend-candidate-readiness.json").read_text())
+    assert (result.returncode == 0) is matches, result.stderr
+    assert report["checks"]["immutable_image"] is matches
+    assert all(value for key, value in report["checks"].items() if key != "immutable_image")

--- a/scripts/ci/resolve-cloud-run-image.py
+++ b/scripts/ci/resolve-cloud-run-image.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Pin Cloud Run's executable manifest without dropping build attestations.
+
+Buildx may publish an image index containing both linux/amd64 and an attestation.
+Cloud Run records the selected executable digest, not that parent index digest.
+Resolve this once, before the deletion fence, so later checks remain exact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+INDEX_TYPES = {
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+}
+IMAGE_TYPES = {
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+}
+
+
+def _digest(value: Any) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", value):
+        raise ValueError("Image digest must be an immutable sha256 digest")
+    return value
+
+
+def resolve_manifest(raw: bytes, expected_digest: str) -> dict[str, str]:
+    expected_digest = _digest(expected_digest)
+    # Some CLI versions append a presentation newline to --raw. Accept only
+    # bytes whose cryptographic digest matches, never reserialized JSON.
+    if not any(
+        "sha256:" + hashlib.sha256(candidate).hexdigest() == expected_digest
+        for candidate in (raw, raw.removesuffix(b"\n"))
+    ):
+        raise ValueError("Manifest bytes do not match the pinned image digest")
+    manifest = json.loads(raw)
+    if not isinstance(manifest, dict) or manifest.get("schemaVersion") != 2:
+        raise ValueError("Expected a schemaVersion 2 image manifest or index")
+    media_type = manifest.get("mediaType")
+    if not isinstance(media_type, str):
+        raise ValueError("Image media type must be a string")
+    if media_type in IMAGE_TYPES:
+        return {"digest": expected_digest, "selection": "direct_manifest"}
+    if media_type not in INDEX_TYPES:
+        raise ValueError("Unsupported image media type")
+    entries = manifest.get("manifests")
+    if not isinstance(entries, list) or not all(
+        isinstance(item, dict) for item in entries
+    ):
+        raise ValueError("Image index must contain manifest descriptors")
+    eligible = []
+    for entry in entries:
+        platform = entry.get("platform") or {}
+        annotations = entry.get("annotations") or {}
+        if not isinstance(platform, dict) or not isinstance(annotations, dict):
+            raise ValueError("Malformed manifest platform or annotations")
+        if (
+            platform.get("os") == "linux"
+            and platform.get("architecture") == "amd64"
+            and annotations.get("vnd.docker.reference.type") != "attestation-manifest"
+            and not entry.get("artifactType")
+        ):
+            eligible.append(entry)
+    if len(eligible) != 1:
+        raise ValueError("Expected exactly one executable linux/amd64 manifest")
+    selected = eligible[0]
+    if (
+        not isinstance(selected.get("mediaType"), str)
+        or selected["mediaType"] not in IMAGE_TYPES
+    ):
+        raise ValueError("Executable descriptor must be an image, not a nested index")
+    return {"digest": _digest(selected.get("digest")), "selection": "linux/amd64"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image-reference", required=True)
+    parser.add_argument("--manifest-json", required=True)
+    parser.add_argument("--json-output", type=Path, required=True)
+    parser.add_argument("--sha", required=True)
+    args = parser.parse_args()
+    try:
+        repository, separator, index_digest = args.image_reference.partition("@")
+        if not separator or not repository or any(c.isspace() for c in repository):
+            raise ValueError("Expected an immutable repository@sha256 image reference")
+        raw = (
+            sys.stdin.buffer.read()
+            if args.manifest_json == "-"
+            else Path(args.manifest_json).read_bytes()
+        )
+        resolved = resolve_manifest(raw, index_digest)
+        image_reference = f"{repository}@{resolved['digest']}"
+        report = {
+            "status": "pinned",
+            "repository": repository,
+            "index_reference": args.image_reference,
+            "image_reference": image_reference,
+            "digest_algorithm": "sha256",
+            "selection": resolved["selection"],
+            "sha": args.sha,
+        }
+        args.json_output.write_text(
+            json.dumps(report, indent=2, sort_keys=True), encoding="utf-8"
+        )
+    except (OSError, ValueError, TypeError) as exc:
+        print(f"Cannot pin Cloud Run image: {exc}", file=sys.stderr)
+        return 1
+    print(image_reference)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/resolve-cloud-run-image.py
+++ b/scripts/ci/resolve-cloud-run-image.py
@@ -24,12 +24,39 @@ IMAGE_TYPES = {
     "application/vnd.oci.image.manifest.v1+json",
     "application/vnd.docker.distribution.manifest.v2+json",
 }
+CONFIG_TYPES = {
+    "application/vnd.oci.image.config.v1+json",
+    "application/vnd.docker.container.image.v1+json",
+}
 
 
 def _digest(value: Any) -> str:
     if not isinstance(value, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", value):
         raise ValueError("Image digest must be an immutable sha256 digest")
     return value
+
+
+def _validate_descriptor(value: Any) -> None:
+    if not isinstance(value, dict):
+        raise ValueError("Image descriptor must be an object")
+    _digest(value.get("digest"))
+    size = value.get("size")
+    if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+        raise ValueError("Image descriptor size must be a nonnegative integer")
+    if not isinstance(value.get("mediaType"), str) or not value["mediaType"]:
+        raise ValueError("Image descriptor media type is missing")
+
+
+def _validate_direct_image(manifest: dict[str, Any]) -> None:
+    config = manifest.get("config")
+    _validate_descriptor(config)
+    if config["mediaType"] not in CONFIG_TYPES:
+        raise ValueError("Direct image requires an executable image config")
+    layers = manifest.get("layers")
+    if not isinstance(layers, list):
+        raise ValueError("Direct image layers must be a list")
+    for layer in layers:
+        _validate_descriptor(layer)
 
 
 def resolve_manifest(raw: bytes, expected_digest: str) -> dict[str, str]:
@@ -44,10 +71,19 @@ def resolve_manifest(raw: bytes, expected_digest: str) -> dict[str, str]:
     manifest = json.loads(raw)
     if not isinstance(manifest, dict) or manifest.get("schemaVersion") != 2:
         raise ValueError("Expected a schemaVersion 2 image manifest or index")
+    annotations = manifest.get("annotations", {})
+    if not isinstance(annotations, dict):
+        raise ValueError("Image annotations must be an object")
+    if (
+        "artifactType" in manifest
+        or annotations.get("vnd.docker.reference.type") == "attestation-manifest"
+    ):
+        raise ValueError("An artifact cannot be pinned as an executable image")
     media_type = manifest.get("mediaType")
     if not isinstance(media_type, str):
         raise ValueError("Image media type must be a string")
     if media_type in IMAGE_TYPES:
+        _validate_direct_image(manifest)
         return {"digest": expected_digest, "selection": "direct_manifest"}
     if media_type not in INDEX_TYPES:
         raise ValueError("Unsupported image media type")
@@ -58,20 +94,21 @@ def resolve_manifest(raw: bytes, expected_digest: str) -> dict[str, str]:
         raise ValueError("Image index must contain manifest descriptors")
     eligible = []
     for entry in entries:
-        platform = entry.get("platform") or {}
-        annotations = entry.get("annotations") or {}
+        platform = entry.get("platform", {})
+        annotations = entry.get("annotations", {})
         if not isinstance(platform, dict) or not isinstance(annotations, dict):
             raise ValueError("Malformed manifest platform or annotations")
         if (
             platform.get("os") == "linux"
             and platform.get("architecture") == "amd64"
             and annotations.get("vnd.docker.reference.type") != "attestation-manifest"
-            and not entry.get("artifactType")
+            and "artifactType" not in entry
         ):
             eligible.append(entry)
     if len(eligible) != 1:
         raise ValueError("Expected exactly one executable linux/amd64 manifest")
     selected = eligible[0]
+    _validate_descriptor(selected)
     if (
         not isinstance(selected.get("mediaType"), str)
         or selected["mediaType"] not in IMAGE_TYPES


### PR DESCRIPTION
# Description

Recover the UAT rollout for #6537 and #6544 by pinning the exact executable image before the account-deletion fence and migration. Keep acceptance tracking open in #6490.

[UAT run 33991970377](https://github.com/hushh-labs/hushh-research/actions/runs/33991970377) successfully built and deployed a no-traffic backend candidate, but the readiness gate rejected `immutable_image`. Its other ten checks passed. Registry inspection proves the submitted immutable OCI index contains the exact Linux/AMD64 executable Cloud Run reports; the second child is a build attestation. Comparing the index digest to the executable digest was incorrect.

The pre-fence build/pin step now resolves that executable once. The later exact-image gate remains unchanged. Attestations stay in the registry, and release evidence records both the original immutable index and selected executable plus raw manifest bytes.

## 📌 Impact Map (Required)

- Routes, APIs, schema, cache keys, runtime DB data plane and world-model summaries: no changes.
- Mobile parity: no web, Swift or Kotlin product changes in this deployment-only follow-up.
- Docs: runtime rationale is in the helper/workflow; release evidence and the 17-case manual matrix are maintained in #6490.
- Config/devex: existing UAT `Build and pin backend image before lifecycle migration` calls `scripts/ci/resolve-cloud-run-image.py`; its behavior tests are in the existing backend CI manifest.
- Trust boundary: immutable deployment provenance. Registry bytes must hash to the pinned parent digest; selection is same-repository, unambiguous, executable Linux/AMD64. No authority, credential, IAM, traffic or security-gate bypass.
- Caller/proxy/backend pairing: not applicable; release pipeline only.
- Safe failure: unknown/ambiguous/malformed/tampered manifests fail before publishing the image output or installing the deletion fence. Existing strict candidate equality, no-traffic rollout, migration, scheduler and activation controls remain unchanged.
- Browser proof: not applicable to the deployment-only diff; live public-login and protected browser verification remain required for the subsequent successful combined rollout.

## ✅ Review-Ready Contract

- [x] Title, code and tests describe the same reachable deployment contract.
- [x] Existing pinning and provenance authorities inspected; no parallel runtime or relaxed verifier introduced.
- [x] Production attach point: pre-fence image resolution in `deploy-uat.yml`.
- [x] Tests exercise the actual workflow body, production resolver, and actual candidate gate.
- [x] Original workflow characterized RED: it emitted the parent index instead of the executable digest.
- [x] Live read-only registry replay through the new helper resolves the exact digest in the failed candidate revision.
- [x] Current exact-head CI, DCO, governance and independent read-only regression review are complete. This is not an independent human approval.

## 🛑 Tri-Flow Architecture Check

Web, iOS and Android product layers: not applicable to this deployment-only change. Their account/session implementation remains in #6537.

## 🧪 Testing

- 83 focused release/image-resolution/Cloud Build/no-traffic/readiness tests passed twice after final hardening.
- Covers OCI and Docker indexes, reversed descriptor order, attestations, direct manifests, wrong architecture, duplicate/missing executables, bad digests, malformed payloads, nested indexes, byte tampering and strict candidate mismatch rejection.
- Workflow-level negative case verifies a wrong-platform index cannot publish an image reference.
- Ruff check/format and Python compilation pass; managed Vertex manifest collection passes with the UAT model setting without a provider call.
- Independent read-only review found and then confirmed closure of direct-image artifact/structure and malformed-descriptor gaps. Twelve additional negative cases cover those boundaries; eleven reproduced RED before the fix.
- Live immutable registry-byte replay passed twice, including after final hardening.
- [Exact-head CI 33993599637](https://github.com/hushh-labs/hushh-research/actions/runs/33993599637) passed for `cdda3e3e331e6394889ef4a9be9befc1f73e994c`: Protocol 2,232 passed / 2 intentional skips, Web Core production build/typecheck/lint, integration, MCP, governance, secret scan, DCO and CI Status Gate. Web Targeted completed successfully with no focused pack selected for the five deployment-only files; iOS Native was intentionally skipped. No new rendered-browser or native acceptance is claimed here.
- Final repository governance, DCO and secret scans pass locally. The pre-PR Python wrapper launches unavailable WSL Bash on this Windows host. Its underlying canonical `./bin/hushh ci` was run through Git Bash: governance, web design/docs and TypeScript passed, then ESLint traversed existing generated `.next-codex-preview` bundles. That owned redundant lint process was stopped after clean hosted Web Core passed; preview files were preserved. The full local mirror is incomplete, not green, and no test skip flag or tracked configuration was introduced.

### Landing status

Merged by DamriaNeelesh on 2026-09-05 at 21:57 UTC into main `c7d070860a721d703adfc2c27adc4268b24d7e7e`. The landed tree exactly matches reviewed head `cdda3e3e331e6394889ef4a9be9befc1f73e994c`. [Main smoke 33994497011](https://github.com/hushh-labs/hushh-research/actions/runs/33994497011) passed. [UAT run 33994606818](https://github.com/hushh-labs/hushh-research/actions/runs/33994606818) is running for the exact landed SHA with requested `scope=auto`; successful deployment and activation are not yet claimed. The prior ordinary merge request had been review-blocked; the user performed the landing, and no Queue Validation is claimed. Production and native distribution remain out of scope.

## 📸 Screenshots / Video

Not applicable: no rendered UI changes. Live successful UAT acceptance is not claimed by this PR.

## 🛡️ Privacy & Consent

Tests use inert fixtures and intercept all cloud/build commands. Registry inspection is read-only and uses the existing credential helper; no secrets are stored in fixtures or logs. No production deployment, native distribution, security-gate relaxation or manual traffic repair is included.

## 📜 Licensing

First-party changes remain Apache-2.0 compatible; no dependency or third-party notice changes.
