### PR TITLE
fix(agent): one button for "open One", not four

### DIFF
--- a/hushh-webapp/app/one/email/email-agent-page-client.tsx
+++ b/hushh-webapp/app/one/email/email-agent-page-client.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useCallback } from "react";
-import { CheckCircle2, Mail, MessageCircle } from "lucide-react";
+import { CheckCircle2, Mail } from "lucide-react";
 import { useRouter } from "next/navigation";
 
+import { AskOneButton } from "@/components/agent/ask-one-button";
 import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { useOneConversationSession } from "@/lib/agent/one-conversation-session";
 import {
@@ -127,10 +128,9 @@ export function EmailAgentPageClient() {
                   </p>
                 </div>
               </div>
-              <Button type="button" onClick={openOneForDraft} className="w-full sm:w-auto">
-                <MessageCircle className="mr-2 h-4 w-4" />
+              <AskOneButton onClick={openOneForDraft}>
                 Try Email Agent with One
-              </Button>
+              </AskOneButton>
             </SurfaceInset>
           ) : (
             <SurfaceInset className="space-y-4 px-4 py-5 sm:px-5">

--- a/hushh-webapp/components/agent/ask-one-button.tsx
+++ b/hushh-webapp/components/agent/ask-one-button.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { ComponentPropsWithoutRef } from "react";
+import { MessageCircle } from "lucide-react";
+
+import { Button } from "@/lib/morphy-ux/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * The one control that opens One from inside a screen.
+ *
+ * Five surfaces had drawn their own: the Email Agent and Calendar used the
+ * shared Button with a MessageCircle, the Gmail workspace used the same Button
+ * with a Sparkles, and RIA's onboarding used a hand-rolled pill with inline
+ * colours and a gold Sparkles. Same act, four appearances -- so "open One" read
+ * as a different kind of thing on each screen.
+ *
+ * This is the shape the most screens already had: the shared Button, a
+ * MessageCircle, full width on a phone and intrinsic above it. The label stays
+ * with the caller, because what One is being asked to do IS different on each
+ * screen -- only the button is not.
+ */
+export function AskOneButton({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<typeof Button>) {
+  return (
+    <Button
+      type="button"
+      className={cn("w-full justify-center sm:w-auto", className)}
+      {...props}
+    >
+      <MessageCircle className="h-4 w-4 shrink-0" aria-hidden />
+      {children}
+    </Button>
+  );
+}

--- a/hushh-webapp/components/calendar/calendar-agent-page.tsx
+++ b/hushh-webapp/components/calendar/calendar-agent-page.tsx
@@ -5,11 +5,11 @@ import {
   CalendarDays,
   CheckCircle2,
   Loader2,
-  MessageCircle,
-} from "lucide-react";
+  } from "lucide-react";
 import { toast } from "sonner";
 
 import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
+import { AskOneButton } from "@/components/agent/ask-one-button";
 import {
   AppPageContentRegion,
   AppPageShell,
@@ -265,14 +265,15 @@ export function CalendarAgentPage({
 
                 {/* Actions */}
                 <div className="flex flex-col items-center gap-2.5 w-full pt-1">
-                  <Button
+                  <AskOneButton
                     disabled={busy || !agentPopover}
                     onClick={() => openChat("Summarize my calendar events")}
-                    className="w-full justify-center"
+                    // Full width at every size: this card is a centred column,
+                    // not a page whose actions sit inline.
+                    className="sm:w-full"
                   >
-                    <MessageCircle className="size-4" aria-hidden />
                     Try Calendar Agent with One
-                  </Button>
+                  </AskOneButton>
                   <button
                     type="button"
                     className="text-xs font-medium text-muted-foreground transition-colors hover:text-destructive focus-visible:outline-none"

--- a/hushh-webapp/components/gmail/gmail-receipts-page.tsx
+++ b/hushh-webapp/components/gmail/gmail-receipts-page.tsx
@@ -29,6 +29,7 @@ import {
   GmailWorkspaceNavigation,
   type GmailWorkspace,
 } from "@/components/gmail/gmail-workspace-navigation";
+import { AskOneButton } from "@/components/agent/ask-one-button";
 import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { SetupCompletionFooter } from "@/components/onboarding/setup/setup-completion-footer";
 import { SurfaceInset, SurfaceStack } from "@/components/app-ui/surfaces";
@@ -1930,14 +1931,9 @@ export default function GmailReceiptsPage({
                   </p>
                 </div>
               </div>
-              <Button
-                type="button"
-                onClick={handleOpenOneChat}
-                className="w-full sm:w-auto"
-              >
-                <Sparkles className="mr-2 h-4 w-4" />
+              <AskOneButton onClick={handleOpenOneChat}>
                 Open One Chat
-              </Button>
+              </AskOneButton>
             </SurfaceInset>
           ) : null}
 

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-review.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-review.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import { AskOneButton } from "@/components/agent/ask-one-button";
 import { ChevronDown, ChevronUp, Pencil, ShieldCheck } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { RiaAiActionPill, RiaChip } from "@/components/ria/ui/ria-primitives";
+import { RiaChip } from "@/components/ria/ui/ria-primitives";
 
 interface OnboardingStepReviewProps {
   advisorName: string;
@@ -220,9 +221,9 @@ export function OnboardingStepReview({
         </span>
       </div>
 
-      <RiaAiActionPill onClick={onAskKaiUpdateAnything}>
+      <AskOneButton onClick={onAskKaiUpdateAnything}>
         Ask One to update anything
-      </RiaAiActionPill>
+      </AskOneButton>
     </div>
   );
 }

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { AskOneButton } from "@/components/agent/ask-one-button";
 import {
   BarChart3,
   FileText,
@@ -13,7 +14,6 @@ import { SettingsGroup } from "@/components/app-ui/settings-ui";
 import { SectionLabel as AppSectionLabel } from "@/components/app-ui/typography";
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
-import { RiaAiActionPill } from "@/components/ria/ui/ria-primitives";
 
 const AVAILABLE_SERVICES: { label: string; icon: LucideIcon }[] = [
   { label: "Portfolio Management", icon: BarChart3 },
@@ -308,9 +308,9 @@ export function OnboardingStepServices({
 
       <div className="space-y-3">
         <SectionLabel htmlFor="ria-bio">Short Bio</SectionLabel>
-        <RiaAiActionPill onClick={onDraftBio}>
+        <AskOneButton onClick={onDraftBio}>
           Ask One to draft a bio
-        </RiaAiActionPill>
+        </AskOneButton>
         {hasBio && !bioEditing ? (
           <button
             type="button"

--- a/hushh-webapp/components/ria/ui/ria-primitives.tsx
+++ b/hushh-webapp/components/ria/ui/ria-primitives.tsx
@@ -15,7 +15,7 @@
  */
 
 import type { ComponentPropsWithoutRef, CSSProperties, ReactNode } from "react";
-import { Check, Sparkles } from "lucide-react";
+import { Check } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -233,34 +233,3 @@ export function RiaBanner({
   );
 }
 
-/**
- * "Ask One" action pill (white + gold sparkle). Forwards all button props so the
- * caller can attach onClick / data-voice-control-id / testid.
- */
-export function RiaAiActionPill({
-  children,
-  className,
-  ...props
-}: ComponentPropsWithoutRef<"button">) {
-  return (
-    <button
-      type="button"
-      className={cn(
-        "inline-flex items-center gap-2 rounded-full border px-4 py-2 text-[14px] font-semibold transition-transform active:scale-[0.98]",
-        className,
-      )}
-      style={{
-        backgroundColor: "var(--ria-selected-tint)",
-        borderColor: "var(--ria-divider-outer)",
-        color: "var(--ria-ink)",
-      }}
-      {...props}
-    >
-      <Sparkles
-        className="h-4 w-4 text-[color:var(--ria-gold)]"
-        fill="currentColor"
-      />
-      {children}
-    </button>
-  );
-}


### PR DESCRIPTION
## Asked

> Is the Talk to One button uniform across the app? If not, make it uniform like the most common design.

## Answer, in two halves

**The persistent "Talk to One" bar is already uniform.** It is one component (`AgentBar`), mounted once by `AppBottomShell` as `layout="slot"`. Nothing forks it per screen.

**The buttons inside screens that open One were not:**

| Screen | Control | Icon |
|---|---|---|
| Email Agent | shared `Button` | MessageCircle |
| Calendar | shared `Button` | MessageCircle |
| Gmail workspace | shared `Button` | **Sparkles** |
| RIA onboarding (×2) | **hand-rolled pill**, inline colours | **gold Sparkles** |

Same act, four appearances — and RIA's was a different control class entirely, with its own inline `backgroundColor` / `borderColor` / `color`.

## Change

`AskOneButton` (`components/agent/ask-one-button.tsx`) is the shape the most screens already had: the shared `Button`, a MessageCircle, full width on a phone and intrinsic above it. All five sites now use it.

- Labels are unchanged — what One is asked to do genuinely differs per screen ("Try Email Agent with One", "Open One Chat", "Ask One to draft a bio"). Only the button is shared.
- Calendar passes `sm:w-full`: its card is a centred column, so the button stays full width at every size.
- `RiaAiActionPill` had no callers left and is removed, so the outlier cannot return by being imported.

## Verification

- 54 tests pass across the RIA onboarding, Email Agent, Calendar and Gmail suites — several assert these buttons by accessible name, which is why the labels were kept exactly
- `npm run verify:design-system` passes (design system + accent tokens + Apple hierarchy)
- `eslint --max-warnings=0` and `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)