### PR TITLE
fix(agent): return to the page the agent was opened from on minimize

### DIFF
--- a/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
@@ -1,3 +1,4 @@
+import type * as React from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -8,10 +9,18 @@ import {
 
 const navigationMock = vi.hoisted(() => ({
   pathname: "/one/profile",
+  push: vi.fn(),
+  replace: vi.fn(),
+  back: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
   usePathname: () => navigationMock.pathname,
+  useRouter: () => ({
+    push: navigationMock.push,
+    replace: navigationMock.replace,
+    back: navigationMock.back,
+  }),
 }));
 
 vi.mock("@/hooks/use-auth", () => ({
@@ -24,14 +33,20 @@ vi.mock("@/components/agent/agent-chat-workspace", () => ({
   AgentChatWorkspace: ({
     isSurfaceClosing,
     onMinimize,
+    // The real workspace renders the popover's own window controls in its
+    // header. Rendering them here is what lets a test reach Minimize and
+    // Maximize -- the two controls #6134 asked about.
+    windowControls,
   }: {
     isSurfaceClosing?: boolean;
     onMinimize?: () => void;
+    windowControls?: React.ReactNode;
   }) => (
     <div data-testid="agent-chat-workspace" data-closing={isSurfaceClosing || undefined}>
       <textarea aria-label="Message One" />
+      {windowControls}
       <button type="button" onClick={onMinimize}>
-        Close One
+        Dismiss One
       </button>
     </div>
   ),
@@ -74,6 +89,9 @@ describe("AgentPopoverProvider surface ownership", () => {
 
   beforeEach(() => {
     navigationMock.pathname = "/login";
+    navigationMock.push.mockClear();
+    navigationMock.replace.mockClear();
+    navigationMock.back.mockClear();
     window.localStorage.clear();
     Object.defineProperty(window, "innerWidth", {
       configurable: true,
@@ -181,7 +199,7 @@ describe("AgentPopoverProvider surface ownership", () => {
     composer.focus();
     expect(document.activeElement).toBe(composer);
 
-    fireEvent.click(screen.getByRole("button", { name: "Close One" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss One" }));
 
     expect(blur).toHaveBeenCalledOnce();
     expect(document.activeElement).not.toBe(composer);
@@ -196,5 +214,77 @@ describe("AgentPopoverProvider surface ownership", () => {
       "ease-[cubic-bezier(0.64,0,0.78,0)]",
     );
     expect(closingDialog.className).not.toContain("sm:ring-1");
+  });
+
+  /**
+   * The second half of #6134.
+   *
+   * The route half was real: the full-page `/agent` screen read
+   * `document.referrer`, which App Router never sets, so minimize always fell
+   * through to One home. The report also showed the URL bar reading
+   * `/one/gmail` with the chat maximized -- that is the POPOVER, whose window
+   * controls only move local state. If minimizing there had navigated too, it
+   * would have been a second, separate defect.
+   *
+   * It does not, and these two tests hold that: the popover never navigates,
+   * at either size. So a future "minimize took me to /one" from a popover
+   * surface is something else moving the page underneath it -- a guard, a
+   * redirect -- and not this control.
+   */
+  it("minimizes the popover without navigating away from the page", () => {
+    vi.useFakeTimers();
+    navigationMock.pathname = "/one/gmail";
+    render(
+      <AgentPopoverProvider>
+        <PopoverControl />
+      </AgentPopoverProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open One" }));
+    act(() => vi.advanceTimersByTime(20));
+    fireEvent.click(screen.getByRole("button", { name: "Minimize One" }));
+
+    expect(screen.getByTestId("agent-popover-motion")).toHaveTextContent(
+      "closing",
+    );
+    expect(navigationMock.push).not.toHaveBeenCalled();
+    expect(navigationMock.replace).not.toHaveBeenCalled();
+    expect(navigationMock.back).not.toHaveBeenCalled();
+  });
+
+  it("changes size and minimizes from the window controls without navigating", () => {
+    // The state the report was filed from: maximized, URL still on the feature
+    // page. Size is a stored preference, not a route change -- so neither the
+    // toggle nor the minimize beside it may move the page.
+    vi.useFakeTimers();
+    navigationMock.pathname = "/one/gmail";
+    render(
+      <AgentPopoverProvider>
+        <PopoverControl />
+      </AgentPopoverProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open One" }));
+    act(() => vi.advanceTimersByTime(20));
+
+    // This viewport opens fullscreen, so the toggle offers Restore first.
+    const sizeToggle =
+      screen.queryByRole("button", { name: "Restore One" }) ??
+      screen.getByRole("button", { name: "Maximize One" });
+    fireEvent.click(sizeToggle);
+    expect(
+      screen.queryByRole("button", { name: "Maximize One" }) ??
+        screen.queryByRole("button", { name: "Restore One" }),
+    ).toBeInTheDocument();
+    expect(navigationMock.push).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Minimize One" }));
+
+    expect(screen.getByTestId("agent-popover-motion")).toHaveTextContent(
+      "closing",
+    );
+    expect(navigationMock.push).not.toHaveBeenCalled();
+    expect(navigationMock.replace).not.toHaveBeenCalled();
+    expect(navigationMock.back).not.toHaveBeenCalled();
   });
 });

--- a/hushh-webapp/__tests__/lib/agent-origin.test.ts
+++ b/hushh-webapp/__tests__/lib/agent-origin.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  agentRouteWithOrigin,
+  readAgentOrigin,
+} from "@/lib/navigation/agent-origin";
+import { ROUTES } from "@/lib/navigation/routes";
+
+describe("agentRouteWithOrigin", () => {
+  it("records the originating page on the agent route", () => {
+    expect(agentRouteWithOrigin(ROUTES.EMAIL_AGENT)).toBe(
+      "/agent?from=%2Fone%2Femail",
+    );
+  });
+
+  it("keeps a query string on the origin intact through a round trip", () => {
+    const href = agentRouteWithOrigin("/one/gmail?tab=receipts");
+    expect(readAgentOrigin(new URL(href, "https://one.hushh.ai").search)).toBe(
+      "/one/gmail?tab=receipts",
+    );
+  });
+
+  it("degrades to the plain route rather than encoding an unsafe origin", () => {
+    for (const unsafe of ["//evil.com", "https://evil.com", "", null]) {
+      expect(agentRouteWithOrigin(unsafe)).toBe(ROUTES.AGENT);
+    }
+  });
+});
+
+describe("readAgentOrigin", () => {
+  it("reads the recorded origin", () => {
+    expect(readAgentOrigin("?from=%2Fone%2Femail")).toBe("/one/email");
+  });
+
+  it("accepts a search string with or without the leading question mark", () => {
+    expect(readAgentOrigin("from=/one/gmail")).toBe("/one/gmail");
+  });
+
+  it("returns null when nothing was recorded", () => {
+    expect(readAgentOrigin("")).toBeNull();
+    expect(readAgentOrigin(null)).toBeNull();
+    expect(readAgentOrigin("?other=/one/email")).toBeNull();
+  });
+
+  it("refuses origins that would navigate off-site", () => {
+    // The value arrives from the query string, so a shared link can carry
+    // anything. Each of these leaves the origin if pushed unchecked.
+    expect(readAgentOrigin("?from=//evil.com")).toBeNull();
+    expect(readAgentOrigin("?from=https%3A%2F%2Fevil.com")).toBeNull();
+    expect(readAgentOrigin("?from=%2F%5Cevil.com")).toBeNull();
+    expect(readAgentOrigin("?from=javascript%3Aalert(1)")).toBeNull();
+    expect(readAgentOrigin("?from=one%2Femail")).toBeNull();
+  });
+
+  it("refuses the agent route itself so minimize cannot loop", () => {
+    expect(readAgentOrigin(`?from=${encodeURIComponent(ROUTES.AGENT)}`)).toBeNull();
+    expect(readAgentOrigin("?from=%2Fagent%3Ffrom%3D%2Fagent")).toBeNull();
+  });
+});

--- a/hushh-webapp/app/one/email/email-agent-page-client.tsx
+++ b/hushh-webapp/app/one/email/email-agent-page-client.tsx
@@ -23,6 +23,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useAuth } from "@/hooks/use-auth";
 import { useGmailConnectorStatus } from "@/lib/profile/gmail-connector-store";
 import { Button } from "@/lib/morphy-ux/button";
+import { agentRouteWithOrigin } from "@/lib/navigation/agent-origin";
 import { ROUTES } from "@/lib/navigation/routes";
 
 /**
@@ -80,8 +81,9 @@ export function EmailAgentPageClient() {
       return;
     }
     // Any queued handoff remains in the shared in-memory session for the
-    // legacy dedicated chat route too.
-    router.push(ROUTES.AGENT);
+    // legacy dedicated chat route too. Record this page as the origin so
+    // minimizing the full-page agent comes back here rather than One home.
+    router.push(agentRouteWithOrigin(ROUTES.EMAIL_AGENT));
   }, [
     agentPopover,
     createHandoff,

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -170,6 +170,7 @@ import {
   type DelegateResult,
 } from "@/lib/agent/specialist-directive-runtime";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
+import { readAgentOrigin } from "@/lib/navigation/agent-origin";
 import { ROUTES } from "@/lib/navigation/routes";
 import { GoogleCalendarService } from "@/lib/services/google-calendar-service";
 import { cn } from "@/lib/utils";
@@ -4674,6 +4675,16 @@ export function AgentChatWorkspace({
       return;
     }
     if (typeof window !== "undefined") {
+      // The page that handed off records itself as ?from=. This is checked
+      // before any history heuristic because it is the only signal that
+      // survives a reload or a shared link — and because `document.referrer`,
+      // which this used to rely on, is never set by App Router client
+      // navigation, so every minimize fell through to One home.
+      const origin = readAgentOrigin(window.location.search);
+      if (origin) {
+        router.push(origin);
+        return;
+      }
       const referrer = document.referrer ? new URL(document.referrer) : null;
       const isSameOriginReferrer =
         referrer?.origin === window.location.origin &&
@@ -4683,9 +4694,9 @@ export function AgentChatWorkspace({
         return;
       }
     }
-    // No same-origin referrer to retrace to (e.g. a direct link into this
-    // legacy full-page route): land on One home, not Profile, so minimizing
-    // always returns to the section this screen lives under.
+    // Nothing to retrace to (e.g. a direct link into this legacy full-page
+    // route with no recorded origin): land on One home, not Profile, so
+    // minimizing always returns to the section this screen lives under.
     router.push(ROUTES.ONE_HOME);
   }, [onMinimize, router]);
   const handleHistoryDrawerKeyDown = useCallback(

--- a/hushh-webapp/components/gmail/__tests__/gmail-email-agent-handoff.contract.test.ts
+++ b/hushh-webapp/components/gmail/__tests__/gmail-email-agent-handoff.contract.test.ts
@@ -16,7 +16,9 @@ describe("Gmail Email Agent handoff contract", () => {
     // empty for whatever the owner actually came to write.
     expect(source).toContain("const handleOpenOneChat = useCallback(() => {");
     expect(source).toContain("agentPopover.openAgent();");
-    expect(source).toContain("router.push(ROUTES.AGENT);");
+    // The legacy full-page fallback now records this page as its origin, so
+    // minimizing that screen returns here instead of One home (#6134).
+    expect(source).toContain("router.push(agentRouteWithOrigin(pathname));");
     expect(source).not.toContain("createHandoff");
     expect(source).not.toContain("buildGmailAgentHandoffPrompt");
   });

--- a/hushh-webapp/components/gmail/gmail-receipts-page.tsx
+++ b/hushh-webapp/components/gmail/gmail-receipts-page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Capacitor } from "@capacitor/core";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
   Loader2,
   Lock,
@@ -50,6 +50,7 @@ import { VaultUnlockDialog } from "@/components/vault/vault-unlock-dialog";
 import { Button } from "@/lib/morphy-ux/button";
 import { morphyToast } from "@/lib/morphy-ux/morphy";
 import { useAuth } from "@/hooks/use-auth";
+import { agentRouteWithOrigin } from "@/lib/navigation/agent-origin";
 import { ROUTES } from "@/lib/navigation/routes";
 import {
   describeGmailReceiptScanProgress,
@@ -395,6 +396,9 @@ export default function GmailReceiptsPage({
   initialWorkspace = "overview",
 }: GmailReceiptsPageProps) {
   const router = useRouter();
+  // This component is hosted on both /one/gmail and /one/setup/gmail, so the
+  // origin handed to the agent has to be the live path, not a route constant.
+  const pathname = usePathname();
   const { user, loading } = useAuth();
   const { vaultKey, vaultOwnerToken, isVaultUnlocked } = useVault();
   const agentPopover = useOptionalAgentPopover();
@@ -959,8 +963,8 @@ export default function GmailReceiptsPage({
       agentPopover.openAgent();
       return;
     }
-    router.push(ROUTES.AGENT);
-  }, [agentPopover, router]);
+    router.push(agentRouteWithOrigin(pathname));
+  }, [agentPopover, pathname, router]);
 
   useLocalOnboardingActionHandler("setup.connect_gmail", () => {
     if (journeyVariant !== "onboarding") {

--- a/hushh-webapp/lib/navigation/agent-origin.ts
+++ b/hushh-webapp/lib/navigation/agent-origin.ts
@@ -1,0 +1,65 @@
+/**
+ * Where the full-page `/agent` route should return to when it is minimized.
+ *
+ * Minimize used to infer this from `document.referrer`, which App Router client
+ * navigation never updates — every entry point into `/agent` is a client
+ * `router.push`, so the referrer stayed empty and minimize always fell through
+ * to One home. The origin is therefore carried explicitly in the URL instead:
+ * it survives a reload, a shared link and a restored tab, none of which a
+ * history- or referrer-based heuristic can.
+ */
+
+import { ROUTES } from "@/lib/navigation/routes";
+
+export const AGENT_ORIGIN_PARAM = "from";
+
+/**
+ * `/agent?from=<originPath>` — the href a feature page hands off to so minimize
+ * can retrace it. A path that is not a safe in-app target is dropped rather
+ * than encoded, so the link degrades to the plain route.
+ */
+export function agentRouteWithOrigin(originPath: string | null | undefined): string {
+  const safe = normalizeAgentOrigin(originPath);
+  if (!safe) return ROUTES.AGENT;
+  return `${ROUTES.AGENT}?${AGENT_ORIGIN_PARAM}=${encodeURIComponent(safe)}`;
+}
+
+/**
+ * The return path recorded on a `/agent` URL, or null when there is none to
+ * trust. Accepts a full search string (`?from=/one/email`) or a bare one.
+ */
+export function readAgentOrigin(search: string | null | undefined): string | null {
+  if (!search) return null;
+  let raw: string | null;
+  try {
+    raw = new URLSearchParams(
+      search.startsWith("?") ? search.slice(1) : search,
+    ).get(AGENT_ORIGIN_PARAM);
+  } catch {
+    return null;
+  }
+  return normalizeAgentOrigin(raw);
+}
+
+/**
+ * Reduce a candidate to a same-origin app path, or null.
+ *
+ * The value reaches us from the query string, so it is attacker-controllable in
+ * a shared link: anything that could leave the origin has to be rejected, not
+ * sanitised. That means a single leading slash only — `//evil.com` is
+ * protocol-relative and `https://evil.com` carries a scheme, and both would
+ * navigate off-site. `/agent` itself is rejected too, so minimize can never
+ * return to the screen it is leaving.
+ */
+function normalizeAgentOrigin(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("/")) return null;
+  if (trimmed.startsWith("//")) return null;
+  // A backslash is treated as a slash by some URL parsers, so `/\evil.com`
+  // can escape the origin in exactly the way `//evil.com` does.
+  if (trimmed.startsWith("/\\")) return null;
+  const path = trimmed.split(/[?#]/, 1)[0];
+  if (path === ROUTES.AGENT) return null;
+  return trimmed;
+}


### PR DESCRIPTION
Closes #6134. Supersedes #6135, which carried the same fix but was ~690 commits behind `main`; this branch is that commit (authorship preserved) rebased onto current `main`, plus the answer to the open question it left.

## The route half — the diagnosed bug

`handlePageMinimize` decided where to go by reading `document.referrer`. App Router client navigation never updates it, and every entry point into `/agent` is a client `router.push`, so the referrer stayed empty, the same-origin guard was always false, and minimize fell through to `ROUTES.ONE_HOME` every time. Page-agnostic, which matches "happening across many other pages too".

The origin is now carried in the URL — `/agent?from=/one/email` — and checked before any history heuristic. Unlike a referrer or history guess it survives a reload, a shared link and a restored tab. `readAgentOrigin` accepts a single-leading-slash app path only, rejecting protocol-relative (`//evil.com`), scheme-carrying and backslash-escaping values, and `/agent` itself so minimize cannot loop back to the screen it is leaving. One home remains the fallback for a direct link with no recorded origin.

Gmail records the live pathname rather than a route constant, because that page is hosted at both `/one/gmail` and `/one/setup/gmail`.

## The popover half — the open question, now answered

The report's screenshot showed the URL bar reading `/one/gmail` with the chat maximized. That is the **popover** at `sizeMode: "fullscreen"`, not the `/agent` route — and the issue correctly flagged that if minimizing there navigated too, it would be a second, separate defect.

**It does not.** The popover's minimize, close and size controls only move local state, and the workspace's `handlePageMinimize` returns before any navigation whenever `onMinimize` is supplied — which the popover always supplies. Two new tests pin that at both sizes, so it stops being an inference from reading code.

What that means for the next report: a "minimize took me to /one" from a popover surface is **something else moving the page underneath it** while the sheet covered the screen. One concrete candidate, worth checking first: `OnboardingJourneyGuard` does `router.replace(ROUTES.ONE_HOME)` from any `/one/setup/*` surface once setup is dismissed — and the Gmail workspace is hosted at `/one/setup/gmail` as well as `/one/gmail`.

## Verification

- 21 tests pass across `agent-origin`, the popover provider, the Email Agent page and the Gmail suites
- The Gmail handoff contract test is updated: it pinned the exact fallback push this changes
- `eslint --max-warnings=0` and `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)