### PR TITLE
fix(ria): give RIA's own screens the header Location already has

### DIFF
--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -215,6 +215,8 @@ export default function RiaClientsPage() {
           description={RIA_COPY.clients.description}
           icon={UserRound}
           accent="ria"
+          titleRole="agent"
+          className="[&>div:first-child]:!gap-3.5 [&_[data-slot=page-header-row]]:!items-center"
         />
       </AppPageHeaderRegion>
 

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -2712,6 +2712,8 @@ export default function RiaPicksPage() {
           description={RIA_COPY.picks.description}
           icon={FileSpreadsheet}
           accent="ria"
+          titleRole="agent"
+          className="[&>div:first-child]:!gap-3.5 [&_[data-slot=page-header-row]]:!items-center"
         />
       </AppPageHeaderRegion>
 

--- a/hushh-webapp/app/ria/profile/page.tsx
+++ b/hushh-webapp/app/ria/profile/page.tsx
@@ -59,6 +59,7 @@ export default function RiaProfilePage() {
       eyebrow="RIA"
       title="Profile"
       description="Manage your advisor profile and verification details."
+      titleRole="agent"
       nativeTest={{
         routeId: "ria-profile",
         marker: "ria-profile-page",

--- a/hushh-webapp/components/app-ui/page-sections.tsx
+++ b/hushh-webapp/components/app-ui/page-sections.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 
 import { SurfaceCard, type SurfaceAccent, type SurfaceTone } from "@/components/app-ui/surfaces";
@@ -119,16 +119,50 @@ const ACCENT_STYLES: Record<SectionAccent, {
   },
 };
 
+/**
+ * The agent hero's icon: a filled accent tile, not the outlined square a page
+ * header carries.
+ *
+ * Location drew this inline, so it was the only screen that had it, and the
+ * report was that RIA and Location "should be the same". It is the accent that
+ * makes a screen read as an agent's home rather than a page inside one, so it
+ * lives here with the header it belongs to and every `titleRole="agent"` header
+ * gets it from passing an `icon`.
+ */
+export function AgentHeaderIcon({
+  icon: IconComponent,
+  className,
+  ...props
+}: {
+  icon: LucideIcon;
+  className?: string;
+} & Omit<ComponentPropsWithoutRef<"span">, "children">) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-[12px] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]",
+        className
+      )}
+      {...props}
+    >
+      <IconComponent className="h-6 w-6" strokeWidth={2} />
+    </span>
+  );
+}
+
 function HeaderLeading({
   icon,
   leading,
   iconClassName,
   iconSize,
+  titleRole,
 }: {
   icon?: LucideIcon;
   leading?: ReactNode;
   iconClassName: string;
   iconSize: "md" | "lg";
+  titleRole: "page" | "agent";
 }) {
   if (leading) {
     // Centred, not top-pinned. `self-start` aligned a 44px tile to the top of a
@@ -141,6 +175,16 @@ function HeaderLeading({
 
   if (!icon) {
     return null;
+  }
+
+  // An agent's home gets the filled tile, centred against its much larger
+  // title the same way a `leading` node is.
+  if (titleRole === "agent") {
+    return (
+      <div className="shrink-0 self-center">
+        <AgentHeaderIcon icon={icon} />
+      </div>
+    );
   }
 
   return (
@@ -192,6 +236,7 @@ export function PageHeader({
           <HeaderLeading
             icon={icon}
             leading={leading}
+            titleRole={titleRole}
             iconSize="lg"
             iconClassName={cn(
               "flex shrink-0 items-center justify-center",
@@ -302,6 +347,7 @@ export function SectionHeader({
           <HeaderLeading
             icon={icon}
             leading={leading}
+            titleRole="page"
             iconSize="md"
             iconClassName={cn(
               "flex h-[29px] w-[29px] shrink-0 items-center justify-center rounded-[7px]",

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -83,7 +83,7 @@ import {
 } from "@/components/ui/dialog";
 import { Switch } from "@/components/ui/switch";
 import { LocationPermissionRecoveryCard } from "@/components/one-location/location-permission-recovery-card";
-import { PageHeader } from "@/components/app-ui/page-sections";
+import { AgentHeaderIcon, PageHeader } from "@/components/app-ui/page-sections";
 import {
   ButtonLabel,
   CardTitle,
@@ -2141,15 +2141,9 @@ function LocationPrimaryShareCard({ onClick }: { onClick: () => void }) {
 }
 
 function LocationHeaderIconTile() {
-  return (
-    <span
-      aria-hidden="true"
-      className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-[12px] bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)]"
-      data-testid="one-location-header-icon"
-    >
-      <MapPin className="h-6 w-6" strokeWidth={2} />
-    </span>
-  );
+  // The tile itself now lives with the header primitive, so RIA's agent
+  // screens draw the same one instead of a second copy of these classes.
+  return <AgentHeaderIcon icon={MapPin} data-testid="one-location-header-icon" />;
 }
 
 function LocationSharePulseIcon() {

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -50,6 +50,10 @@ export function RiaPageShell({
   // difference shows up on an iPad or any Capacitor window wider than a
   // phone, which is where "very wide, wrong container" was reported from.
   width = "agent",
+  // "page" for a screen inside RIA (an account, a request, one client's
+  // workspace); "agent" for a screen a person lands on, which wears the same
+  // hero header as Location -- a filled accent tile and the larger title.
+  titleRole = "page",
   className,
   headerClassName,
   contentClassName,
@@ -64,6 +68,7 @@ export function RiaPageShell({
   statusPanel?: ReactNode;
   children: ReactNode;
   width?: AppPageShellWidth;
+  titleRole?: "page" | "agent";
   className?: string;
   headerClassName?: string;
   contentClassName?: string;
@@ -98,8 +103,15 @@ export function RiaPageShell({
           title={title}
           description={description}
           actions={actions}
+          actionsInlineMobile={titleRole === "agent"}
           icon={icon}
           accent="ria"
+          titleRole={titleRole}
+          className={
+            titleRole === "agent"
+              ? "[&>div:first-child]:!gap-3.5 [&_[data-slot=page-header-actions]]:!self-center [&_[data-slot=page-header-row]]:!items-center"
+              : undefined
+          }
         />
       </AppPageHeaderRegion>
 


### PR DESCRIPTION
## Reported

> Header in RIA and Location is different — the layout should be the same. The header for all should be in the format on the Location agent right now.

## What was different

| | Location | RIA (before) |
|---|---|---|
| Icon | 48px **filled** accent tile | 34px outlined tile |
| Title | agent title (large) | page title (small) |
| Actions | centred on the title row | wrapped below on mobile |

The filled tile was drawn inline in the Location hub, so Location was the only screen that could have it.

## Change

- `AgentHeaderIcon` moves into `components/app-ui/page-sections.tsx`, and `PageHeader` renders it for any header with `titleRole="agent"` that passes an `icon`. A screen opts into the whole format with one prop instead of copying class strings.
- Location draws the shared tile now and keeps its `one-location-header-icon` test id.
- `RiaPageShell` takes a `titleRole` (still defaulting to `"page"`).

Adopted on the three RIA screens a person **lands on**: **Clients**, **Picks**, **Profile**.

## Deliberately not changed

The screens **inside** RIA — one client's workspace, an account detail, a request detail — keep the page header. They are arrived at from a RIA screen rather than being RIA's home, and the hero would say otherwise. Marketplace's RIA screen is untouched for the same reason. This matches the scope confirmed with the reporter.

Eyebrow and description are unchanged on every screen: this is the layout, not the words.

## Verification

- 185 tests pass across `page-sections`, the RIA suites and `one-location-agent-page` (which asserts the Location header tile still renders)
- `npm run verify:design-system` passes (design system + accent tokens + Apple hierarchy)
- `eslint --max-warnings=0` and `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)