### PR TITLE
fix(location): drop the incoming row when no one is sharing

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -758,10 +758,16 @@ describe("LocationImmersiveMap demo experience", () => {
     // subtitle reading "Sharing with 1", which is two true statements about
     // two different audiences stacked as though they were one.
     expect(screen.getByText("No one sharing yet")).toBeInTheDocument();
-    // The row below the header is where the audience is named in full.
+    // The incoming row is gone with the audience it counted. Its action is
+    // "fit them all on the map", so an empty map leaves it nothing to do --
+    // and a chevron in front of a sentence saying there is nothing reads as
+    // a way in to something that is not there.
     expect(
-      screen.getByText("No one is sharing their location"),
-    ).toBeInTheDocument();
+      screen.queryByTestId("one-location-map-show-everyone"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("No one is sharing their location"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText("0 people sharing with you"),
     ).not.toBeInTheDocument();
@@ -2454,7 +2460,7 @@ describe("LocationImmersiveMap reported map defects", () => {
     expect(screen.getByTestId("one-location-map-locate")).toBeInTheDocument();
   });
 
-  it("answers Everyone instead of sitting disabled when no one shares with you", async () => {
+  it("offers no Everyone row at all when no one shares with you", async () => {
     serviceHarness.getState.mockResolvedValue({
       recipients: [],
       ownerGrants: [],
@@ -2466,19 +2472,13 @@ describe("LocationImmersiveMap reported map defects", () => {
 
     await renderReadyMap();
 
-    const everyone = screen.getByTestId("one-location-map-show-everyone");
-    // Never disabled: a disabled control gives no reason, and on a touch screen
-    // is indistinguishable from a broken one.
-    expect(everyone).not.toBeDisabled();
-
-    vi.mocked(toast.message).mockClear();
-    fireEvent.click(everyone);
-
-    await waitFor(() => {
-      expect(toast.message).toHaveBeenCalledWith(
-        "No one is sharing a live location with you yet.",
-      );
-    });
+    // The row framed people on the map, so with nobody on it the row had no
+    // action left -- and a chevron in front of "No one is sharing their
+    // location" reads as a way in to a list that does not exist. Absent beats
+    // present-and-inert: there is nothing to press and nothing to explain.
+    expect(
+      screen.queryByTestId("one-location-map-show-everyone"),
+    ).not.toBeInTheDocument();
   });
 
   it("frames the people who do share with you when Everyone is pressed", async () => {

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -2361,16 +2361,17 @@ export function LocationImmersiveMap({
    *
    * `markers` is exactly that -- it is built from grants where the viewer is
    * the recipient -- so this number is never affected by the viewer's own
-   * Ghost Mode, and the empty-state line under it says so, because "I turned
-   * on Ghost and now my map is empty" is the confusion the old two-pill row
-   * invited.
+   * Ghost Mode.
+   *
+   * There is no empty case here any more. The row this labels only renders
+   * while somebody is on the map, because its whole action is "fit them all"
+   * and an empty map has nothing to fit -- so the count is always >= 1 by the
+   * time this is read.
    */
   const incomingShareLabel =
-    markers.length === 0
-      ? "No one is sharing their location"
-      : markers.length === 1
-        ? "1 person sharing with you"
-        : `${markers.length} people sharing with you`;
+    markers.length === 1
+      ? "1 person sharing with you"
+      : `${markers.length} people sharing with you`;
 
   /** OUTGOING: people this account is sharing with. A different audience from
    *  the one above, and the reason the two get separate rows. */
@@ -2604,15 +2605,12 @@ export function LocationImmersiveMap({
     setSelected(null);
     setSearchQuery("");
     setTrayExpanded(false);
-    // Everyone was `disabled` whenever there was nothing to frame, and silent
-    // whenever the only thing to frame was you. Both are the same experience
-    // from the outside -- press it, nothing happens, no reason given -- and
-    // both are exactly the state a new account is in. That is the reported
+    // A backstop, not the empty state's answer. The row that calls this only
+    // renders while `markers` is non-empty, so the ordinary "no one shares
+    // with me" account never reaches here -- it has no control to press. What
+    // is left is the race: the last share ending between paint and tap. Still
+    // answer it rather than letting the press go silent, which is the reported
     // "everyone is not working on your map, why does it so?".
-    //
-    // So the control is never disabled, and it answers the question it was
-    // asked. `markers` is the incoming set: people who chose to share with this
-    // account. Your own pin is not "everyone".
     if (markers.length === 0) {
       toast.message("No one is sharing a live location with you yet.");
     }
@@ -3634,42 +3632,43 @@ export function LocationImmersiveMap({
                   data-testid="one-location-map-visibility"
                 >
                   {/* Incoming. Keeps the `show-everyone` id: this IS the old
-                    Everyone control, finally saying what it frames. */}
-                  <button
-                    type="button"
-                    className="flex min-h-[52px] w-full items-center gap-3 rounded-2xl bg-muted/70 px-3 py-2 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
-                    data-testid="one-location-map-show-everyone"
-                    aria-label={
-                      markers.length > 0
-                        ? `${incomingShareLabel}. Fit them all on the map.`
-                        : incomingShareLabel
-                    }
-                    onClick={() => void showEveryone()}
-                  >
-                    <span
-                      className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--app-accent-surface)] text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]"
-                      aria-hidden="true"
+                    Everyone control, finally saying what it frames.
+
+                    Only while there is somebody to frame. With an empty map
+                    the row was a chevron and a tappable surface -- the shape
+                    UI uses for "there is more behind this" -- in front of a
+                    sentence saying there is nothing, and tapping it fit an
+                    empty set and moved nothing. The count it wants to show is
+                    already the reason to show it, so the absence of a count
+                    is the reason not to. */}
+                  {markers.length > 0 ? (
+                    <button
+                      type="button"
+                      className="flex min-h-[52px] w-full items-center gap-3 rounded-2xl bg-muted/70 px-3 py-2 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
+                      data-testid="one-location-map-show-everyone"
+                      aria-label={`${incomingShareLabel}. Fit them all on the map.`}
+                      onClick={() => void showEveryone()}
                     >
-                      <UsersRound className="h-[18px] w-[18px]" />
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate text-sm font-medium">
-                        {incomingShareLabel}
+                      <span
+                        className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--app-accent-surface)] text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]"
+                        aria-hidden="true"
+                      >
+                        <UsersRound className="h-[18px] w-[18px]" />
                       </span>
-                      {/* Only when it adds something the title cannot. The
-                        empty state has nothing to fit on the map, so it says
-                        nothing rather than restating the line above it. */}
-                      {markers.length > 0 ? (
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium">
+                          {incomingShareLabel}
+                        </span>
                         <span className="block truncate text-xs text-muted-foreground">
                           Tap to fit everyone on the map
                         </span>
-                      ) : null}
-                    </span>
-                    <ChevronDown
-                      className="h-4 w-4 shrink-0 -rotate-90 text-muted-foreground"
-                      aria-hidden="true"
-                    />
-                  </button>
+                      </span>
+                      <ChevronDown
+                        className="h-4 w-4 shrink-0 -rotate-90 text-muted-foreground"
+                        aria-hidden="true"
+                      />
+                    </button>
+                  ) : null}
 
                   {/* Outgoing. Hidden in demo, where the count is never fetched
                     and a number would be fiction. */}


### PR DESCRIPTION
The map sheet's incoming row exists to frame the people sharing with you — its action is "fit them all on the map." On an account nobody shares with there is nothing to fit, so what was left was a filled, tappable surface with a people icon and a chevron, in front of a sentence saying there is nothing:

> 👥 No one is sharing their location ›

That is the shape UI uses for "there is more behind this," so it reads as a way in to a list that does not exist. Tapping it framed an empty set and moved the camera nowhere.

## Change

The row renders only while `markers.length > 0`. The count is the reason the row exists; the absence of a count is the reason it does not.

Falling out of that:

- `incomingShareLabel` loses its now-unreachable `"No one is sharing their location"` branch.
- The subtitle's `markers.length > 0` guard inside the button is gone — always true there now.
- `showEveryone`'s empty-set toast stays, as a backstop for the last share ending between paint and tap, with a comment saying that is what it now is rather than the empty state's answer.

The header above the sheet still says "No one sharing yet," and the people list still says "Pins appear when someone shares." The empty state keeps its words; it loses the control that had nothing to do.

## Tests

Two tests asserted the old behavior and were rewritten:

- The empty-state test asserted the label was present; it now asserts the row is absent.
- `"answers Everyone instead of sitting disabled when no one shares with you"` pressed the row with zero markers, which cannot happen now → `"offers no Everyone row at all when no one shares with you"`.

`vitest run __tests__/components/location-immersive-map.test.tsx` — 57 passed. `tsc --noEmit` and `eslint` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)