### PR TITLE
fix(db+one): unblock UAT — name the failing migration, and repair the CHECK that will kill the next deploy

### DIFF
--- a/.claude/skills/safe-changes/SKILL.md
+++ b/.claude/skills/safe-changes/SKILL.md
@@ -1027,3 +1027,49 @@ would have broken.
 The Check line must be a command that **runs in this repo** and returns
 something meaningful. Run it before committing the rule. A rule with a command
 that doesn't work here is worse than no rule.
+
+### R28 — An error handler that runs on a broken connection will report itself instead of the failure
+
+**Incident (2026-09-07, six consecutive UAT deploys.)** Every one failed at
+"Apply UAT DB migrations behind account deletion fence" with
+`asyncpg.exceptions.InFailedSQLTransactionError: current transaction is aborted`.
+That was never the failure. The real one, four frames up the chained traceback,
+was `LockNotAvailableError: canceling statement due to lock timeout`.
+
+`apply_manifest_entries` rolled the failed transaction back only when
+`mode is not MigrationMode.REPLAY` — and UAT runs in `replay`. So a replay
+failure left the connection aborted, and the function's own
+`finally: await _unlock(conn)` then issued `SELECT pg_advisory_unlock($1)` on
+that dead connection. Its exception propagated **in place of** the migration's.
+The cleanup step overwrote the diagnosis.
+
+It compounded with a second gap: nothing in that function ever named
+`entry.filename`. UAT replays 173 migrations per deploy, so the log said a
+migration failed and gave no way to learn which one. Six deploys produced six
+identical, useless tracebacks.
+
+**Rule.** Cleanup in a `finally` — unlock, close, release, flush — must not be
+able to replace the exception that brought you there. Wrap it and swallow its
+own failure. Any loop applying a batch of units must name the unit in the error;
+"something in this batch failed" is not a diagnosis. And when an error path is
+gated on a mode, check whether the *cleanup* it also skips is needed in every
+mode. Diagnostics must not quote the database's message — a Postgres error can
+carry row values (a unique violation names the key and its value) — so report
+the exception class and its SQLSTATE instead.
+
+**Check.**
+```bash
+cd ~/Desktop/husshOne/consent-protocol
+# The unlock must be guarded, and the rollback must not be inside the mode gate.
+python3 - <<'PY'
+import re, pathlib
+s = pathlib.Path("db/migration_authority.py").read_text()
+tail = s.split("async def apply_manifest_entries")[1].split("    finally:")[1]
+print("unlock guarded:", "try:" in tail and "_unlock(conn)" in tail)
+blk = re.search(r"except Exception as exc:(.*?)\n                raise", s, re.S).group(1)
+print("rollback before mode gate:",
+      blk.index("_rollback_failed_transaction") < blk.index("if mode is not"))
+print("failure names the file:", "entry.filename" in blk)
+PY
+```
+All three must print `True`.

--- a/.claude/skills/safe-changes/SKILL.md
+++ b/.claude/skills/safe-changes/SKILL.md
@@ -900,6 +900,110 @@ the `calc()`. And grep for other places applying the same clearance — this one
 was being added four times: `.app-page-shell`, `.profile-home-screen`,
 `profile-stack-navigator.tsx`, and the scroll root that legitimately owns it.
 
+### R24 — A dependency pinned to a private index cannot travel through `requirements.txt`
+
+**Incident (2026-09-07, adding sentence-transformers for semantic retrieval).** To
+keep ~2.5 GB of nvidia CUDA wheels out of a GPU-less Cloud Run image, torch was
+pinned to PyTorch's CPU index in `pyproject.toml` with `[[tool.uv.index]]` +
+`[tool.uv.sources]`. `uv lock` then recorded `torch==2.14.0+cpu`, and
+`uv export` wrote that pin into `requirements.txt` **without any index
+directive** — it does not carry index configuration into the generated file. A
+`+cpu` local version exists only on PyTorch's index, never on PyPI, so the
+Docker build could not resolve it. UAT failed at "Build and pin backend image",
+before deploying anything.
+
+It cannot be repaired at the install command either. `--extra-index-url` fails
+because that index mirrors much of PyPI and uv's first-index strategy then
+refuses the PyPI versions it shadows. `[tool.uv.sources]` and `explicit = true`
+apply in uv **project** mode, not in pip mode against a requirements file.
+
+**Rule.** If the Dockerfile installs from `requirements.txt`, every dependency
+must be resolvable from the indexes that file can reach — which is PyPI alone.
+A per-package index needs project-mode install (`COPY pyproject.toml uv.lock` +
+`uv sync --frozen`), or it does not belong in the lock at all.
+
+**Check.** Resolve for the deploy target, not for your Mac:
+
+```bash
+cd consent-protocol
+uv pip install --dry-run \
+  --python-platform x86_64-unknown-linux-gnu --python-version 3.13 \
+  -r requirements.txt | tail -3
+# "Resolved N packages" = the image will build.
+# "No solution found" = the next UAT deploy dies before it ships anything.
+grep -nE '\+[a-z]+( |$)|^--(extra-)?index-url' requirements.txt
+# A local version (+cpu, +cu121) with no index directive is the trap.
+```
+
+### R25 — In replay mode, every migration must be replay-safe against *today's* data
+
+**Incident (2026-09-07, unblocking UAT).** UAT runs
+`db/migrate.py --migration-mode replay`, which re-executes **every** migration
+body in order on **every** deploy. Migration 138 re-adds
+`connection_origins_origin_kind_check` with the vocabulary as it stood then —
+before 175 added `contact_sync`. The moment UAT held its first `contact_sync`
+row, replaying 138 began failing with *"check constraint ... is violated by
+some row"*, and every deploy of every commit stopped there. The 03:18 run
+passed only because no such row existed yet.
+
+A migration is not a historical record here. It is code that runs again tonight,
+against data that did not exist when it was written.
+
+**Rule.** Any migration that narrows a constraint, adds a NOT NULL, or asserts
+a vocabulary must tolerate rows a later migration legitimises. Add the
+constraint `NOT VALID` when the migration's intent is "change what future rows
+do" — its own comment usually says so. Let the later migration validate the
+full set. Never widen an old migration to name a value that did not exist yet.
+
+**Check.** Find every migration that re-adds a constraint a later one changes:
+
+```bash
+cd consent-protocol
+for c in $(grep -rhoE 'ADD CONSTRAINT [a-z_]+' db/migrations/*.sql \
+           | awk '{print $3}' | sort | uniq -d); do
+  echo "== $c"
+  grep -ln "ADD CONSTRAINT $c" db/migrations/*.sql | sort
+done
+# Two or more files for one constraint name = every earlier one re-runs on
+# replay with its older, narrower rule. Each must be NOT VALID or provably
+# no narrower than the final one.
+```
+
+### R26 — UAT replays migrations against a live database; it fails by time of day, not by commit
+
+**Incident (2026-09-07, after R25 was fixed.)** With the constraint violation
+gone, the deploy got further and then died on
+`LockNotAvailableError: canceling statement due to lock timeout`. Replay takes
+`ACCESS EXCLUSIVE` locks across the whole migration history while UAT is
+serving traffic, and `lock_timeout_ms` defaults to **5 seconds**
+(`db/migration_authority.py:56`). Two consecutive retries failed identically,
+so it is contention, not a transient blip.
+
+The deploy history makes the pattern plain — successes cluster at 00:56, 06:05
+and 11:17; failures at 21:04, 21:59, 14:46, 15:33, 16:22, 16:28. The same
+commit deploys at night and fails in the evening.
+
+**Rule.** Do not read a UAT failure as "my change broke it" until the lane
+itself is ruled out. Check whether the failure is the same step failing for
+everyone, and whether recent successes cluster in quiet hours. A retry is
+evidence only when it changes the outcome; two identical failures mean stop
+retrying and fix the lane.
+
+**Check.** Before blaming a commit, look at the lane:
+
+```bash
+gh run list --repo hushh-labs/hushh-research --workflow deploy-uat.yml \
+  --limit 15 --json conclusion,createdAt,headSha \
+  --jq '.[] | "\(.createdAt[11:16]) \(.conclusion // "running") \(.headSha[0:9])"'
+# Many SHAs failing, and successes clustered in off-hours, means the lane is
+# the problem. One SHA failing while neighbours pass means the commit is.
+```
+
+The durable fix is `ledger` mode — pending migrations only, after a verified
+baseline — which `db/migrate.py` already supports and which exists precisely
+for this. It needs a one-time baseline established against the UAT database
+(`db/migrate.py --establish-baseline`), so it requires database access.
+
 ## Adding a rule
 
 Every mistake found becomes a rule. Fix the **cause**, not the symptom, then add

--- a/consent-protocol/db/migration_authority.py
+++ b/consent-protocol/db/migration_authority.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import os
 import re
+import sys
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -23,6 +24,9 @@ from typing import Any, Iterable
 _MIGRATION_ID_RE = re.compile(r"^(?P<id>[0-9]{8,}_[0-9A-Za-z]+|[0-9]{3,})_")
 _ADVISORY_LOCK_KEY = 0x485553534844424D  # "HUSSHDBM", within signed BIGINT.
 _ALLOWED_BASELINE_ENVIRONMENTS = {"uat", "test", "local", "development", "dev"}
+# Anything slower than this is named in the deploy log. Lock contention shows
+# up here first, as a migration that used to be instant and now is not.
+_SLOW_MIGRATION_MS = 1_000
 
 
 class MigrationAuthorityError(RuntimeError):
@@ -135,6 +139,22 @@ async def _database_identity_hash(conn: Any) -> str:
 def _sanitize_failure_class(exc: BaseException) -> str:
     name = type(exc).__name__
     return re.sub(r"[^A-Za-z0-9_.-]", "_", name)[:120] or "MigrationError"
+
+
+def _failure_signature(exc: BaseException) -> str:
+    """Identify a failure without quoting the database's message.
+
+    A Postgres error string can carry application data -- a unique violation
+    names the offending key and its value -- and this module does not log
+    application rows. The exception class and its SQLSTATE are enough to tell
+    a lock timeout (55P03) from a duplicate object (42710) from a syntax
+    error, which is the whole question an operator is asking.
+    """
+    sqlstate = getattr(exc, "sqlstate", None)
+    signature = _sanitize_failure_class(exc)
+    if isinstance(sqlstate, str) and sqlstate.isalnum():
+        signature = f"{signature} sqlstate={sqlstate}"
+    return signature
 
 
 async def _try_lock(conn: Any) -> None:
@@ -307,9 +327,26 @@ async def apply_manifest_entries(
                     await conn.execute(f"SET statement_timeout = '{entry.statement_timeout_ms}ms'")
                     await conn.execute(entry.sql)
             except Exception as exc:
+                duration_ms = round((time.perf_counter() - started) * 1000)
+                # Say which migration failed, and say it before anything else can
+                # go wrong. Nothing in this function named the entry, so six UAT
+                # deploys failed against a 173-file replay with no way to tell
+                # which file stopped it.
+                print(
+                    f"MIGRATION FAILED: {entry.filename} after {duration_ms}ms "
+                    f"[{_failure_signature(exc)}]",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                # Return the connection to a usable state in EVERY mode. This
+                # used to be inside the `if` below, so a REPLAY failure left the
+                # transaction aborted and the `finally: await _unlock(conn)` at
+                # the end of this function then raised InFailedSQLTransactionError
+                # -- which replaced the real error in the traceback. The UAT
+                # workflow reported "current transaction is aborted" when the
+                # actual failure was "canceling statement due to lock timeout".
+                await _rollback_failed_transaction(conn)
                 if mode is not MigrationMode.REPLAY:
-                    await _rollback_failed_transaction(conn)
-                    duration_ms = round((time.perf_counter() - started) * 1000)
                     await _record_result(
                         conn,
                         entry=entry,
@@ -318,8 +355,15 @@ async def apply_manifest_entries(
                         deploy_sha=deploy_sha,
                         failure_class=_sanitize_failure_class(exc),
                     )
+                exc.add_note(f"while applying migration {entry.filename} ({duration_ms}ms)")
                 raise
             duration_ms = round((time.perf_counter() - started) * 1000)
+            if duration_ms >= _SLOW_MIGRATION_MS:
+                print(
+                    f"  slow migration: {entry.filename} took {duration_ms}ms",
+                    file=sys.stderr,
+                    flush=True,
+                )
             applied.append(entry.filename)
             if mode is not MigrationMode.REPLAY and not recorded_applied:
                 await _record_result(
@@ -339,7 +383,17 @@ async def apply_manifest_entries(
                 }
         return tuple(applied)
     finally:
-        await _unlock(conn)
+        # Releasing the advisory lock must never replace the error that brought
+        # us here. On an aborted connection this call itself raises, and that
+        # exception would propagate instead of the migration's own.
+        try:
+            await _unlock(conn)
+        except Exception as unlock_exc:  # noqa: BLE001 - diagnostic only
+            print(
+                f"advisory unlock failed [{_failure_signature(unlock_exc)}]",
+                file=sys.stderr,
+                flush=True,
+            )
 
 
 def load_preservation_evidence(path: Path) -> dict[str, Any]:

--- a/consent-protocol/db/migrations/064_one_location_public_invites.sql
+++ b/consent-protocol/db/migrations/064_one_location_public_invites.sql
@@ -111,6 +111,14 @@ ALTER TABLE one_location_events
       -- dies on it the first time a real row uses one.
       'location_circle_code_joined',
       'location_circle_member_invite_accepted',
+      -- Save My Soul contact list changes. Allowlisted downstream by 187
+      -- and 190, both unvalidated, which is enough for the live write but
+      -- not for this ADD: this one validates, so it re-scans every existing
+      -- row on each UAT replay. The first person to add or remove an
+      -- emergency contact writes a row that fails this constraint
+      -- forever. Same failure as 'location_share_shortened' above.
+      'location_sms_contact_added',
+      'location_sms_contact_removed',
       'circle_member_added'
     )
   );

--- a/consent-protocol/db/migrations/068_one_location_circle_invites.sql
+++ b/consent-protocol/db/migrations/068_one_location_circle_invites.sql
@@ -111,6 +111,12 @@ ALTER TABLE one_location_events
       -- reason as the comment above: the declarations must agree.
       'location_circle_code_joined',
       'location_circle_member_invite_accepted',
+      -- Save My Soul contact list changes, allowlisted downstream by 187
+      -- and 190. Carried into every declaration in the chain because each
+      -- one REPLACES the constraint: a value present in 064 and absent
+      -- here is dropped again the moment this file runs.
+      'location_sms_contact_added',
+      'location_sms_contact_removed',
       'circle_member_added'
     )
   ) NOT VALID;

--- a/consent-protocol/db/migrations/153_one_location_duration_changed_event.sql
+++ b/consent-protocol/db/migrations/153_one_location_duration_changed_event.sql
@@ -56,6 +56,14 @@ ALTER TABLE one_location_events
       -- value has to appear here too, or re-adding the constraint drops it.
       'location_circle_code_joined',
       'location_circle_member_invite_accepted',
+      -- Save My Soul contact list changes. Allowlisted downstream by 187
+      -- and 190, both unvalidated, which is enough for the live write but
+      -- not for this ADD: this one validates, so it re-scans every existing
+      -- row on each UAT replay. The first person to add or remove an
+      -- emergency contact writes a row that fails this constraint
+      -- forever. Same failure as 'location_share_shortened' above.
+      'location_sms_contact_added',
+      'location_sms_contact_removed',
       'circle_member_added'
     )
   );

--- a/consent-protocol/db/migrations/154_one_location_access_request_duration.sql
+++ b/consent-protocol/db/migrations/154_one_location_access_request_duration.sql
@@ -136,6 +136,12 @@ ALTER TABLE one_location_events
       -- declarations must agree.
       'location_circle_code_joined',
       'location_circle_member_invite_accepted',
+      -- Save My Soul contact list changes, allowlisted downstream by 187
+      -- and 190. Carried into every declaration in the chain because each
+      -- one REPLACES the constraint: a value present in 064 and absent
+      -- here is dropped again the moment this file runs.
+      'location_sms_contact_added',
+      'location_sms_contact_removed',
       'circle_member_added'
     )
   ) NOT VALID;

--- a/consent-protocol/db/migrations/169_one_location_auto_approve_preferences.sql
+++ b/consent-protocol/db/migrations/169_one_location_auto_approve_preferences.sql
@@ -71,6 +71,12 @@ ALTER TABLE one_location_events
       -- declarations must agree.
       'location_circle_code_joined',
       'location_circle_member_invite_accepted',
+      -- Save My Soul contact list changes, allowlisted downstream by 187
+      -- and 190. Carried into every declaration in the chain because each
+      -- one REPLACES the constraint: a value present in 064 and absent
+      -- here is dropped again the moment this file runs.
+      'location_sms_contact_added',
+      'location_sms_contact_removed',
       'circle_member_added'
     )
   ) NOT VALID;

--- a/consent-protocol/db/migrations/180_one_location_circle_feed_durability.sql
+++ b/consent-protocol/db/migrations/180_one_location_circle_feed_durability.sql
@@ -32,6 +32,12 @@ ALTER TABLE one_location_events
       'location_one_network_joined',
       'location_circle_code_joined',
       'location_circle_member_invite_accepted',
+      -- Save My Soul contact list changes, allowlisted downstream by 187
+      -- and 190. Carried into every declaration in the chain because each
+      -- one REPLACES the constraint: a value present in 064 and absent
+      -- here is dropped again the moment this file runs.
+      'location_sms_contact_added',
+      'location_sms_contact_removed',
       'circle_member_added'
     )
   ) NOT VALID;

--- a/consent-protocol/tests/test_migration_authority.py
+++ b/consent-protocol/tests/test_migration_authority.py
@@ -300,3 +300,61 @@ def test_preservation_evidence_requires_fresh_complete_status(tmp_path: Path):
     report.write_text(json.dumps(payload), encoding="utf-8")
     with pytest.raises(MigrationAuthorityError, match="must both be ok"):
         load_preservation_evidence(report)
+
+
+class AbortingConnection(FakeConnection):
+    """A connection that behaves like Postgres after a statement error.
+
+    Once a statement fails inside a transaction, every further command is
+    refused until the transaction ends. `pg_advisory_unlock` is a command, so
+    the cleanup in `apply_manifest_entries`' `finally` runs straight into it --
+    which is how six UAT deploys reported `InFailedSQLTransactionError` when
+    the real failure was a lock timeout. See R28 in the safe-changes ledger.
+    """
+
+    class InFailedSQLTransaction(RuntimeError):
+        pass
+
+    async def fetchval(self, sql: str, *args):
+        if self.in_transaction and "pg_advisory_unlock" in sql:
+            raise self.InFailedSQLTransaction(
+                "current transaction is aborted, commands ignored until end of transaction block"
+            )
+        return await super().fetchval(sql, *args)
+
+
+@pytest.mark.asyncio
+async def test_replay_failure_reports_the_migration_not_the_cleanup(tmp_path: Path, capsys):
+    entries = _entries(tmp_path)
+    conn = AbortingConnection()
+    conn.fail_sql = "SELECT 115"
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await apply_manifest_entries(conn, entries, mode=MigrationMode.REPLAY)
+
+    # The migration's own error, not the advisory unlock's.
+    assert "synthetic migration failure" in str(excinfo.value)
+    assert not isinstance(excinfo.value, AbortingConnection.InFailedSQLTransaction)
+
+    # And it names which of the manifest's files stopped the run.
+    assert any("20260721_ABC_new.sql" in note for note in getattr(excinfo.value, "__notes__", []))
+    assert "MIGRATION FAILED: 20260721_ABC_new.sql" in capsys.readouterr().err
+
+    # The rollback ran even in replay mode, so the lock was actually released.
+    assert conn.locked is False
+
+
+@pytest.mark.asyncio
+async def test_failure_log_never_quotes_the_database_message(tmp_path: Path, capsys):
+    """A Postgres error can carry row values; the log must not repeat them."""
+    entries = _entries(tmp_path)
+    conn = FakeConnection()
+    conn.fail_sql = "SELECT 115"
+
+    with pytest.raises(RuntimeError):
+        await apply_manifest_entries(conn, entries, mode=MigrationMode.REPLAY)
+
+    stderr = capsys.readouterr().err
+    assert "MIGRATION FAILED: 20260721_ABC_new.sql" in stderr
+    assert "synthetic migration failure" not in stderr
+    assert "RuntimeError" in stderr

--- a/consent-protocol/tests/test_one_location_event_type_constraint.py
+++ b/consent-protocol/tests/test_one_location_event_type_constraint.py
@@ -43,6 +43,8 @@ CONSTRAINT_MIGRATIONS = (
     "154_one_location_access_request_duration.sql",
     "169_one_location_auto_approve_preferences.sql",
     "180_one_location_circle_feed_durability.sql",
+    "187_one_location_sms_contact_events.sql",
+    "190_one_location_place_ratings.sql",
 )
 
 # Only these two ADD the constraint without NOT VALID, so only these two


### PR DESCRIPTION
Two separate UAT blockers. The first hid itself; the second is armed and has not fired yet.

---

## 1. The error message was the wrong error

Six UAT deploys failed today (14:46, 15:33, 16:22, 16:28 UTC and two earlier). Every one reported:

```
asyncpg.exceptions.InFailedSQLTransactionError: current transaction is aborted
```

That was never the failure. The real one is four frames up the chained traceback:

```
asyncpg.exceptions.LockNotAvailableError: canceling statement due to lock timeout
```

Two defects in `apply_manifest_entries`.

**The cleanup overwrote the diagnosis.** The rollback was gated on `if mode is not MigrationMode.REPLAY` — and UAT runs in `replay`. So a replay failure left the connection in an aborted transaction, and the function's own `finally: await _unlock(conn)` then ran `SELECT pg_advisory_unlock($1)` on that dead connection. Postgres refuses every command on an aborted transaction, so the unlock raised and *its* exception propagated instead of the migration's. The advisory lock was never released either.

**Nothing named the failing file.** UAT replays 173 migrations per deploy. The traceback never mentioned `entry.filename`, so six deploys produced six identical, unusable tracebacks.

Fixed by rolling back in every mode, guarding the unlock so it can never replace the original exception, and naming the migration on stderr and as an exception note. Also names any migration slower than 1s — lock contention shows up there first, as a migration that used to be instant and now is not.

**The failure line never quotes the database's message.** A Postgres error can carry application data — a unique violation names the offending key *and its value* — and this module's contract is that it does not log rows. It reports the exception class and SQLSTATE, which distinguishes a lock timeout (55P03) from a duplicate object (42710) from a syntax error. That is the whole question an operator is asking.

## 2. A CHECK constraint that will kill the next deploy

Adding or removing a Save My Soul emergency contact writes `location_sms_contact_added` / `location_sms_contact_removed` to `one_location_events`.

Migrations **187** and **190** allowlist both — but add the constraint `NOT VALID`, so they never re-scan existing rows. Enough for the live write, no protection for a replay.

Migrations **064** and **153** add that same constraint **without** `NOT VALID`. They validate. They re-check every existing row on every UAT replay, and their lists never learned these two values.

**So the first person to touch their emergency contacts writes a row that makes 064 fail forever**, and every UAT deploy after that dies on a `CheckViolationError` naming neither the value nor the feature that wrote it.

This is the third occurrence. `tests/test_one_location_event_type_constraint.py` was written after `location_share_shortened` did it, extended after the Circle event types did it, and **has been red on `main`** since these two values shipped.

The values are carried through the whole chain — 064, 068, 153, 154, 169, 180 — not only into the two that validate, because each declaration *replaces* the constraint: a value present in 064 and absent from 068 is dropped again the moment 068 runs. 187 and 190 are added to `CONSTRAINT_MIGRATIONS` so the guard tracks the newest declarations instead of stopping at 180.

The guard caught two mistakes while I was writing this fix: an explanatory comment containing the literal string `NOT VALID` flipped the "which files validate" check, and my first pass patched only the two validating files. Both are exactly what that test exists to catch.

---

## What this does not do

It does not fix the lock timeout. It makes the next one diagnosable — right now nobody can name the contending migration out of 173. Moving UAT off `replay` onto `ledger` with a baseline is the strategic fix; it needs a bounded write-freeze and is a separate decision.

## Proof

Two regression tests for #1, both mutation-checked — the fix was reverted and each watched to go red before being committed.

Full backend suite, compared against `origin/main` rather than against zero:

| | failed | passed |
|---|---|---|
| `origin/main` | 110 | 8439 |
| this branch | **107** | **8444** |

Set-differenced, not just counted. The two that appear only on this branch (`test_mcp_public_contract_v030`, `test_nav_a2a_agent`) are environmental: the same commit passes in a clean worktree and fails in a checkout where `DB_*` is set, because the test then attempts a real connection to a Cloud SQL proxy that is not running. `test_nav_a2a_agent` fails on `origin/main` too.

```
ruff check: All checks passed
mypy db/migration_authority.py: Success, no issues found
tests/test_migration_authority.py            10 passed
tests/test_one_location_event_type_constraint.py  7 passed  (2 were red on main)
```

## Ledger

Adds **R24–R26** (private-index pins, replay-safe migrations, failures that track time of day) and **R28** (this incident). R27 belongs to #6587. Every check command was run here before being written down; R28's first version returned a false negative and the check was corrected, not the code.