### PR TITLE
fix(circles): hold the sheet title off the 24px top corner

### DIFF
--- a/hushh-webapp/components/one-location/redesign/circles/circle-sheet-layout.ts
+++ b/hushh-webapp/components/one-location/redesign/circles/circle-sheet-layout.ts
@@ -48,7 +48,7 @@
 /**
  * The sheet's header, aligned with the body under it.
  *
- * `p-0` before `pt-1`, not `px-0 pt-1 pb-0`: `SheetHeader`'s own `p-4` is a
+ * `p-0` before `pt-5`, not `px-0 pt-5 pb-0`: `SheetHeader`'s own `p-4` is a
  * single shorthand, and clearing it side by side leaves the reader checking
  * four tailwind-merge groups to be sure nothing survived. One reset, then the
  * one value this surface wants back.
@@ -56,8 +56,22 @@
  * The horizontal padding belongs to `SheetContent` (`px-4 sm:px-6`), which is
  * what the search field and the list are measured against -- so the title
  * lines up with them instead of sitting 16px inboard of both.
+ *
+ * `pt-5` and not the `pt-1` this started at, because the top padding is the
+ * only thing holding the title off a 24px corner. The sheets round their top
+ * at `rounded-t-[24px]` and the title starts at the `px-4` gutter, 16px in --
+ * which is still inside that corner's 24px arc. Solve the circle there and
+ * the surface only begins about 1.4px down, so 4px of padding left the title
+ * sitting in the curve rather than below it, and it read as text crowding the
+ * rounded edge.
+ *
+ * 20px clears the arc, and it also lands the title's optical centre within a
+ * couple of pixels of the close button's, which `SheetContent` pins at
+ * `top-4` with a 32px box (centre 32px; the title's is ~34px). Matching the
+ * radius exactly at `pt-6` would clear the curve just as well but push the
+ * title 6px below that centre, so the X would read as floating high.
  */
-export const CIRCLE_SHEET_HEADER_CLASSNAME = "p-0 pt-1 text-left";
+export const CIRCLE_SHEET_HEADER_CLASSNAME = "p-0 pt-5 text-left";
 
 /**
  * A sheet body that is simply as tall as its content (Rename, Invite code).


### PR DESCRIPTION
Reported on the Invite code sheet: the title sits too close to the rounded top edge.

## Why it happened

The Circle sheets round their top at `rounded-t-[24px]`, and the title starts at the `px-4` gutter — 16px in, which is **still inside that corner's 24px arc**. Solving the circle at x=16 (centre `(24,24)`, r=24):

```
dy = √(24² − 8²) ≈ 22.6   →   surface begins at y ≈ 24 − 22.6 ≈ 1.4px
```

So at the title's left edge the sheet has barely started. The header's `pt-1` put the text 4px down — about 2.6px below the visible edge — which is why it read as crowding the curve rather than sitting below it.

## The change

One line in the shared layout constant:

```diff
-export const CIRCLE_SHEET_HEADER_CLASSNAME = "p-0 pt-1 text-left";
+export const CIRCLE_SHEET_HEADER_CLASSNAME = "p-0 pt-5 text-left";
```

**Why `pt-5` (20px) and not `pt-6` (24px):** both clear the arc. `pt-5` additionally lands the title's optical centre (~34px) within a couple of pixels of the close button's — `SheetContent` pins that at `top-4` with a 32px box, centre 32px. `pt-6` would push the title 6px below it and leave the X reading as floating high.

It's the shared constant, so **Invite code, Rename Circle, and Add people** all get it — which is what that file exists for, per its own docstring: the three sheets state their rhythm once instead of drifting apart a sheet at a time.

No markup changed, and no test asserted the old value.

## Checks

- `tsc --noEmit` — clean
- `eslint` on the changed file — clean
- `vitest run` on the three circle suites — 26 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)