### PR TITLE
chore(ios): open marketing version train 1.4.0

### DIFF
--- a/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
@@ -640,7 +640,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.9;
+				MARKETING_VERSION = 1.4.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.hushh.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -669,7 +669,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.9;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hushh.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Why

TestFlight run [34015625554](https://github.com/hushh-labs/hushh-research/actions/runs/34015625554) **built, archived and signed cleanly**, then failed at upload validation on Apple's side:

```
Invalid Pre-Release Train. The train version '1.3.9' is closed for new build submissions
CFBundleShortVersionString [1.3.9] must contain a higher version than the previously approved version [1.3.9]
```

This is the exact case in `ship-testflight`'s troubleshooting table: *"The marketing version is closed on Apple's side. `MARKETING_VERSION` must be bumped and landed on `main`. A `dry_run` will NOT catch this."*

Nothing is wrong with the binary — `iOS Native (Xcode)` was green on the shipped SHA, and the archive step here succeeded. The train is simply closed.

## What changed

Two lines. `MARKETING_VERSION` `1.3.9` → `1.4.0`, in the App target's Debug and Release configurations only.

Deliberately unchanged:
- **AppTests / AppUITests** keep `MARKETING_VERSION = 1.0` — they do not ship.
- **`CURRENT_PROJECT_VERSION`** stays at `69`. The ship workflow resolves a monotonic build number against App Store Connect at build time via `scripts/ci/resolve-ios-build-number.py`; hand-setting it here would collide with that.

`1.4.0` rather than `1.3.10` because the build this unblocks adds user-facing Siri capability. Either opens a valid new train — say the word and I'll change it.

## After merge

Re-dispatch `ship-ios-testflight.yml` against the new main SHA. The Siri work itself already landed in #6542 (`dde3472b5`) and is live on UAT.