### PR TITLE
fix(deploy): preserve least-privilege scheduler activation

### DIFF
--- a/consent-protocol/tests/test_account_deletion_release_workflow.py
+++ b/consent-protocol/tests/test_account_deletion_release_workflow.py
@@ -263,6 +263,58 @@ def test_uat_scheduler_service_account_id_is_valid_and_consistent() -> None:
     ) in deploy_run
     assert "expected_service_account_email" in activation_run
     assert f"SCHEDULER_SERVICE_ACCOUNT_NAME:-{scheduler_account_id}" in scheduler_setup
+    assert "iam service-accounts add-iam-policy-binding" not in scheduler_setup
+    assert "roles/iam.serviceAccountTokenCreator" not in scheduler_setup
+
+
+def test_scheduler_setup_does_not_require_service_account_policy_admin(
+    tmp_path: Path,
+) -> None:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "BACKEND_URL": "https://api.uat.example.com",
+            "PROJECT_ID": "example-uat-project",
+            "SCHEDULER_SERVICE_ACCOUNT_NAME": "account-deletion-cleanup",
+        }
+    )
+    calls = tmp_path / "gcloud-calls"
+    guards = f'''gcloud() {{
+      printf '%s\\n' "$*" >> "{calls.as_posix()}"
+      case "$1 $2 $3" in
+        "iam service-accounts describe") return 0 ;;
+        "scheduler jobs describe")
+          printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' \\
+            'ENABLED' '*/2 * * * *' \\
+            'https://api.uat.example.com/api/account/deletion-cleanup/drain?limit=10' \\
+            'POST' \\
+            'account-deletion-cleanup@example-uat-project.iam.gserviceaccount.com' \\
+            'https://api.uat.example.com'
+          return 0
+          ;;
+        "scheduler jobs update") return 0 ;;
+        *) echo "UNEXPECTED_GCLOUD_COMMAND: $*" >&2; return 96 ;;
+      esac
+    }}
+'''
+    bash = shutil.which("bash")
+    assert bash is not None, "Bash is required for the scheduler behavior test"
+
+    result = subprocess.run(  # noqa: S603 - trusted script with guarded cloud commands
+        [bash, "-c", guards + SCHEDULER_SETUP_SCRIPT.read_text(encoding="utf-8")],
+        cwd=ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "Configured and verified Cloud Scheduler job" in result.stdout
+    assert "UNEXPECTED_GCLOUD_COMMAND" not in output
+    assert "add-iam-policy-binding" not in calls.read_text(encoding="utf-8")
 
 
 @pytest.mark.parametrize(

--- a/deploy/account-deletion/setup_cleanup_scheduler.sh
+++ b/deploy/account-deletion/setup_cleanup_scheduler.sh
@@ -56,12 +56,12 @@ if ! gcloud iam service-accounts describe "${SCHEDULER_SERVICE_ACCOUNT_EMAIL}" \
     --display-name="Account deletion cleanup scheduler" >/dev/null
 fi
 
-PROJECT_NUMBER="$(gcloud projects describe "${PROJECT_ID}" --format='value(projectNumber)')"
-SCHEDULER_SERVICE_AGENT="service-${PROJECT_NUMBER}@gcp-sa-cloudscheduler.iam.gserviceaccount.com"
-gcloud iam service-accounts add-iam-policy-binding "${SCHEDULER_SERVICE_ACCOUNT_EMAIL}" \
-  --project="${PROJECT_ID}" \
-  --member="serviceAccount:${SCHEDULER_SERVICE_AGENT}" \
-  --role="roles/iam.serviceAccountTokenCreator" >/dev/null
+# Cloud Scheduler's Google-managed service agent receives the project-scoped
+# roles/cloudscheduler.serviceAgent grant when the API is enabled. That role is
+# what lets Scheduler mint an OIDC token for this client service account. Do not
+# mutate the client account's IAM policy during an application deployment: it is
+# unnecessary, requires broad iam.serviceAccounts.setIamPolicy permission, and
+# would make every otherwise-safe scheduler repair depend on IAM-admin access.
 
 URI="${BACKEND_URL%/}/api/account/deletion-cleanup/drain?limit=${BATCH_LIMIT}"
 COMMON_ARGS=(


### PR DESCRIPTION
## Incident

UAT run 34028275965 proved the scheduler service-account ID fix, created `account-deletion-cleanup`, and then failed because the deploy workflow attempted to mutate that account's IAM policy. The constrained deployer correctly lacks `iam.serviceAccounts.setIamPolicy`.

## Fix

- remove the unnecessary per-client-service-account `roles/iam.serviceAccountTokenCreator` binding
- rely on the Google-managed Cloud Scheduler service agent's project-scoped `roles/cloudscheduler.serviceAgent` grant for OIDC minting
- keep the dedicated client service account, OIDC audience, job configuration, fresh 2xx execution evidence, legacy-revision retirement, and release fence unchanged
- add a regression test that executes the real setup script with IAM-policy administration unavailable

This preserves least privilege and prevents UAT application deployment from depending on IAM-admin authority.

## Verification

- scheduler release bundle, twice: `98 passed, 1 skipped`
- full consent-protocol Ruff check: passed
- Ruff format check: `1052 files already formatted`
- shell syntax and `git diff --check`: passed

Refs #6490
