### PR TITLE
ci(ios): assert the archive ships our own dSYM instead of ignoring symbol warnings

### DIFF
--- a/.claude/skills/safe-changes/SKILL.md
+++ b/.claude/skills/safe-changes/SKILL.md
@@ -1127,6 +1127,54 @@ PY
 ```
 All three must print `True`.
 
+### R29 — A warning you cannot fix must become an assertion about the one you can
+
+**Incident (2026-09-07, TestFlight build 100.)** Every `exportArchive` logs four copies of
+`warning: exportArchive Upload Symbols Failed. The archive did not include a dSYM for the
+FirebaseAnalytics.framework with the UUIDs [...]` — also for `GoogleAppMeasurement`,
+`GoogleAppMeasurementIdentitySupport` and `GoogleAdsOnDeviceConversion`. It was reported as
+"not something this change introduced" and left alone, which was accurate and useless.
+
+The warning is genuinely unfixable. Those four arrive through Swift Package Manager as binary
+targets under `SourcePackages/artifacts/`; `file` reports **`current ar archive`**, so they are
+static libraries in a `.framework` wrapper, and `find` returns **no `.dSYM` anywhere inside the
+`.xcframework`**. They are linked into `App` and never ship as a separate image. There is no dSYM
+to supply and never will be — Google strips them before publishing.
+
+The danger is not the warning. It is that **our own dSYM going missing prints the same sentence**.
+Flip `DEBUG_INFORMATION_FORMAT` from `dwarf-with-dsym` to `dwarf` on Release and the log grows a
+fifth identical-looking line among four that are always there, every build, forever. Nobody would
+see it, and every crash report from real users would arrive as raw addresses. Crashlytics is not
+linked in this app, so App Store Connect's symbol upload is the *only* symbolication path there is.
+
+**Rule.** Do not silence a warning class that contains a real signal, and do not silence it by
+turning `uploadSymbols` off — that drops our own symbols too, which is the exact failure being
+guarded against. Instead assert the thing that matters (our dSYM exists **and its UUIDs match the
+shipped binary**), name each known-unfixable exception in an allow-list with the reason, and fail
+on anything outside it. Apply it to every lane that exports an archive, not just the one where it
+was noticed (R14).
+
+**Check.** Prove the vendor binaries really are static and dSYM-less rather than assuming it:
+
+```bash
+DD=$(ls -d ~/Library/Developer/Xcode/DerivedData/App-*/SourcePackages/artifacts 2>/dev/null | head -1)
+for n in firebase-ios-sdk/FirebaseAnalytics/FirebaseAnalytics \
+         googleappmeasurement/GoogleAppMeasurement/GoogleAppMeasurement; do
+  b="$DD/$n.xcframework"; s=$(basename "$n")
+  echo "== $s"
+  [ -n "$(find "$b" -name '*.dSYM' 2>/dev/null)" ] && echo "  ships a dSYM" || echo "  ships NO dSYM"
+  file "$b/ios-arm64/$s.framework/$s" | sed 's/.*: /  /'
+done
+# "current ar archive" + "ships NO dSYM" == nothing to upload, permanently. Do not chase it.
+```
+
+Then mutation-test the guard, because a passing new check proves nothing (R22). Against a mock
+archive, all five must hold: healthy passes; a deleted `App.app.dSYM` fails; a dSYM whose UUIDs no
+longer match the binary fails; an allow-listed vendor framework with no dSYM passes; any other
+framework with no dSYM fails. Note that `clang -g` re-runs `dsymutil` automatically, so a "stale
+dSYM" test that rebuilds in place silently regenerates it and passes — hold the dSYM aside first,
+or the mutation test proves nothing.
+
 ## Adding a rule
 
 Every mistake found becomes a rule. Fix the **cause**, not the symptom, then add

--- a/.github/workflows/release-ios-appstore.yml
+++ b/.github/workflows/release-ios-appstore.yml
@@ -397,6 +397,63 @@ jobs:
             CURRENT_PROJECT_VERSION="${{ steps.build_number.outputs.next_build }}" \
             archive 2>&1 | tee "${RUNNER_TEMP}/xcodebuild-archive.log"
 
+      - name: Assert the archive ships our own debug symbols
+        shell: bash
+        run: |
+          set -euo pipefail
+          ARCHIVE="${RUNNER_TEMP}/App.xcarchive"
+          APP_BIN="${ARCHIVE}/Products/Applications/App.app/App"
+          APP_DSYM="${ARCHIVE}/dSYMs/App.app.dSYM"
+
+          # Google ships FirebaseAnalytics, GoogleAppMeasurement,
+          # GoogleAppMeasurementIdentitySupport and GoogleAdsOnDeviceConversion as
+          # STATIC frameworks -- `file` reports "current ar archive" -- and the
+          # .xcframework contains no dSYM at all. They are linked into App and never
+          # ship as separate images, so no dSYM can exist for them, and exportArchive
+          # logs "Upload Symbols Failed" for each on every single run. That is
+          # unfixable upstream (see R29). This step exists so that permanent noise can
+          # never hide the one failure that matters: OUR dSYM going missing.
+          ALLOWED_WITHOUT_DSYM="FirebaseAnalytics GoogleAppMeasurement GoogleAppMeasurementIdentitySupport GoogleAdsOnDeviceConversion"
+
+          test -f "$APP_BIN" || { echo "::error::No app binary at $APP_BIN"; exit 1; }
+          if [ ! -d "$APP_DSYM" ]; then
+            echo "::error::The archive contains no App.app.dSYM, so crash reports for our own code would arrive unsymbolicated. Check that DEBUG_INFORMATION_FORMAT is dwarf-with-dsym for the Release configuration."
+            exit 1
+          fi
+
+          app_uuids="$(dwarfdump --uuid "$APP_BIN" | awk '{print $2}' | sort)"
+          dsym_uuids="$(dwarfdump --uuid "$APP_DSYM" | awk '{print $2}' | sort)"
+          echo "app binary UUIDs:"; printf '%s\n' "$app_uuids" | sed 's/^/  /'
+          echo "App.app.dSYM UUIDs:"; printf '%s\n' "$dsym_uuids" | sed 's/^/  /'
+
+          [ -n "$app_uuids" ] || { echo "::error::The app binary reports no UUIDs."; exit 1; }
+          if [ "$app_uuids" != "$dsym_uuids" ]; then
+            echo "::error::App.app.dSYM does not match the shipped app binary; crash reports would not symbolicate."
+            exit 1
+          fi
+
+          # Anything that actually ships as its own image must carry symbols.
+          fail=0
+          FW_DIR="${ARCHIVE}/Products/Applications/App.app/Frameworks"
+          if [ -d "$FW_DIR" ]; then
+            for fw in "$FW_DIR"/*.framework; do
+              [ -e "$fw" ] || continue
+              name="$(basename "$fw" .framework)"
+              case " $ALLOWED_WITHOUT_DSYM " in
+                *" $name "*) echo "  skip  $name (vendor static binary; upstream ships no dSYM)"; continue ;;
+              esac
+              if [ -d "${ARCHIVE}/dSYMs/${name}.framework.dSYM" ]; then
+                echo "  ok    $name"
+              else
+                echo "::error::Embedded framework $name ships with no dSYM and is not an approved exception."
+                fail=1
+              fi
+            done
+          fi
+          [ "$fail" -eq 0 ] || exit 1
+
+          echo "OK: App.app.dSYM present and matching; every separately shipped image has symbols or a named exception."
+
       - name: Export & upload to App Store Connect
         shell: bash
         run: |

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -399,6 +399,63 @@ jobs:
             CURRENT_PROJECT_VERSION="${{ steps.build_number.outputs.next_build }}" \
             archive 2>&1 | tee "${RUNNER_TEMP}/xcodebuild-archive.log"
 
+      - name: Assert the archive ships our own debug symbols
+        shell: bash
+        run: |
+          set -euo pipefail
+          ARCHIVE="${RUNNER_TEMP}/App.xcarchive"
+          APP_BIN="${ARCHIVE}/Products/Applications/App.app/App"
+          APP_DSYM="${ARCHIVE}/dSYMs/App.app.dSYM"
+
+          # Google ships FirebaseAnalytics, GoogleAppMeasurement,
+          # GoogleAppMeasurementIdentitySupport and GoogleAdsOnDeviceConversion as
+          # STATIC frameworks -- `file` reports "current ar archive" -- and the
+          # .xcframework contains no dSYM at all. They are linked into App and never
+          # ship as separate images, so no dSYM can exist for them, and exportArchive
+          # logs "Upload Symbols Failed" for each on every single run. That is
+          # unfixable upstream (see R29). This step exists so that permanent noise can
+          # never hide the one failure that matters: OUR dSYM going missing.
+          ALLOWED_WITHOUT_DSYM="FirebaseAnalytics GoogleAppMeasurement GoogleAppMeasurementIdentitySupport GoogleAdsOnDeviceConversion"
+
+          test -f "$APP_BIN" || { echo "::error::No app binary at $APP_BIN"; exit 1; }
+          if [ ! -d "$APP_DSYM" ]; then
+            echo "::error::The archive contains no App.app.dSYM, so crash reports for our own code would arrive unsymbolicated. Check that DEBUG_INFORMATION_FORMAT is dwarf-with-dsym for the Release configuration."
+            exit 1
+          fi
+
+          app_uuids="$(dwarfdump --uuid "$APP_BIN" | awk '{print $2}' | sort)"
+          dsym_uuids="$(dwarfdump --uuid "$APP_DSYM" | awk '{print $2}' | sort)"
+          echo "app binary UUIDs:"; printf '%s\n' "$app_uuids" | sed 's/^/  /'
+          echo "App.app.dSYM UUIDs:"; printf '%s\n' "$dsym_uuids" | sed 's/^/  /'
+
+          [ -n "$app_uuids" ] || { echo "::error::The app binary reports no UUIDs."; exit 1; }
+          if [ "$app_uuids" != "$dsym_uuids" ]; then
+            echo "::error::App.app.dSYM does not match the shipped app binary; crash reports would not symbolicate."
+            exit 1
+          fi
+
+          # Anything that actually ships as its own image must carry symbols.
+          fail=0
+          FW_DIR="${ARCHIVE}/Products/Applications/App.app/Frameworks"
+          if [ -d "$FW_DIR" ]; then
+            for fw in "$FW_DIR"/*.framework; do
+              [ -e "$fw" ] || continue
+              name="$(basename "$fw" .framework)"
+              case " $ALLOWED_WITHOUT_DSYM " in
+                *" $name "*) echo "  skip  $name (vendor static binary; upstream ships no dSYM)"; continue ;;
+              esac
+              if [ -d "${ARCHIVE}/dSYMs/${name}.framework.dSYM" ]; then
+                echo "  ok    $name"
+              else
+                echo "::error::Embedded framework $name ships with no dSYM and is not an approved exception."
+                fail=1
+              fi
+            done
+          fi
+          [ "$fail" -eq 0 ] || exit 1
+
+          echo "OK: App.app.dSYM present and matching; every separately shipped image has symbols or a named exception."
+
       - name: Export & upload to TestFlight
         shell: bash
         run: |


### PR DESCRIPTION
## Outcome

The four `Upload Symbols Failed` warnings on every iOS export stop being unexamined noise, and a real dSYM regression can no longer hide inside them.

## What was actually wrong

The warnings themselves are **unfixable**, and I proved that rather than assuming it:

- `FirebaseAnalytics`, `GoogleAppMeasurement`, `GoogleAppMeasurementIdentitySupport` and `GoogleAdsOnDeviceConversion` arrive as SPM **binary targets** under `SourcePackages/artifacts/`.
- `file` reports **`current ar archive`** — they are static libraries in a `.framework` wrapper, linked into `App`, never shipped as a separate image.
- `find` returns **no `.dSYM` anywhere** inside the `.xcframework`. Google strips them before publishing.

So there is no dSYM to supply, and there never will be.

The real defect is that **our own dSYM going missing prints the same sentence.** Flip `DEBUG_INFORMATION_FORMAT` from `dwarf-with-dsym` to `dwarf` on Release and the log grows a fifth identical-looking line among four that are always there, on every build. Nobody would notice, and every crash report from a real user would arrive as raw addresses. Crashlytics is not linked in this app, so App Store Connect symbol upload is the only symbolication path that exists.

## What this does

A step between `Archive` and `Export` in **both** iOS lanes that:

1. requires `App.app.dSYM` to exist in the archive;
2. requires its UUIDs to match the shipped app binary, per architecture;
3. allow-lists the four vendor binaries **by name, with the reason**;
4. fails on any other separately shipped framework with no symbols.

Applied to `release-ios-appstore.yml` as well as `ship-ios-testflight.yml` — same export path, same defect, per R14.

## Rejected alternative

Setting `uploadSymbols` to `false` silences all four warnings in one line. It also stops uploading **our own** dSYM, which is precisely the failure this is meant to catch. Not done.

## Validation

Both workflows parse (js-yaml); the guard sits between `Archive` and `Export` in each. Embedded bash passes `bash -n`.

Mutation-tested against a mock `App.xcarchive` — a passing new check proves nothing (R22):

| case | expected | result |
|---|---|---|
| healthy archive | pass | exit 0 |
| `App.app.dSYM` deleted | fail | exit 1, names `DEBUG_INFORMATION_FORMAT` |
| dSYM present but UUIDs stale | fail | exit 1 |
| allow-listed vendor framework, no dSYM | pass | exit 0, skipped with reason |
| any other framework, no dSYM | fail | exit 1 |

Worth recording: the first attempt at the stale-dSYM case **failed to fire**, because `clang -g` re-runs `dsymutil` automatically and silently regenerated the "stale" dSYM. Redone with the dSYM held aside. That trap is written into R29.

## What I have not verified

The guard has not run against a real `App.xcarchive` — only a mock one built to the same layout. First real exercise is the next TestFlight or App Store dispatch.

## Rollback

Revert the commit. The step is additive; nothing else in either lane changes.