### PR TITLE
fix(android): prevent agents from showing behind search

### DIFF
--- a/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
@@ -1,10 +1,21 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OneDashboardPage } from "@/components/dashboard/one-dashboard-page";
 import { buildOneSetupCapabilityRoute, ROUTES } from "@/lib/navigation/routes";
 import type { CapabilityStatus } from "@/lib/services/capability-setup-state-service";
 import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
+
+const platformHarness = vi.hoisted(() => ({ isAndroid: false }));
+
+vi.mock("@/lib/capacitor/platform", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/capacitor/platform")>();
+  return {
+    ...actual,
+    isAndroid: () => platformHarness.isAndroid,
+  };
+});
 
 function status(
   id: string,
@@ -46,6 +57,7 @@ function countRosterMetrics(
 
 describe("OneDashboardPage", () => {
   beforeEach(() => {
+    platformHarness.isAndroid = false;
     window.localStorage.clear();
   });
 
@@ -91,7 +103,7 @@ describe("OneDashboardPage", () => {
     expect(screen.getByTestId("one-agents-section")).toBeTruthy();
     expect(screen.getByTestId("one-agents-list")).toBeTruthy();
     expect(container.textContent).not.toContain("Finish setup");
-    expect(screen.getByRole("heading", { name: "Agents (8)" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Agents (9)" })).toBeTruthy();
 
     // Every dashboard tile enters the same static setup workspace as the hub.
     // A resolved journey is redirected by that workspace to the normal product
@@ -102,13 +114,14 @@ describe("OneDashboardPage", () => {
     );
     const expectedProfileFormatIcons = [
       "finance",
+      "wallet",
+      "location",
       "ria",
       "gmail",
       "calendar",
       "email",
       "pkm",
       "consent",
-      "location",
     ] as const;
     for (const id of expectedProfileFormatIcons) {
       const icon = screen.getAllByTestId(`one-agent-icon-${id}`)[0];
@@ -122,12 +135,11 @@ describe("OneDashboardPage", () => {
       "--agent-icon-profile-fg": "#5856D6",
     });
     // Palette slots are assigned by roster position, so this list must track
-    // ONE_CAPABILITIES order. Location moved from sixth to second, which shifts
-    // the five agents it passed by one slot each — a deliberate consequence of
-    // the reorder, not an incidental one: the palette exists to keep adjacent
-    // rows distinguishable, and that property is preserved.
+    // ONE_CAPABILITIES order: the palette exists to keep adjacent rows
+    // distinguishable, and that property is preserved.
     const rosterPaletteOrder = [
       "finance",
+      "wallet",
       "location",
       "ria",
       "gmail",
@@ -150,6 +162,7 @@ describe("OneDashboardPage", () => {
       "5",
       "6",
       "7",
+      "8",
     ]);
     const iconBackgrounds = Object.fromEntries(
       rosterPaletteOrder.map((id) => [
@@ -160,6 +173,7 @@ describe("OneDashboardPage", () => {
       ]),
     );
     expect(iconBackgrounds.ria).toBe(iconBackgrounds.finance);
+    expect(iconBackgrounds.wallet).toBe(iconBackgrounds.location);
     expect(iconBackgrounds.gmail).toBe(iconBackgrounds.location);
     expect(iconBackgrounds.calendar).toBe(iconBackgrounds.location);
     expect(iconBackgrounds.email).toBe(iconBackgrounds.location);
@@ -184,6 +198,9 @@ describe("OneDashboardPage", () => {
     expect(financeLink.className).not.toContain("border-emerald-500");
     expect(financeLink.getAttribute("style") ?? "").not.toContain("background");
     expect(
+      screen.getByRole("link", { name: "Open Wallet" }).getAttribute("href"),
+    ).toBe(ROUTES.ONE_WALLET);
+    expect(
       screen.getByRole("link", { name: "Open Gmail" }).getAttribute("href"),
     ).toBe(buildOneSetupCapabilityRoute("gmail"));
     expect(
@@ -203,9 +220,9 @@ describe("OneDashboardPage", () => {
     expect(countRosterMetrics(container, "—", "checking")).toBeGreaterThan(0);
     expect(screen.queryByText("Ready")).toBeNull();
     expect(screen.queryByText("Explore")).toBeNull();
-    // Gmail and Calendar are first-class setup capabilities; Memory and
-    // Consent remain direct workspaces and do not inflate setup progress.
-    expect(container.querySelectorAll('a[aria-label^="Open "]').length).toBe(8);
+    // Gmail and Calendar are first-class setup capabilities; Wallet, Memory,
+    // and Consent remain direct workspaces and do not inflate setup progress.
+    expect(container.querySelectorAll('a[aria-label^="Open "]').length).toBe(9);
     expect(
       screen.getByRole("link", { name: "Open Memory" }).getAttribute("href"),
     ).toBe(ROUTES.PKM);
@@ -238,7 +255,7 @@ describe("OneDashboardPage", () => {
     // Completed workspace setup is represented as an operational KPI rather
     // than the generic Ready label.
     expect(countRosterMetrics(container, "0", "actions")).toBe(6);
-    expect(screen.getByRole("heading", { name: "Agents (8)" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Agents (9)" })).toBeTruthy();
     expect(screen.queryByText("Finish setup")).toBeNull();
   });
 
@@ -288,6 +305,34 @@ describe("OneDashboardPage", () => {
     expect(screen.getByTestId("one-agents-view-content")).toHaveClass(
       "motion-step-enter",
     );
+  });
+
+  it("clips the roster view paint on Android without changing the controls", () => {
+    platformHarness.isAndroid = true;
+    window.localStorage.setItem("hushh:one-agent-roster-view", "grid");
+
+    render(<OneDashboardPage displayName="Kushal Trivedi" />);
+
+    const content = screen.getByTestId("one-agents-view-content");
+    expect(content.className).toContain("isolate");
+    expect(content.className).toContain("overflow-hidden");
+    expect(content.className).toContain("[clip-path:inset(0)]");
+    expect(content.className).toContain("[contain:layout_paint]");
+    expect(content).toHaveAttribute("data-no-auto-fade", "true");
+    expect(content).not.toHaveClass("motion-step-enter");
+    expect(screen.getByRole("heading", { name: "Agents (9)" })).toBeTruthy();
+    expect(screen.getByTestId("one-agents-search")).toBeTruthy();
+    expect(screen.getByTestId("one-agents-view-grid")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByTestId("one-agent-tile-finance")).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Show agent list view"));
+    const listContent = screen.getByTestId("one-agents-view-content");
+    expect(listContent).not.toHaveClass("motion-step-enter");
+    expect(listContent).toHaveAttribute("data-no-auto-fade", "true");
+    expect(screen.getByTestId("one-agents-list")).toBeTruthy();
   });
 
   it("filters the local agent roster without opening a second global search surface", () => {

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -18,6 +18,7 @@ import {
   getCapabilityStatusDisplay,
   type CapabilityStatusTone,
 } from "@/lib/onboarding/capability-status-display";
+import { isAndroid } from "@/lib/capacitor/platform";
 import { getCapabilitySetupCopy } from "@/lib/onboarding/capability-setup-copy";
 import { buildOneSetupCapabilityRoute } from "@/lib/navigation/routes";
 import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
@@ -118,6 +119,10 @@ function readPersistedRosterView(): AgentRosterView {
   } catch {
     return "list";
   }
+}
+
+function readNativeAndroidRosterSurface(): boolean {
+  return typeof window !== "undefined" && isAndroid();
 }
 
 function positiveNumber(value: unknown): number | null {
@@ -672,6 +677,9 @@ export function OneAgentRoster({
   );
   const modes = buildModes(capabilityStatusById, cachedMetrics, setupDismissed);
   const [view, setView] = useState<AgentRosterView>(readPersistedRosterView);
+  const [usesAndroidCompositorGuard] = useState(
+    readNativeAndroidRosterSurface,
+  );
   const [animateViewChange, setAnimateViewChange] = useState(false);
   const [query, setQuery] = useState("");
   const visibleModes = useMemo(() => {
@@ -736,7 +744,14 @@ export function OneAgentRoster({
       <div
         key={view}
         data-testid="one-agents-view-content"
-        className={animateViewChange ? "motion-step-enter" : undefined}
+        data-no-auto-fade={usesAndroidCompositorGuard ? "true" : undefined}
+        className={cn(
+          usesAndroidCompositorGuard &&
+            "isolate overflow-hidden [clip-path:inset(0)] [contain:layout_paint]",
+          animateViewChange &&
+            !usesAndroidCompositorGuard &&
+            "motion-step-enter",
+        )}
       >
         {view === "grid" ? (
           <div


### PR DESCRIPTION
## Summary
- Add an Android-only compositor guard around the One agents roster view.
- Preserve iOS/web animation behavior while preventing Android WebView stale grid paint from bleeding above the search field.
- Cover the Android path with a focused dashboard regression test.
