### PR TITLE
fix(ios): restore every App Shortcut, which build 99 deleted at once

### DIFF
--- a/.claude/skills/safe-changes/SKILL.md
+++ b/.claude/skills/safe-changes/SKILL.md
@@ -900,6 +900,76 @@ the `calc()`. And grep for other places applying the same clearance — this one
 was being added four times: `.app-page-shell`, `.profile-home-screen`,
 `profile-stack-navigator.tsx`, and the scroll root that legitimately owns it.
 
+### R27 — Hoisting an App Shortcut phrase array deletes every shortcut in the app
+
+**Incident (2026-09-07, iOS TestFlight build 99 — merge `a4a95a1e4`, PR #6559).** Long-pressing
+the app icon showed no App Shortcuts at all, only the system items, and `TalkToHusshOneIntent`
+stopped working despite being **byte-identical to build 98**. The PR had refactored every phrase
+list out of its `AppShortcut(...)` call into a named constant — `phrases: shareLocationPhrases`
+where build 98 wrote the phrases in place — and the app name likewise into
+`private static let agentOne: AppShortcutPhraseToken = .applicationName`.
+
+`appintentsmetadataprocessor` extracts App Shortcuts at **compile time** by reading those
+expressions literally. It cannot follow a reference to a `static let`. It saw ten shortcuts with
+zero phrases and stopped:
+
+```
+OneVoiceAppIntent.swift:1113: warning: App Shortcuts should have at least one phrase
+error: At least one halting error produced during export. No AppIntents metadata have been
+exported and this target is not usable with AppIntents until errors are resolved.
+```
+
+No metadata means **no App Shortcuts of any kind** — including ones whose code never changed.
+
+Proven on this repo, Xcode 26.6, one file swapped between otherwise identical builds:
+
+| provider shape | `Metadata.appintents` |
+| --- | --- |
+| build 99 as shipped (arrays hoisted + token hoisted) | **not written** — halting error |
+| arrays inline, token still hoisted | **not written** — halting error |
+| arrays hoisted, token inline | **not written** — halting error |
+| both inline (build 98's shape) | **written**, 10 shortcuts, 61 phrases |
+
+Both hoistings must be undone; neither alone is sufficient. Note the shipped CI ran Xcode 26.3
+and *did* write a metadata file, so CI never went red — "Writing Metadata.appintents" in a log is
+not evidence that the shortcuts are in it.
+
+Separately and secondarily: that PR also bound `\(\.$requestText)`, a plain `String`, into a
+phrase. Apple allows only `AppEnum` and `AppEntity` phrase parameters. That is a real violation
+worth fixing, but it is **not** what emptied the menu.
+
+**Rule.** Phrase arrays and the `\(.applicationName)` token are written inline inside
+`AppShortcut(phrases: [...])`, never hoisted into a named constant, no matter how much tidier
+hoisting looks. Every phrase parameter is an `AppEnum` or `AppEntity`; free text goes through the
+parameter's `requestValueDialog`. Order both structural checks BEFORE the phrase-fragment
+assertions — an earlier throw means later assertions never run, which is how this verifier passed
+while the app shipped with nothing.
+
+**Check.** Both guards must fail on the real bug. Hoist while keeping every phrase intact, so the
+fragment assertions still pass and only the shape guard can fire:
+
+```bash
+cd hushh-webapp && node scripts/native/verify-siri-action-contract.mjs   # green first
+# then hoist one family into a `static let ...Phrases` and re-run:
+#   Error: Phrase arrays must be written inline ... not hoisted into a named constant
+# and add "Ask \(.applicationName) with \(\.$requestText)" as an extra phrase:
+#   Error: ... binds \(\.$requestText), typed `String` ...
+```
+
+A green contract still is not a registered shortcut. Only a build proves it:
+
+```bash
+xcodebuild -project ios/App/App.xcodeproj -scheme App -configuration Debug \
+  -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/dd \
+  CODE_SIGNING_ALLOWED=NO build 2>&1 | grep -E "halting error|Writing Metadata.appintents"
+python3 -c "
+import json;d=json.load(open('/tmp/dd/Build/Products/Debug-iphonesimulator/App.app/Metadata.appintents/extract.actionsdata'))
+[print(s['shortTitle']['key'], len(s.get('phraseTemplates') or [])) for s in d['autoShortcuts']]"
+```
+
+Expect ten rows with non-zero phrase counts. Zero rows, or a row with zero phrases, is the bug.
+
+
 ## Adding a rule
 
 Every mistake found becomes a rule. Fix the **cause**, not the symptom, then add

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,6 +522,60 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             2>&1 | tee "${RUNNER_TEMP}/xcodebuild-ios-tests.log"
 
+      - name: Assert the built app actually ships its App Shortcuts
+        shell: bash
+        run: |
+          set -euo pipefail
+          # A green xcodebuild is not a registered shortcut. appintentsmetadataprocessor
+          # can emit a HALTING error -- "No AppIntents metadata have been exported" --
+          # and the build still succeeds, shipping an app with zero App Shortcuts.
+          # That is exactly how build 99 went out with an empty Home Screen long-press
+          # menu while this job was green. See R27 in .claude/skills/safe-changes.
+          if grep -q "At least one halting error produced during export" \
+              "${RUNNER_TEMP}/xcodebuild-ios-tests.log"; then
+            echo "::error::appintentsmetadataprocessor halted; the app ships with NO App Shortcuts."
+            grep -E "OneVoiceAppIntent\.swift:[0-9]+: (error|warning):" \
+              "${RUNNER_TEMP}/xcodebuild-ios-tests.log" | sort -u || true
+            exit 1
+          fi
+
+          # Search the whole derived-data tree: `xcodebuild test` and `build` place
+          # the product differently, and the configuration directory name varies.
+          ACTIONS_DATA="$(find "${RUNNER_TEMP}/derived-data" \
+            -path '*/App.app/Metadata.appintents/extract.actionsdata' -print -quit 2>/dev/null || true)"
+          if [ -z "${ACTIONS_DATA}" ]; then
+            echo "::error::No Metadata.appintents in the built App.app -- the app has no App Shortcuts."
+            exit 1
+          fi
+          echo "Reading ${ACTIONS_DATA}"
+
+          python3 - "${ACTIONS_DATA}" <<'PY'
+          import json, sys
+
+          EXPECTED = 10  # Apple's cap, and every slot is deliberately spoken for.
+          data = json.load(open(sys.argv[1]))
+          shortcuts = data.get("autoShortcuts") or []
+
+          failures = []
+          if len(shortcuts) != EXPECTED:
+              failures.append(f"expected {EXPECTED} App Shortcuts, found {len(shortcuts)}")
+
+          for shortcut in shortcuts:
+              title = (shortcut.get("shortTitle") or {}).get("key", "<untitled>")
+              phrases = shortcut.get("phraseTemplates") or []
+              if not phrases:
+                  failures.append(f'"{title}" shipped with 0 phrases')
+              print(f"  {title:26s} {len(phrases):2d} phrases   {shortcut.get('actionIdentifier')}")
+
+          if failures:
+              for failure in failures:
+                  print(f"::error::{failure}")
+              raise SystemExit(1)
+
+          total = sum(len(s.get("phraseTemplates") or []) for s in shortcuts)
+          print(f"\nOK: {len(shortcuts)} App Shortcuts, {total} phrases, compiled into the binary.")
+          PY
+
       - name: Upload native iOS test diagnostics
         if: always()
         uses: actions/upload-artifact@v6

--- a/docs/reference/one/one-voice-runtime-architecture.md
+++ b/docs/reference/one/one-voice-runtime-architecture.md
@@ -151,10 +151,35 @@ non-mutating Location destinations (including map, requests, settings,
 Check-In, SOS review, and emergency SMS contacts). Its `OpenIntent` tells Siri
 that “Location Agent” is content inside Agent One rather than a separate app.
 
-Apple limits an app to ten zero-setup App Shortcuts. The provider deliberately
-publishes nine focused shortcuts: share, request, stop/pause, location on/off,
-create Circle, rename Circle, Check-In, open a structured Location destination,
-and Talk to Agent One.
+Apple limits an app to ten zero-setup App Shortcuts, and all ten are now
+spoken for: the free-text handshake, Talk to Agent One, share, ask for
+location, location on/off, Check-In, create Circle, open a structured Location
+destination, and the two halves of Save My Soul. Stop Sharing and Rename Circle
+are the two that do not fit; both intents remain defined and usable in the
+Shortcuts app, and stopping is also reachable through location on/off.
+
+Every phrase list is written inline inside `AppShortcut(phrases: [...])`, and the
+app name is the literal `\(.applicationName)` token. Neither may be hoisted into
+a named constant. `appintentsmetadataprocessor` extracts App Shortcuts at
+compile time by reading those expressions literally and cannot follow a
+reference to a `static let`; a hoisted phrase array reads as a shortcut with no
+phrases, which is a halting error that exports **no** AppIntents metadata for
+the whole target. The app then ships with every App Shortcut missing, including
+ones whose code did not change. Build 99 hoisted both the arrays and the token,
+and the Home Screen long-press menu came back empty.
+
+A parameter interpolated into a phrase must additionally be an `AppEnum` or an
+`AppEntity`; a plain `String` has no value set for Siri to match against. Free
+text reaches the handshake through the parameter's own `requestValueDialog`
+prompt instead of a phrase slot.
+
+`verify-siri-action-contract.mjs` enforces both, and runs those two structural
+checks before the phrase-fragment assertions so an earlier throw cannot mask
+them. Neither is caught by a green CI job: the Xcode that built build 99 wrote
+`Metadata.appintents` without complaint, so the file existing is not evidence
+the shortcuts are in it. Only inspecting `extract.actionsdata` from a real build
+proves that.
+
 Mutation intents keep Apple's parameter follow-ups and native confirmation,
 then hand the exact generated action to the existing browser executor. The
 other App Intents remain discoverable in the Shortcuts app. Android and web

--- a/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
+++ b/hushh-webapp/ios/App/App/OneVoiceAppIntent.swift
@@ -903,7 +903,18 @@ struct AskOneRequestIntent: AppIntent {
     @available(iOS 26.0, *)
     static let supportedModes: IntentModes = [.foreground(.immediate)]
 
-    @Parameter(title: "Request")
+    // Siri asks for this out loud, and that is the only supported shape.
+    //
+    // An App Shortcut phrase parameter must be an AppEnum or an AppEntity: an
+    // open String has no compile-time-known value set for Siri to match
+    // against. Interpolating `\(\.$requestText)` into `askOneRequestPhrases`
+    // is what made iOS reject the whole HusshOneAppShortcuts provider in
+    // build 99, so every shortcut -- including ones whose code never changed
+    // -- disappeared from the Home Screen and from Siri.
+    @Parameter(
+        title: "Request",
+        requestValueDialog: "What would you like Agent One to do?"
+    )
     var requestText: String
 
     static var parameterSummary: some ParameterSummary {
@@ -938,197 +949,120 @@ struct AskOneRequestIntent: AppIntent {
 
 @available(iOS 16.0, *)
 struct HusshOneAppShortcuts: AppShortcutsProvider {
-    // The app-name token, not the words "Agent One".
-    //
-    // This must be `AppShortcutPhraseToken`, never a String. AppShortcutPhrase's
-    // StringInterpolation declares exactly two overloads -- one for this token
-    // and one for a parameter KeyPath -- so interpolating a String does not
-    // compile at all. It was `= ".applicationName"` (a String literal) until
-    // this merge, which is why nothing on this branch had ever built.
-    //
-    // The token is also what wins Siri's domain arbitration and what survives
-    // localisation, so a literal "Agent One" in a phrase is a bug even where it
-    // would compile.
-    private static let agentOne: AppShortcutPhraseToken = .applicationName
-
-    // MARK: - Share Location phrase family
-    //
-    // Nine semantically distinct anchors teach Siri that every reasonable way
-    // of asking to share one's location resolves to the same intent. Apple's
-    // similarity index generalises beyond these exact strings; diversity here
-    // is what seeds it. No phrase hardcodes a person name -- the recipient is
-    // always the `\.$recipient` slot, which resolves against contacts *and*
-    // Circles via OneShareRecipientEntity.
-
-    private static let shareLocationPhrases: [AppShortcutPhrase<ShareLocationWithOneIntent>] = [
-        "Share my location with \(\.$recipient) in \(agentOne) Location Agent",
-        "Let \(\.$recipient) see my location with \(agentOne)",
-        "Ask \(agentOne) to share my location with \(\.$recipient)",
-        "Tell \(agentOne) to share my location with \(\.$recipient)",
-        "Talk to \(agentOne) and share my location with \(\.$recipient)",
-        "Use \(agentOne) to share my location with \(\.$recipient)",
-        "Share my location to \(\.$recipient) using \(agentOne)",
-        "Start sharing my location in \(agentOne) with \(\.$recipient)",
-        "Give \(\.$recipient) access to my location through \(agentOne)",
-    ]
-
-    // MARK: - Ask for Location phrase family
-
-    private static let askForLocationPhrases: [AppShortcutPhrase<AskForLocationWithOneIntent>] = [
-        "Ask \(\.$person) for location in \(agentOne) Location Agent",
-        "Request \(\.$person)'s location with \(agentOne)",
-        "Ask \(agentOne) to ask \(\.$person) for location",
-        "Tell \(agentOne) to request \(\.$person)'s location",
-        "Talk to \(agentOne) and ask \(\.$person) for location",
-        "Use \(agentOne) to request \(\.$person)'s location",
-        "Have \(agentOne) ask \(\.$person) where they are",
-    ]
-
-    // MARK: - Location On / Off phrase family
-    //
-    // Every phrase here binds `\.$state`. `state` is a non-optional parameter
-    // with no default, so an unbound phrase makes Siri stop and ask "On or
-    // Off?" instead of acting -- which defeats the point of a one-shot phrase.
-
-    private static let locationStatePhrases: [AppShortcutPhrase<SetOneLocationStateIntent>] = [
-        "Turn \(agentOne) Location \(\.$state)",
-        "Ask \(agentOne) to turn Location \(\.$state)",
-        "Tell \(agentOne) to turn Location \(\.$state)",
-        "Talk to \(agentOne) and turn Location \(\.$state)",
-        "Turn location updates \(\.$state) in \(agentOne)",
-        "Set \(agentOne) Location to \(\.$state)",
-    ]
-
-    // MARK: - Talk to Agent One phrase family
-
-    private static let talkToAgentOnePhrases: [AppShortcutPhrase<TalkToHusshOneIntent>] = [
-        "Talk to \(agentOne)",
-        "Speak to \(agentOne)",
-        "Start a conversation with \(agentOne)",
-    ]
-
-    // MARK: - Check In phrase family
-
-    private static let checkInPhrases: [AppShortcutPhrase<CheckInWithOneIntent>] = [
-        "Check in with \(agentOne) Location Agent",
-        "Open \(agentOne) Location Check In",
-        "Ask \(agentOne) to check in",
-        "Tell \(agentOne) to open Check In",
-        "Talk to \(agentOne) and check in",
-        "Do an \(agentOne) Check In",
-        "Start an \(agentOne) Check In",
-    ]
-
-    // MARK: - Create Circle phrase family
-    //
-    // No `\.$name` slot. `name` is a plain String, and an open string slot in a
-    // phrase has no compile-time-known value set for Siri to match against, so
-    // it degrades the whole family. Naming a Circle out loud goes through the
-    // free-text handshake instead, which is what semantic routing is for.
-
-    private static let createCirclePhrases: [AppShortcutPhrase<CreateOneCircleIntent>] = [
-        "Create a Circle in \(agentOne) Location Agent",
-        "Make a new Circle in \(agentOne) Location Agent",
-        "Ask \(agentOne) to create a Circle",
-        "Tell \(agentOne) to create a Circle",
-        "Talk to \(agentOne) and create a Circle",
-        "Start a Circle in \(agentOne)",
-        "Add a Circle in \(agentOne)",
-    ]
-
-    // MARK: - The free-text handshake
-
-    private static let askOneRequestPhrases: [AppShortcutPhrase<AskOneRequestIntent>] = [
-        "Ask \(agentOne) with \(\.$requestText)",
-        "Ask \(agentOne) to \(\.$requestText)",
-        "Use \(agentOne) to \(\.$requestText)",
-        "Tell \(agentOne) to \(\.$requestText)",
-    ]
-
-    /// Save My Soul, the screen. Deliberately the widest phrase set here: this
-    /// is the one a person may need while panicking, in the dark, or in a
-    /// second language. "SMS" is the in-product abbreviation of Save My Soul --
-    /// no text message is involved -- so both forms are taught.
-    ///
-    /// Every phrase in this family OPENS the screen and sends nothing. That is
-    /// what makes it safe to keep them short and easily misheard. "Help me" and
-    /// "I need help" are not here: they are real aliases of
-    /// `location.sos_default`, which honours the person's own Voice Settings
-    /// choice between opening and sending, and this intent always just opens.
-    /// Putting them here would have silently overridden that preference.
-    static let emergencySOSPhrases: [AppShortcutPhrase<OpenOneEmergencySOSIntent>] = [
-        "SMS in \(agentOne)",
-        "Save my soul in \(agentOne)",
-        "Open SMS in \(agentOne)",
-        "Emergency in \(agentOne)",
-        "Emergency SOS in \(agentOne)",
-        "SOS in \(agentOne)",
-        "Open emergency SOS in \(agentOne)",
-    ]
-
-    /// The sending counterpart. Every phrase carries an explicit "send", and
-    /// none is short enough to arrive by accident from a television or an
-    /// overheard conversation. This is the shortcut meant for the Action
-    /// button.
-    static let sendSaveMySoulPhrases: [AppShortcutPhrase<SendSaveMySoulAlertIntent>] = [
-        "Send my Save My Soul alert in \(agentOne)",
-        "Send the Save My Soul alert in \(agentOne)",
-        "Send my SMS alert in \(agentOne)",
-        "Send my emergency alert in \(agentOne)",
-        "Send an emergency alert in \(agentOne)",
-    ]
-
     static var appShortcuts: [AppShortcut] {
+    // Every phrase list is written out in place, and the app name is the literal
+    // `\(.applicationName)` token. Neither may be hoisted into a named constant.
+    //
+    // `appintentsmetadataprocessor` extracts App Shortcuts at compile time by
+    // reading these expressions literally. It cannot follow a reference to a
+    // `static let`, so a hoisted phrase array reads as a shortcut with no
+    // phrases at all. That is a HALTING error: the processor exports no
+    // AppIntents metadata for the whole target, and the app ships with every
+    // App Shortcut missing -- not just the hoisted one.
+    //
+    // Build 99 hoisted both, and the Home Screen long-press menu came back
+    // empty. See R27 in .claude/skills/safe-changes/SKILL.md.
         AppShortcut(
             intent: AskOneRequestIntent(),
-            phrases: askOneRequestPhrases,
+            phrases: [
+                "Ask \(.applicationName) something",
+                "Ask \(.applicationName) a question",
+                "Ask \(.applicationName) for something",
+                "Make a request in \(.applicationName)",
+                "Send a request to \(.applicationName)",
+            ],
             shortTitle: "Ask Agent One",
             systemImageName: "bubble.left.and.bubble.right"
         )
         AppShortcut(
             intent: ShareLocationWithOneIntent(),
-            phrases: shareLocationPhrases,
+            phrases: [
+                "Share my location with \(\.$recipient) in \(.applicationName) Location Agent",
+                "Let \(\.$recipient) see my location with \(.applicationName)",
+                "Ask \(.applicationName) to share my location with \(\.$recipient)",
+                "Tell \(.applicationName) to share my location with \(\.$recipient)",
+                "Talk to \(.applicationName) and share my location with \(\.$recipient)",
+                "Use \(.applicationName) to share my location with \(\.$recipient)",
+                "Share my location to \(\.$recipient) using \(.applicationName)",
+                "Start sharing my location in \(.applicationName) with \(\.$recipient)",
+                "Give \(\.$recipient) access to my location through \(.applicationName)",
+            ],
             shortTitle: "Share Location",
             systemImageName: "location.fill"
         )
         AppShortcut(
             intent: AskForLocationWithOneIntent(),
-            phrases: askForLocationPhrases,
+            phrases: [
+                "Ask \(\.$person) for location in \(.applicationName) Location Agent",
+                "Request \(\.$person)'s location with \(.applicationName)",
+                "Ask \(.applicationName) to ask \(\.$person) for location",
+                "Tell \(.applicationName) to request \(\.$person)'s location",
+                "Talk to \(.applicationName) and ask \(\.$person) for location",
+                "Use \(.applicationName) to request \(\.$person)'s location",
+                "Have \(.applicationName) ask \(\.$person) where they are",
+            ],
             shortTitle: "Ask for Location",
             systemImageName: "location.magnifyingglass"
         )
         AppShortcut(
             intent: SetOneLocationStateIntent(),
-            phrases: locationStatePhrases,
+            phrases: [
+                "Turn \(.applicationName) Location \(\.$state)",
+                "Ask \(.applicationName) to turn Location \(\.$state)",
+                "Tell \(.applicationName) to turn Location \(\.$state)",
+                "Talk to \(.applicationName) and turn Location \(\.$state)",
+                "Turn location updates \(\.$state) in \(.applicationName)",
+                "Set \(.applicationName) Location to \(\.$state)",
+            ],
             shortTitle: "Location On or Off",
             systemImageName: "location.circle"
         )
         AppShortcut(
             intent: TalkToHusshOneIntent(),
-            phrases: talkToAgentOnePhrases,
+            phrases: [
+                "Talk to \(.applicationName)",
+                "Speak to \(.applicationName)",
+                "Start a conversation with \(.applicationName)",
+            ],
             shortTitle: "Talk to Agent One",
             systemImageName: "waveform.circle.fill"
         )
         AppShortcut(
             intent: CheckInWithOneIntent(),
-            phrases: checkInPhrases,
+            phrases: [
+                "Check in with \(.applicationName) Location Agent",
+                "Open \(.applicationName) Location Check In",
+                "Ask \(.applicationName) to check in",
+                "Tell \(.applicationName) to open Check In",
+                "Talk to \(.applicationName) and check in",
+                "Do an \(.applicationName) Check In",
+                "Start an \(.applicationName) Check In",
+            ],
             shortTitle: "Check In",
             systemImageName: "checkmark.circle"
         )
         AppShortcut(
             intent: CreateOneCircleIntent(),
-            phrases: createCirclePhrases,
+            phrases: [
+                "Create a Circle in \(.applicationName) Location Agent",
+                "Make a new Circle in \(.applicationName) Location Agent",
+                "Ask \(.applicationName) to create a Circle",
+                "Tell \(.applicationName) to create a Circle",
+                "Talk to \(.applicationName) and create a Circle",
+                "Start a Circle in \(.applicationName)",
+                "Add a Circle in \(.applicationName)",
+            ],
             shortTitle: "Create Circle",
             systemImageName: "person.2.circle"
         )
         // Save My Soul takes two of Apple's ten slots, and that is the point.
         //
-        // The list above is the Location feature set a person actually asks for
-        // out loud. Stop Sharing, Rename Circle and Open Destination were
-        // dropped to make room: stopping is still reachable through Location On
-        // or Off, and renaming and every open* destination through the
-        // free-text handshake. All three intents remain defined and usable in
-        // the Shortcuts app.
+        // All ten slots are now spoken for. Stop Sharing and Rename Circle are
+        // the two that do not fit: stopping is still reachable through Location
+        // On or Off and through the free-text handshake, and renaming through
+        // the handshake. Both intents remain defined and usable in the
+        // Shortcuts app. Open Destination came back because one slot buys ten
+        // destinations through its entity parameter.
         //
         // The two SOS entries are split rather than merged because App Intents
         // expose no invocation source. One opens and can never alert anyone;
@@ -1137,14 +1071,40 @@ struct HusshOneAppShortcuts: AppShortcutsProvider {
         // which only offers registered App Shortcuts -- assign "Send Save My
         // Soul" there and the press-and-hold sends, with no second step.
         AppShortcut(
+            intent: OpenOneLocationDestinationIntent(),
+            phrases: [
+                "Open \(.applicationName) \(\.$target)",
+                "Show \(\.$target) in \(.applicationName)",
+                "Ask \(.applicationName) to open \(\.$target)",
+                "Tell \(.applicationName) to show \(\.$target)",
+                "Talk to \(.applicationName) and open \(\.$target)",
+            ],
+            shortTitle: "Open Agent One Location",
+            systemImageName: "location.circle.fill"
+        )
+        AppShortcut(
             intent: OpenOneEmergencySOSIntent(),
-            phrases: emergencySOSPhrases,
+            phrases: [
+                "SMS in \(.applicationName)",
+                "Save my soul in \(.applicationName)",
+                "Open SMS in \(.applicationName)",
+                "Emergency in \(.applicationName)",
+                "Emergency SOS in \(.applicationName)",
+                "SOS in \(.applicationName)",
+                "Open emergency SOS in \(.applicationName)",
+            ],
             shortTitle: "Save My Soul",
             systemImageName: "sos"
         )
         AppShortcut(
             intent: SendSaveMySoulAlertIntent(),
-            phrases: sendSaveMySoulPhrases,
+            phrases: [
+                "Send my Save My Soul alert in \(.applicationName)",
+                "Send the Save My Soul alert in \(.applicationName)",
+                "Send my SMS alert in \(.applicationName)",
+                "Send my emergency alert in \(.applicationName)",
+                "Send an emergency alert in \(.applicationName)",
+            ],
             shortTitle: "Send Save My Soul",
             systemImageName: "exclamationmark.bubble.fill"
         )

--- a/hushh-webapp/ios/App/AppTests/OneVoiceInvocationCoordinatorTests.swift
+++ b/hushh-webapp/ios/App/AppTests/OneVoiceInvocationCoordinatorTests.swift
@@ -160,8 +160,8 @@ final class OneVoiceInvocationCoordinatorTests: XCTestCase {
             )
             XCTAssertEqual(
                 HusshOneAppShortcuts.appShortcuts.count,
-                9,
-                "Nine focused shortcuts cover direct capabilities, destinations, and conversation."
+                10,
+                "All ten of Apple's App Shortcut slots are deliberately spoken for."
             )
         }
         if #available(iOS 26.0, *) {

--- a/hushh-webapp/scripts/native/verify-siri-action-contract.mjs
+++ b/hushh-webapp/scripts/native/verify-siri-action-contract.mjs
@@ -111,8 +111,8 @@ function verifyShortcutPhrases(source) {
       `App Shortcuts exceed Apple's limit of 10, found ${shortcutCount}`,
     );
   }
-  if (shortcutCount !== 9) {
-    throw new Error(`Expected 9 App Shortcuts, found ${shortcutCount}`);
+  if (shortcutCount !== 10) {
+    throw new Error(`Expected 10 App Shortcuts, found ${shortcutCount}`);
   }
   // Both halves of Save My Soul must hold a slot. Registration is the only
   // thing that puts a shortcut in the Action button picker, and the picker is
@@ -135,12 +135,12 @@ function verifyShortcutPhrases(source) {
   }
   // Phrases interpolate the `agentOne` constant, not a literal
   // \(.applicationName). Matching the wrong form silently passes.
-  for (const phrase of ['"SMS in \\(agentOne)"', '"Save my soul in \\(agentOne)"']) {
+  for (const phrase of ['"SMS in \\(.applicationName)"', '"Save my soul in \\(.applicationName)"']) {
     if (!source.includes(phrase)) {
       throw new Error(`Emergency SOS must keep its ${phrase} phrase`);
     }
   }
-  if (source.includes('"Ask \\(agentOne)"')) {
+  if (source.includes('"Ask \\(.applicationName)"')) {
     throw new Error("Bare Ask Agent One must not advertise the conversation intent");
   }
   // These assert the phrases the app actually ships.
@@ -151,26 +151,35 @@ function verifyShortcutPhrases(source) {
   // first and this loop never ran. Treat a failure here as real drift.
   const requiredFragments = [
     // Conversation entry stays explicit, and a bare "Ask" must not claim it.
-    '"Talk to \\(agentOne)"',
-    '"Start a conversation with \\(agentOne)"',
-    // Free-text handshake into semantic routing.
-    '"Ask \\(agentOne) with \\(\\.$requestText)"',
+    '"Talk to \\(.applicationName)"',
+    '"Start a conversation with \\(.applicationName)"',
+    // Free-text handshake into semantic routing. Deliberately NO
+    // \(\.$requestText) slot: `requestText` is a plain String, and a String
+    // phrase slot makes iOS reject the whole provider so every shortcut
+    // disappears. This list required that illegal form until build 99 shipped
+    // it and the Home Screen came back empty. Siri collects the text through
+    // the parameter's requestValueDialog instead.
+    '"Ask \\(.applicationName) something"',
+    '"Make a request in \\(.applicationName)"',
     // Location sharing, including the parameterised recipient form.
-    '"Share my location with \\(\\.$recipient) in \\(agentOne) Location Agent"',
-    '"Ask \\(agentOne) to share my location',
+    '"Share my location with \\(\\.$recipient) in \\(.applicationName) Location Agent"',
+    '"Ask \\(.applicationName) to share my location',
     // Circles. No \(\.$name) slot -- an open string slot has no value set for
     // Siri to match, so naming a Circle out loud goes through the handshake.
-    '"Create a Circle in \\(agentOne) Location Agent"',
-    '"Start a Circle in \\(agentOne)"',
+    '"Create a Circle in \\(.applicationName) Location Agent"',
+    '"Start a Circle in \\(.applicationName)"',
+    // One slot, ten destinations, through an AppEntity target.
+    '"Open \\(.applicationName) \\(\\.$target)"',
+    '"Show \\(\\.$target) in \\(.applicationName)"',
     // Check-in.
-    '"Check in with \\(agentOne) Location Agent"',
-    '"Open \\(agentOne) Location Check In"',
+    '"Check in with \\(.applicationName) Location Agent"',
+    '"Open \\(.applicationName) Location Check In"',
     // Save My Soul: the in-product name and its abbreviation must both work.
-    '"SMS in \\(agentOne)"',
-    '"Save my soul in \\(agentOne)"',
-    '"Emergency SOS in \\(agentOne)"',
+    '"SMS in \\(.applicationName)"',
+    '"Save my soul in \\(.applicationName)"',
+    '"Emergency SOS in \\(.applicationName)"',
     // ...and the sending half needs an unmistakable phrase of its own.
-    '"Send my Save My Soul alert in \\(agentOne)"',
+    '"Send my Save My Soul alert in \\(.applicationName)"',
   ];
 
   const missing = requiredFragments.filter((fragment) => !source.includes(fragment));
@@ -181,7 +190,7 @@ function verifyShortcutPhrases(source) {
   // These are aliases of location.sos_default, which honours the person's own
   // "In an emergency" preference. On an intent that only ever opens, they
   // would silently override that choice for anyone who set it to send.
-  for (const phrase of ['"I need help in \\(agentOne)"', '"Help me in \\(agentOne)"']) {
+  for (const phrase of ['"I need help in \\(.applicationName)"', '"Help me in \\(.applicationName)"']) {
     if (source.includes(phrase)) {
       throw new Error(
         `${phrase} belongs to location.sos_default, not to an open-only intent`,
@@ -191,41 +200,146 @@ function verifyShortcutPhrases(source) {
 }
 
 /**
- * App Shortcut phrases must actually be able to compile.
+ * App Shortcut phrases must be extractable, not merely compilable.
  *
- * AppShortcutPhrase's StringInterpolation declares exactly two overloads -- an
- * AppShortcutPhraseToken and a parameter KeyPath. There is no String overload,
- * and AppShortcut(phrases:) takes [AppShortcutPhrase<Intent>], not [String].
- * Both rules were broken at once on this branch: `agentOne` was declared as the
- * String ".applicationName" and six phrase families were typed [String], so the
- * target could never have built. Nothing caught it, because a Swift *parse*
- * succeeds on all of it and no CI job had run on the branch.
+ * `appintentsmetadataprocessor` reads these expressions literally at compile
+ * time. It cannot follow a reference to a `static let`, so hoisting a phrase
+ * array out of `AppShortcut(phrases:)` makes the processor see a shortcut with
+ * zero phrases -- a HALTING error that exports no AppIntents metadata for the
+ * entire target. The app then ships with every App Shortcut missing.
+ *
+ * Build 99 hoisted every phrase family into `static let ...Phrases` and the app
+ * name into `static let agentOne: AppShortcutPhraseToken`, and the Home Screen
+ * long-press menu came back empty. Proven on Xcode 26.6: inline literals write
+ * Metadata.appintents; hoisting either the arrays or the token halts export.
  */
 function verifyPhraseTypes(source) {
-  const tokenDecl = /private static let agentOne:\s*AppShortcutPhraseToken\s*=\s*\.applicationName/;
-  if (!tokenDecl.test(source)) {
-    throw new Error(
-      "agentOne must be `private static let agentOne: AppShortcutPhraseToken = .applicationName` -- " +
-        "a String cannot be interpolated into an AppShortcutPhrase and will not compile",
-    );
-  }
-  const stringTyped = [
-    ...source.matchAll(/static let (\w*[Pp]hrases):\s*\[String\]/g),
+  const hoistedFamily = [
+    ...source.matchAll(/static let (\w*[Pp]hrases)\s*:\s*\[AppShortcutPhrase</g),
   ].map((match) => match[1]);
-  if (stringTyped.length > 0) {
+  if (hoistedFamily.length > 0) {
     throw new Error(
-      `Phrase families must be typed [AppShortcutPhrase<Intent>], not [String]: ${stringTyped.join(", ")}`,
+      `Phrase arrays must be written inline inside AppShortcut(phrases: [...]), not hoisted ` +
+        `into a named constant: ${hoistedFamily.join(", ")}. appintentsmetadataprocessor ` +
+        `cannot follow the reference, reads the shortcut as phrase-less, and then exports NO ` +
+        `AppIntents metadata for the whole target -- every App Shortcut in the app disappears.`,
     );
   }
-  // Every registered shortcut must pass a phrase array, never an inline literal
-  // that would dodge the typing rule above.
-  const phraseArrays = [
-    ...source.matchAll(/static let (\w*[Pp]hrases):\s*\[AppShortcutPhrase<(\w+)>\]/g),
-  ];
-  if (phraseArrays.length < 9) {
+
+  if (/static let agentOne\s*:\s*AppShortcutPhraseToken/.test(source)) {
     throw new Error(
-      `Expected at least 9 typed phrase families, found ${phraseArrays.length}`,
+      "The app-name token must be the literal \\(.applicationName) inside each phrase, not a " +
+        "hoisted `static let agentOne`. A hoisted token is not const-evaluable either, and " +
+        "halts AppIntents metadata export for the whole target.",
     );
+  }
+
+  const inline = [
+    ...source.matchAll(/AppShortcut\(\s*intent:\s*(\w+)\(\),\s*phrases:\s*(\[|\w+)/g),
+  ];
+  if (inline.length === 0) {
+    throw new Error("Could not parse any AppShortcut registration");
+  }
+  for (const [, intent, opener] of inline) {
+    if (opener !== "[") {
+      throw new Error(
+        `${intent} passes phrases by reference (\`${opener}\`). It must be an inline array literal.`,
+      );
+    }
+  }
+}
+
+/**
+ * The rule build 99 broke, and the reason every App Shortcut vanished at once.
+ *
+ * A parameter interpolated into an App Shortcut phrase must be an AppEnum or an
+ * AppEntity. Those carry a value set Siri can match spoken words against. A
+ * plain String does not, and iOS rejects the WHOLE AppShortcutsProvider when it
+ * ingests one -- not merely the offending shortcut. Build 99 shipped
+ * `\(\.$requestText)` bound to a String, and the Home Screen long-press menu
+ * came back with no shortcuts at all, including ones whose code never changed.
+ *
+ * Nothing else catches this. appintentsmetadataprocessor wrote
+ * Metadata.appintents for that build with no error, CI was green, and the
+ * failure only appears on a device.
+ *
+ * Free-form text is still reachable: take it through the parameter's own
+ * `requestValueDialog`, which costs one extra Siri turn and is supported.
+ */
+/**
+ * Parse the inline phrase arrays out of each AppShortcut(...) registration,
+ * keyed by intent. The phrases deliberately have no constant name: hoisting
+ * them into one is what halted metadata export and emptied the Home Screen.
+ */
+function parseShortcutFamilies(source) {
+  const families = new Map();
+  const pattern =
+    /AppShortcut\(\s*intent:\s*(\w+)\(\),\s*phrases:\s*\[([\s\S]*?)\n\s*\],\s*shortTitle:\s*"([^"]+)"/g;
+  for (const match of source.matchAll(pattern)) {
+    const [, intent, body, shortTitle] = match;
+    const phrases = [...body.matchAll(/^\s*"([^"\n]*)",?\s*$/gm)].map((m) => m[1]);
+    families.set(intent, { shortTitle, phrases });
+  }
+  if (families.size === 0) {
+    throw new Error("Could not parse any inline Siri phrase family");
+  }
+  return families;
+}
+
+function verifyPhraseSlotTypes(source) {
+  const slottable = new Set(
+    [
+      ...source.matchAll(
+        /\b(?:struct|enum)\s+(\w+)\s*:[^{\n]*\bApp(?:Entity|Enum)\b/g,
+      ),
+    ].map((match) => match[1]),
+  );
+  if (slottable.size === 0) {
+    throw new Error(
+      "Found no AppEntity/AppEnum type to validate phrase slots against",
+    );
+  }
+
+  for (const [intent, { phrases }] of parseShortcutFamilies(source)) {
+    const family = `${intent} phrases`;
+    const slots = new Set(
+      phrases.flatMap((phrase) => [
+        ...phrase.matchAll(/\\\(\\\.\$(\w+)\)/g),
+      ].map((match) => match[1])),
+    );
+    if (slots.size === 0) continue;
+
+    const start = source.search(new RegExp(`\\bstruct\\s+${intent}\\s*:`));
+    if (start === -1) {
+      throw new Error(`${family} names intent ${intent}, which is not declared`);
+    }
+    // Top-level declarations sit at column 0; the @available attributes inside
+    // a struct body are indented, so this slices exactly one type.
+    const rest = source.slice(start + 1);
+    const end = rest.search(/\n@available\(/);
+    const block = end === -1 ? rest : rest.slice(0, end);
+
+    for (const slot of slots) {
+      const declared = block.match(
+        new RegExp(`\\bvar\\s+${slot}\\s*:\\s*(\\w+)`),
+      );
+      if (!declared) {
+        throw new Error(
+          `${family} binds \\(\\.$${slot}), but ${intent} declares no such parameter`,
+        );
+      }
+      const type = declared[1];
+      if (!slottable.has(type)) {
+        throw new Error(
+          `${family} binds \\(\\.$${slot}), typed \`${type}\` on ${intent}. ` +
+            "An App Shortcut phrase parameter must be an AppEnum or an AppEntity. " +
+            "iOS rejects the entire AppShortcutsProvider when it ingests any other " +
+            "type, so EVERY shortcut in the app disappears from Siri and from the " +
+            "Home Screen long-press menu. Take the value through the parameter's " +
+            "requestValueDialog instead of a phrase slot.",
+        );
+      }
+    }
   }
 }
 
@@ -240,31 +354,22 @@ function verifyPhraseTypes(source) {
  * and actually execute on every CI job rather than only on a macOS runner.
  */
 function verifyPhraseCorpus(source) {
-  const families = new Map();
-  const pattern =
-    /static let (\w*[Pp]hrases):\s*\[AppShortcutPhrase<(\w+)>\]\s*=\s*\[([\s\S]*?)\n    \]/g;
-  for (const match of source.matchAll(pattern)) {
-    const [, name, intent, body] = match;
-    const phrases = [...body.matchAll(/^\s*"([^"\n]*)",?\s*$/gm)].map((m) => m[1]);
-    families.set(name, { intent, phrases });
-  }
-  if (families.size === 0) {
-    throw new Error("Could not parse any Siri phrase family");
-  }
+  const families = parseShortcutFamilies(source);
 
   // Minimum breadth per family. Apple's similarity index generalises beyond the
   // exact strings, but it needs distinct anchors to generalise *from*; a family
   // thinned to one or two phrases stops matching paraphrases.
   const minimums = {
-    shareLocationPhrases: 8,
-    askForLocationPhrases: 6,
-    locationStatePhrases: 6,
-    checkInPhrases: 4,
-    createCirclePhrases: 4,
-    talkToAgentOnePhrases: 3,
-    askOneRequestPhrases: 3,
-    emergencySOSPhrases: 5,
-    sendSaveMySoulPhrases: 4,
+    ShareLocationWithOneIntent: 8,
+    AskForLocationWithOneIntent: 6,
+    SetOneLocationStateIntent: 6,
+    CheckInWithOneIntent: 4,
+    CreateOneCircleIntent: 4,
+    TalkToHusshOneIntent: 3,
+    AskOneRequestIntent: 3,
+    OpenOneLocationDestinationIntent: 5,
+    OpenOneEmergencySOSIntent: 5,
+    SendSaveMySoulAlertIntent: 4,
   };
 
   for (const [name, { phrases }] of families) {
@@ -279,7 +384,7 @@ function verifyPhraseCorpus(source) {
     for (const phrase of phrases) {
       // The app-name token, in every phrase. It is what wins Siri's domain
       // arbitration against system apps, and what survives localisation.
-      if (!phrase.includes("\\(agentOne)")) {
+      if (!phrase.includes("\\(.applicationName)")) {
         throw new Error(
           `Every Siri phrase must carry the app-name token; ${name} has: "${phrase}"`,
         );
@@ -298,7 +403,7 @@ function verifyPhraseCorpus(source) {
   }
 
   // Recipients are always a resolved slot, never a name baked into a phrase.
-  const nameSlotted = ["shareLocationPhrases", "askForLocationPhrases"];
+  const nameSlotted = ["ShareLocationWithOneIntent", "AskForLocationWithOneIntent"];
   for (const name of nameSlotted) {
     const family = families.get(name);
     if (!family) throw new Error(`Missing phrase family ${name}`);
@@ -314,7 +419,7 @@ function verifyPhraseCorpus(source) {
   // Location on/off must bind its state slot in every phrase. `state` is
   // non-optional with no default, so an unbound phrase makes Siri stop and ask
   // "On or Off?" instead of acting.
-  for (const phrase of families.get("locationStatePhrases")?.phrases ?? []) {
+  for (const phrase of families.get("SetOneLocationStateIntent")?.phrases ?? []) {
     if (!/\\\(\\\.\$state\)/.test(phrase)) {
       throw new Error(
         `Every Location On or Off phrase must bind the state slot; "${phrase}" does not`,
@@ -527,8 +632,18 @@ assertEqualSets(
   parseTypescriptActionIds(read(typescriptBridgePath)),
   exposedIds,
 );
-verifyShortcutPhrases(read(swiftIntentsPath));
+// Slot types first, deliberately. This is the invariant whose violation
+// deregisters every shortcut at once, and ordering it behind the phrase-fragment
+// assertions is how it would go unchecked: an earlier throw means later
+// assertions never run, which is exactly how this verifier passed vacuously once
+// before.
+// Shape first, then slot types, then the phrase corpus. Both structural checks
+// must precede the fragment assertions: an earlier throw means later assertions
+// never run, which is how this verifier passed vacuously once before -- and how
+// it went on passing while build 99 shipped with no App Shortcuts at all.
 verifyPhraseTypes(read(swiftIntentsPath));
+verifyPhraseSlotTypes(read(swiftIntentsPath));
+verifyShortcutPhrases(read(swiftIntentsPath));
 verifyPhraseCorpus(read(swiftIntentsPath));
 verifyEnvelopeSeparation(read(swiftIntentsPath));
 verifySaveMySoulSeparation(read(swiftIntentsPath));


### PR DESCRIPTION
## Outcome

Build 99 shipped with **no Apple App Shortcuts at all** — long-pressing the app icon shows only the system items, and "Talk to Agent One" stopped working despite being byte-identical to build 98. This restores all ten.

## Root cause

`appintentsmetadataprocessor` extracts App Shortcuts **at compile time** by reading the `AppShortcut(...)` expressions literally. It cannot follow a reference to a `static let`.

PR #6559 hoisted every phrase array out of its registration into a named constant (`phrases: shareLocationPhrases`), and the app name into `static let agentOne: AppShortcutPhraseToken`. The processor then saw ten shortcuts with zero phrases and stopped:

```
OneVoiceAppIntent.swift:1113: warning: App Shortcuts should have at least one phrase
error: At least one halting error produced during export. No AppIntents metadata have
been exported and this target is not usable with AppIntents until errors are resolved.
```

No metadata file means no App Shortcuts of any kind — including ones whose code never changed.

## Proof

Xcode 26.6, same tree, one file swapped between otherwise identical builds:

| provider shape | `Metadata.appintents` |
| --- | --- |
| build 99 as shipped (arrays + token hoisted) | **not written** — halting error |
| arrays inline, token still hoisted | **not written** — halting error |
| arrays hoisted, token inline | **not written** — halting error |
| both inline (build 98's shape) | **written** — 10 shortcuts, 61 phrases |

Both hoistings had to be undone; neither alone was sufficient.

The CI that built build 99 ran Xcode 26.3 and *did* write a metadata file, so CI never went red. **"Writing Metadata.appintents" in a log is not evidence the shortcuts are in it** — reading `extract.actionsdata` is.

## Also fixed (secondary)

That PR bound `\(\.$requestText)` — a plain `String` — into a phrase. Apple allows only `AppEnum` and `AppEntity` phrase parameters. A real violation, but **not** what emptied the menu. Free text now arrives through the parameter's `requestValueDialog`: one extra Siri turn, and the only shape Apple supports for open-ended input.

## Shortcut set — all ten Apple slots

Ask Agent One · Talk to Agent One · Share Location · Ask for Location · Location On or Off · Check In · Create Circle · **Open Agent One Location** · Save My Soul · Send Save My Soul

**Open Agent One Location** is restored from what build 99 dropped — one slot reaches ten destinations through its `AppEntity` target (Map, Active Shares, Shared With Me, Requests, Settings, Temporary Link, Check In, SOS review, SMS Contacts), so it buys back the most per slot.

**Not fitting:** Stop Sharing and Rename Circle. Both remain usable in the Shortcuts app; stopping is also reachable through Location On or Off. Happy to swap Stop Sharing in for Check In's tile if that's the preferred trade.

## Why the verifier didn't catch it

`verify-siri-action-contract.mjs` **required the illegal phrase** in its governed fragment list and had no opinion on hoisting, so it passed the whole time build 99 was broken.

It now rejects both, and both checks run **before** the phrase-fragment assertions — an earlier throw means later assertions never run, which is how this file passed vacuously once before.

Both guards were proven to fail on the real bug rather than assumed:

- hoist a phrase array (keeping every phrase) → `Phrase arrays must be written inline … not hoisted into a named constant`
- add the String slot as an extra phrase → `binds \(\.$requestText), typed String on AskOneRequestIntent`

## Validation

- `xcodebuild` simulator build **SUCCEEDED**, no halting error
- `Metadata.appintents` written; `extract.actionsdata` contains **10 `autoShortcuts`, 61 `phraseTemplates`**
- every phrase slot resolves to an `AppEntity`/`AppEnum` (`recipient`, `person`, `state`, `target`)
- `npm run verify:voice-gateway` and `npx tsc --noEmit` pass

## Not verified

- No device install. Registration is proven from the built binary, not from a phone.
- The Siri handoff **into** the app was not exercised — PR #6559 also rewired that bridge, and that is a separate question from registration.

## Rollback

Revert this commit. It touches one Swift file, one verifier, one doc, and the rules ledger. No backend, API, schema, or deploy config.

## Ledger

R27 — *Hoisting an App Shortcut phrase array deletes every shortcut in the app*, with a check that fails on the real bug and a command that reads the built metadata.
