### PR TITLE
fix(db): make migration 138 replay-safe so UAT can deploy again

### DIFF
--- a/consent-protocol/db/migrations/138_circle_member_connection_origin.sql
+++ b/consent-protocol/db/migrations/138_circle_member_connection_origin.sql
@@ -23,6 +23,23 @@ BEGIN;
 ALTER TABLE connection_origins
   DROP CONSTRAINT IF EXISTS connection_origins_origin_kind_check;
 
+-- NOT VALID, because UAT and production replay this file on every deploy.
+--
+-- `origin_kind` gained 'contact_sync' later, in 175. Replaying this migration
+-- re-adds the narrower list above against present-day rows, so the first real
+-- contact_sync row made this line fail with:
+--
+--   check constraint "connection_origins_origin_kind_check"
+--   of relation "connection_origins" is violated by some row
+--
+-- and the whole UAT deploy stopped there, before anything shipped.
+--
+-- NOT VALID applies the rule to new and updated rows without re-validating
+-- existing ones, which is what this migration ever meant: it changes what
+-- future joins create, and explicitly does not backfill. Migration 175 drops
+-- and re-adds this same constraint fully validated with the complete
+-- vocabulary, so the schema still ends up identical -- and a genuinely
+-- unknown origin_kind still fails there, where it should.
 ALTER TABLE connection_origins
   ADD CONSTRAINT connection_origins_origin_kind_check
   CHECK (origin_kind IN (
@@ -31,7 +48,7 @@ ALTER TABLE connection_origins
     'circle_member',
     'legacy_invite',
     'import'
-  ));
+  )) NOT VALID;
 
 -- `circle_member` is pair provenance, not Circle-scoped provenance: one row per
 -- connection regardless of how many Circles the pair later share. The existing


### PR DESCRIPTION
UAT deploys have been failing at **Apply UAT DB migrations** for every commit, not just recent ones. This unblocks them.

## What happens

UAT runs `db/migrate.py --migration-mode replay`, which re-executes every migration body in order on every deploy.

Migration 138 re-adds `connection_origins_origin_kind_check` with the vocabulary as it stood then — before 175 added `contact_sync`. Once UAT held its first `contact_sync` row, replaying 138 began failing:

```
check constraint "connection_origins_origin_kind_check"
of relation "connection_origins" is violated by some row
```

The deploy stops there, before building or promoting anything. The 03:18 run on `51d5abacc` passed only because no `contact_sync` row existed yet; the two runs after it failed identically.

## The fix

`NOT VALID` applies the constraint to new and updated rows without re-validating existing ones — which is what 138 always meant. Its own comment says it changes what future joins create and deliberately does not backfill; validating history was never its intent.

175 still drops and re-adds the same constraint fully validated with the complete vocabulary, so the end schema is unchanged, and a genuinely unknown `origin_kind` still fails there, where it should.

## Why editing a historical migration is safe here

Replay mode never reads the ledger. `apply_manifest_entries` skips the ledger DDL, the recorded checksums, and the applied-state bookkeeping entirely when mode is `REPLAY` (`db/migration_authority.py:260`, `:310`, `:324`). No checksum or tamper guard applies.

## The real fix, not done here

Ledger mode — pending migrations only, after a verified baseline — which the repo already supports and which exists precisely for this. It needs a baseline established against the UAT database (`db/migrate.py --establish-baseline`), which requires DB access this change cannot reach. Until then every migration must stay replay-safe, and this one was not.

`scripts/ci/orchestrate.sh governance` passes: 223 checks, 0 errors.