### PR TITLE
fix(location): trim the map sheet's copy

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -760,7 +760,7 @@ describe("LocationImmersiveMap demo experience", () => {
     expect(screen.getByText("No one sharing yet")).toBeInTheDocument();
     // The row below the header is where the audience is named in full.
     expect(
-      screen.getByText("No one is sharing your location"),
+      screen.getByText("No one is sharing their location"),
     ).toBeInTheDocument();
     expect(
       screen.queryByText("0 people sharing with you"),

--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -757,8 +757,10 @@ describe("LocationImmersiveMap demo experience", () => {
     // Named audience. The header used to read "No one sharing yet" over a
     // subtitle reading "Sharing with 1", which is two true statements about
     // two different audiences stacked as though they were one.
+    expect(screen.getByText("No one sharing yet")).toBeInTheDocument();
+    // The row below the header is where the audience is named in full.
     expect(
-      screen.getByText("No one sharing with you yet"),
+      screen.getByText("No one is sharing your location"),
     ).toBeInTheDocument();
     expect(
       screen.queryByText("0 people sharing with you"),
@@ -2157,12 +2159,11 @@ describe("LocationImmersiveMap reported map defects", () => {
     const ghost = screen.getByTestId("one-location-map-ghost-toggle");
     expect(ghost).toHaveAttribute("role", "switch");
     expect(ghost).toHaveAttribute("data-state", "checked");
-    // The rule, stated under the switch that used to break it.
+    // The switch is the whole control now: a name and an on/off state, with
+    // no paragraph under it restating what the two rows above already say.
     expect(
-      screen.getByText(
-        "Hidden from general visibility. The 2 people you share with privately still see you.",
-      ),
-    ).toBeInTheDocument();
+      screen.getByTestId("one-location-map-ghost"),
+    ).toHaveTextContent(/^Ghost Mode$/);
 
     // Check-in is still here and still one tap away -- it is just no longer
     // the loudest thing on a sheet that is not about it.

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -2347,10 +2347,11 @@ export function LocationImmersiveMap({
     }
     return markers.length > 0
       ? `${markers.length} on your map`
-      : // "No one sharing yet" beside a subtitle reading "Sharing with 1" was
-        // the reported contradiction. Naming the audience resolves it without
-        // making the row any longer.
-        "No one sharing with you yet";
+      : // The subtitle that made this read as a contradiction ("Sharing with
+        // 1" under "No one sharing yet") is gone, and the row below states
+        // the incoming audience in full -- so the header stays the shorter of
+        // the two rather than printing that sentence twice on one screen.
+        "No one sharing yet";
   }, [markers.length, nearbyAttendees.length, nearbyPresenceState.presence]);
 
   // Only when it adds something the title cannot. Restating the title in
@@ -2366,7 +2367,7 @@ export function LocationImmersiveMap({
    */
   const incomingShareLabel =
     markers.length === 0
-      ? "No one sharing with you"
+      ? "No one is sharing your location"
       : markers.length === 1
         ? "1 person sharing with you"
         : `${markers.length} people sharing with you`;
@@ -2376,7 +2377,7 @@ export function LocationImmersiveMap({
   const privateShareLabel = !privateShareCountKnown
     ? "Private sharing"
     : privateShareCount === 0
-      ? "Not sharing with anyone privately"
+      ? "Not sharing with anyone"
       : privateShareCount === 1
         ? "Private sharing with 1 person"
         : `Private sharing with ${privateShareCount} people`;
@@ -2405,31 +2406,12 @@ export function LocationImmersiveMap({
       ? // The lifetime, because it is the thing a person actually wonders
         // about a share they started days ago -- and because it is now true
         // without an asterisk: Ghost Mode no longer ends it early.
-        "Runs until you stop it or it expires"
-      : "Start one from Location to appear on their map";
+        "Runs until you stop it"
+      : "Start a share to appear on their map";
 
   /** Anything other than an explicit "visible" is treated as hidden, so an
    *  unrecognised value from an older server errs toward privacy. */
   const isGhostMode = preferences.presenceMode !== "foreground_private";
-
-  /**
-   * The rule, stated where it is switched.
-   *
-   * The old control said "Ghost Mode is on. Nobody sees you on their map",
-   * which was true only because Ghost was silently cancelling private shares
-   * the person had deliberately started. With that gone, the sentence has to
-   * name the audience it does not touch -- and it sits directly under the
-   * count of that audience, so the two lines are read together.
-   */
-  const ghostModeExplainer = isGhostMode
-    ? privateShareCount > 0
-      ? `Hidden from general visibility. The ${
-          privateShareCount === 1 ? "person" : `${privateShareCount} people`
-        } you share with privately still see you.`
-      : "Hidden from general visibility."
-    : privateShareCount > 0
-      ? "Not hidden from anyone. Private sharing is separate either way."
-      : "Not hidden from anyone.";
 
   /** Check-in is a separate one-time share, and this is the one place that
    *  decides whether it has a control on this sheet at all. */
@@ -2954,9 +2936,7 @@ export function LocationImmersiveMap({
               >
                 <UsersRound className="h-4 w-4 shrink-0" />
                 <span className="truncate">
-                  {nearbyPresenceState.presence
-                    ? "Checked in"
-                    : "Check in nearby"}
+                  {nearbyPresenceState.presence ? "Checked in" : "Check in"}
                 </span>
               </ShellActionSurface>
             ) : null}
@@ -3586,7 +3566,7 @@ export function LocationImmersiveMap({
                           : // The header already says no one is sharing. This
                             // line spends itself on the part the header cannot:
                             // what it takes to appear here.
-                            "Pins appear once they share with maps on."}
+                            "Pins appear when someone shares."}
                       </p>
                     ) : null}
                   </div>
@@ -3676,11 +3656,14 @@ export function LocationImmersiveMap({
                       <span className="block truncate text-sm font-medium">
                         {incomingShareLabel}
                       </span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {markers.length > 0
-                          ? "Tap to fit everyone on the map"
-                          : "Ghost Mode never hides them from you"}
-                      </span>
+                      {/* Only when it adds something the title cannot. The
+                        empty state has nothing to fit on the map, so it says
+                        nothing rather than restating the line above it. */}
+                      {markers.length > 0 ? (
+                        <span className="block truncate text-xs text-muted-foreground">
+                          Tap to fit everyone on the map
+                        </span>
+                      ) : null}
                     </span>
                     <ChevronDown
                       className="h-4 w-4 shrink-0 -rotate-90 text-muted-foreground"
@@ -3784,15 +3767,10 @@ export function LocationImmersiveMap({
                       )}
                     </span>
                     <label
-                      className="min-w-0 flex-1 cursor-pointer"
+                      className="min-w-0 flex-1 cursor-pointer text-sm font-medium"
                       htmlFor="one-location-map-ghost-toggle"
                     >
-                      <span className="block text-sm font-medium">
-                        Ghost Mode
-                      </span>
-                      <span className="block text-xs text-muted-foreground">
-                        {ghostModeExplainer}
-                      </span>
+                      Ghost Mode
                     </label>
                     <Switch
                       id="one-location-map-ghost-toggle"
@@ -3858,7 +3836,7 @@ export function LocationImmersiveMap({
                         <span className="truncate">
                           {nearbyPresenceState.presence
                             ? "Checked in"
-                            : "Check in nearby"}
+                            : "Check in"}
                         </span>
                       </Button>
                     ) : null}

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -2367,7 +2367,7 @@ export function LocationImmersiveMap({
    */
   const incomingShareLabel =
     markers.length === 0
-      ? "No one is sharing your location"
+      ? "No one is sharing their location"
       : markers.length === 1
         ? "1 person sharing with you"
         : `${markers.length} people sharing with you`;
@@ -2403,10 +2403,10 @@ export function LocationImmersiveMap({
   const privateShareHint = !privateShareCountKnown
     ? "Checking your active shares…"
     : privateShareCount > 0
-      ? // The lifetime, because it is the thing a person actually wonders
-        // about a share they started days ago -- and because it is now true
-        // without an asterisk: Ghost Mode no longer ends it early.
-        "Runs until you stop it"
+      ? // Nothing. The row expands to the names, which is what a person opens
+        // it for; a line about the lifetime of a share they can see listed
+        // was one more sentence to read past.
+        null
       : "Start a share to appear on their map";
 
   /** Anything other than an explicit "visible" is treated as hidden, so an
@@ -3696,9 +3696,11 @@ export function LocationImmersiveMap({
                           <span className="block truncate text-sm font-medium">
                             {privateShareLabel}
                           </span>
-                          <span className="block truncate text-xs text-muted-foreground">
-                            {privateShareHint}
-                          </span>
+                          {privateShareHint ? (
+                            <span className="block truncate text-xs text-muted-foreground">
+                              {privateShareHint}
+                            </span>
+                          ) : null}
                         </span>
                         {privateShareCount > 0 ? (
                           <ChevronDown


### PR DESCRIPTION
## What

The Location map sheet said the same thing in three places and explained a switch in a sentence the switch already carries. This is a copy-only pass over that sheet.

| Before | After |
|---|---|
| No one sharing with you yet *(sheet header)* | No one sharing yet |
| No one sharing with you / Ghost Mode never hides them from you | **No one is sharing their location** *(no subtitle)* |
| Not sharing with anyone privately / Start one from Location to appear on their map | Not sharing with anyone / Start a share to appear on their map |
| Private sharing with N / Runs until you stop it or it expires | Private sharing with N *(no subtitle — the row expands to the names)* |
| Ghost Mode / Not hidden from anyone. | Ghost Mode — the name and the on/off switch, nothing under it |
| Pins appear once they share with maps on. | Pins appear when someone shares. |
| Check in nearby *(button and top-bar pill)* | Check in |

The header and the incoming row no longer print one sentence twice: the header is the short summary, the row names what is missing. The check-in control keeps `aria-label="Check in nearby"` in both places, where the icon carries no other context.

## Verification

- `vitest run __tests__/components/location-immersive-map.test.tsx components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx __tests__/components/one-location-copy-pass.contract.test.ts` — 139 passed
- `eslint --max-warnings=0` on both changed files — clean
- `tsc --noEmit` — clean

Two assertions in `location-immersive-map.test.tsx` that pinned the old strings were updated; the Ghost Mode one now asserts the row is exactly "Ghost Mode".

No behaviour, no state, no API surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)