### PR TITLE
fix(web): the OTP screen no longer disappears, and the consent SSE storm stops

### DIFF
--- a/hushh-webapp/__tests__/app/register-phone-revalidation-remount.test.tsx
+++ b/hushh-webapp/__tests__/app/register-phone-revalidation-remount.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PhoneMandatePageContent } from "@/app/register-phone/page";
+
+/**
+ * The bug this file exists for.
+ *
+ * A person entered their number, pressed Send code, and saw "Verification code
+ * sent". The OTP screen never appeared -- they were put back on the phone form,
+ * forever, and could not finish phone verification at all.
+ *
+ * Nothing was wrong with the verification flow. The page returned a fullscreen
+ * loader whenever `useAuth().loading` was true, which UNMOUNTS
+ * PhoneVerificationFlow. Its `step` lives in useState, so the OTP screen was
+ * destroyed. And `loading` is not "still booting": the web auth observer sets
+ * it true on every re-validation, and starting Firebase phone verification
+ * triggers one.
+ *
+ * So the contract is about identity, not about a revalidation flag: once a user
+ * is present, this page must never tear its own subtree down.
+ */
+
+const { replace, authState } = vi.hoisted(() => ({
+  replace: vi.fn(),
+  authState: {
+    current: {
+      user: { uid: "u1", phoneNumber: null } as Record<string, unknown> | null,
+      loading: false,
+    },
+  },
+}));
+
+let mountCount = 0;
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock("@/components/app-ui/hushh-loader", () => ({
+  HushhLoader: ({ label }: { label: string }) => <p>{label}</p>,
+}));
+vi.mock("@/components/app-ui/native-route-marker", () => ({
+  NativeRouteMarker: () => null,
+}));
+vi.mock("@/components/vault/vault-lock-guard", () => ({
+  VaultLockGuard: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => children,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => children,
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => children,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => children,
+}));
+
+// Stands in for the real flow. It counts mounts and keeps a piece of local
+// state, which is exactly what a remount destroys.
+vi.mock("@/components/auth/phone-verification-flow", () => ({
+  PhoneVerificationFlow: () => {
+    const [step, setStep] = useState("phone");
+    useEffect(() => {
+      mountCount += 1;
+    }, []);
+    return (
+      <div>
+        <p>step: {step}</p>
+        <button type="button" onClick={() => setStep("code")}>
+          Send code
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock("@/lib/firebase/auth-context", () => ({
+  useAuth: () => ({
+    user: authState.current.user,
+    loading: authState.current.loading,
+    phoneNumber: null,
+    startPhoneVerification: vi.fn(),
+    confirmPhoneVerification: vi.fn(),
+    refreshUser: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/services/account-identity-service", () => ({
+  AccountIdentityService: {
+    syncCurrentUser: vi.fn().mockResolvedValue({ phone_verified: false }),
+    hasVerifiedPhone: () => false,
+  },
+}));
+vi.mock("@/lib/services/onboarding-route-cookie", () => ({
+  setOnboardingFlowActiveCookie: vi.fn(),
+  setOnboardingRequiredCookie: vi.fn(),
+}));
+vi.mock("@/lib/services/post-auth-route-service", () => ({
+  PostAuthRouteService: { resolveAfterLogin: vi.fn() },
+}));
+vi.mock("@/lib/services/pre-vault-user-state-service", () => ({
+  PreVaultUserStateService: {
+    bootstrapState: vi.fn(),
+    isSetupResolved: () => false,
+    syncOnboardingJourney: vi.fn(),
+  },
+}));
+vi.mock("@/lib/services/phone-mandate-service", () => ({
+  shouldBypassPhoneMandateForLocalhost: () => false,
+}));
+vi.mock("@/lib/voice/voice-surface-metadata", () => ({
+  usePublishVoiceSurfaceMetadata: vi.fn(),
+}));
+vi.mock("@/lib/onboarding/onboarding-journey-phase", () => ({
+  resolvePostPhoneOnboardingPhase: () => "setup_hub",
+}));
+
+describe("the phone mandate page survives an auth re-validation", () => {
+  it("does not unmount the verification flow when loading flips true for a signed-in person", async () => {
+    mountCount = 0;
+    authState.current = { user: { uid: "u1", phoneNumber: null }, loading: false };
+
+    const view = render(<PhoneMandatePageContent />);
+    await screen.findByText("step: phone");
+    expect(mountCount).toBe(1);
+
+    // Starting Firebase phone verification republishes auth state, and the web
+    // observer sets loading=true while it re-validates the session.
+    authState.current = { ...authState.current, loading: true };
+    view.rerender(<PhoneMandatePageContent />);
+
+    // The flow must still be on screen. If the page swapped in a loader, the
+    // step state is already gone.
+    await waitFor(() => {
+      expect(screen.queryByText("step: phone")).not.toBeNull();
+    });
+    expect(screen.queryByText("Loading phone verification...")).toBeNull();
+
+    authState.current = { ...authState.current, loading: false };
+    view.rerender(<PhoneMandatePageContent />);
+    await screen.findByText("step: phone");
+
+    // One mount for the whole cycle. Two means the OTP screen would have been
+    // destroyed mid-verification.
+    expect(mountCount).toBe(1);
+  });
+
+  it("still shows the loader while no user is present", async () => {
+    mountCount = 0;
+    authState.current = { user: null, loading: true };
+
+    render(<PhoneMandatePageContent />);
+    await screen.findByText("Loading phone verification...");
+    expect(mountCount).toBe(0);
+  });
+});

--- a/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
+++ b/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
@@ -18,6 +18,7 @@ vi.mock("next/navigation", () => ({
 function renderPhoneVerificationFlow(options?: {
   startRejects?: boolean;
   confirmVerification?: ReturnType<typeof vi.fn>;
+  currentPhoneNumber?: string | null;
 }) {
   const startVerification = options?.startRejects
     ? vi.fn().mockRejectedValue(new Error("provider unavailable"))
@@ -27,19 +28,25 @@ function renderPhoneVerificationFlow(options?: {
     vi.fn().mockResolvedValue({ uid: "user_1" });
   const onCompleted = vi.fn();
 
-  render(
+  const flow = (currentPhoneNumber?: string | null) => (
     <PhoneVerificationFlow
       mode="link"
+      currentPhoneNumber={currentPhoneNumber}
       startVerification={startVerification}
       confirmVerification={confirmVerification}
       onCompleted={onCompleted}
-    />,
+    />
   );
+
+  const view = render(flow(options?.currentPhoneNumber));
 
   return {
     startVerification,
     confirmVerification,
     onCompleted,
+    // Republishes the flow with a new auth-context phone value, the way
+    // register-phone/page.tsx does when useAuth().phoneNumber settles.
+    rerenderWithPhone: (next?: string | null) => view.rerender(flow(next)),
   };
 }
 
@@ -456,5 +463,73 @@ describe("PhoneVerificationFlow country selector", () => {
     expect(startVerification).toHaveBeenCalledTimes(1);
 
     resolveConfirm({ uid: "user_1" });
+  });
+});
+
+describe("the OTP screen survives a late auth-context update", () => {
+  async function sendCode(
+    handle: ReturnType<typeof renderPhoneVerificationFlow>,
+  ) {
+    const phoneInput = screen.getByRole("textbox", { name: "Phone number" });
+    fireEvent.change(phoneInput, { target: { value: "6505550101" } });
+    fireEvent.submit(phoneInput.closest("form")!);
+    await waitFor(() =>
+      expect(handle.startVerification).toHaveBeenCalledWith("+16505550101", {
+        resendCode: false,
+      }),
+    );
+    return screen.findByRole("textbox", { name: "One-time code" });
+  }
+
+  it("keeps the person on the OTP screen when the backend phone number lands after the code was sent", async () => {
+    // /register-phone always mounts with phoneNumber === null, which is the
+    // exact condition that makes the auth context resolve the verified number
+    // from the backend. That read can settle AFTER the code is sent.
+    const handle = renderPhoneVerificationFlow({ currentPhoneNumber: null });
+    const codeInput = await sendCode(handle);
+    fireEvent.change(codeInput, { target: { value: "1234" } });
+
+    handle.rerenderWithPhone("+16505550101");
+
+    // The sent code is the only thing that matters now. A late identity read
+    // must not take away the one screen that can consume it.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("textbox", { name: "One-time code" }),
+      ).not.toBeNull();
+    });
+    expect(
+      screen.getByRole("textbox", { name: "One-time code" }),
+    ).toHaveValue("1234");
+  });
+
+  it("keeps the person on the OTP screen when the context settles from undefined to null", async () => {
+    const handle = renderPhoneVerificationFlow({ currentPhoneNumber: undefined });
+    await sendCode(handle);
+
+    handle.rerenderWithPhone(null);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("textbox", { name: "One-time code" }),
+      ).not.toBeNull();
+    });
+  });
+
+  it("still re-seeds the form from a changed number before any code is sent", async () => {
+    // The reset must keep working where it is meant to: no code is
+    // outstanding, so a new owner number should still take effect.
+    const handle = renderPhoneVerificationFlow({ currentPhoneNumber: null });
+    expect(
+      screen.getByRole("textbox", { name: "Phone number" }),
+    ).not.toBeNull();
+
+    handle.rerenderWithPhone("+16505550101");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("textbox", { name: "Phone number" }),
+      ).toBeNull();
+    });
   });
 });

--- a/hushh-webapp/__tests__/consent-notification-provider-sse-backoff.test.tsx
+++ b/hushh-webapp/__tests__/consent-notification-provider-sse-backoff.test.tsx
@@ -1,0 +1,217 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const toast = Object.assign(vi.fn(), { dismiss: vi.fn() });
+  const user = {
+    uid: "recipient-user",
+    getIdToken: vi.fn().mockResolvedValue("firebase-token"),
+  };
+  return {
+    toast,
+    user,
+    auth: { user: user as typeof user | null },
+    platform: { value: "web", native: false },
+    initializeFCM: vi.fn(),
+    prepareFCMListeners: vi.fn(),
+    getState: vi.fn(),
+    getVaultOwnerToken: vi.fn(),
+    onConsentMutated: vi.fn(),
+    dispatchConsentStateChanged: vi.fn(),
+    dispatchFeedStateChanged: vi.fn(),
+    markPendingConsentOpened: vi.fn(),
+    navigation: { pathname: "/one/setup", search: "" },
+    apiFetchStream: vi.fn(),
+    vault: { unlocked: true, token: "vault-owner-token" },
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mocks.navigation.pathname,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(mocks.navigation.search),
+}));
+
+vi.mock("sonner", () => ({ toast: mocks.toast }));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => mocks.platform.native,
+    getPlatform: () => mocks.platform.value,
+  },
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ user: mocks.auth.user }),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    isVaultUnlocked: mocks.vault.unlocked,
+    getVaultOwnerToken: mocks.getVaultOwnerToken,
+  }),
+}));
+
+vi.mock("@/lib/notifications", () => ({
+  initializeFCM: mocks.initializeFCM,
+  prepareFCMListeners: mocks.prepareFCMListeners,
+  clearDeliveredConsentNotifications: vi.fn(),
+  FCM_MESSAGE_EVENT: "fcm-message",
+}));
+
+vi.mock("@/lib/one-location/service", () => ({
+  OneLocationService: { getState: mocks.getState },
+}));
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    getPendingConsents: vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ pending: [] }),
+    }),
+    markPendingConsentOpened: mocks.markPendingConsentOpened,
+    apiFetchStream: mocks.apiFetchStream,
+  },
+}));
+
+vi.mock("@/lib/services/app-background-task-service", () => ({
+  AppBackgroundTaskService: {
+    startTask: vi.fn(),
+    completeTask: vi.fn(),
+    dismissTask: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/cache/cache-sync-service", () => ({
+  CacheSyncService: {
+    onConsentMutated: mocks.onConsentMutated,
+    onConsentReviewed: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/consent/consent-events", () => ({
+  CONSENT_STATE_CHANGED_EVENT: "consent-state-changed",
+  dispatchConsentStateChanged: mocks.dispatchConsentStateChanged,
+}));
+
+vi.mock("@/lib/feed/feed-events", () => ({
+  dispatchFeedStateChanged: mocks.dispatchFeedStateChanged,
+}));
+
+import { ConsentNotificationProvider } from "@/components/consent/notification-provider";
+
+/**
+ * The request storm this file exists for.
+ *
+ * Consent SSE is deliberately switched off in production: the backend answers
+ * 410 with CONSENT_SSE_DISABLED and tells the client to use FCM instead. The
+ * client discarded the status, treated a settled configuration as a transient
+ * blip, and reconnected on a fixed 3-second timer with no cap. Every retry cost
+ * two Cloud Run invocations, one logged backend error and one failed
+ * api_request_completed metric -- per open tab, forever. The founder's console
+ * showed the error count climbing from 79 to 157 while he sat on one screen.
+ */
+
+const EMPTY_LOCATION_STATE = {
+  recipients: [],
+  ownerGrants: [],
+  receivedGrants: [],
+  requests: [],
+  referrals: [],
+  publicInvites: [],
+  networkConnections: [],
+  publicInviteSubmissions: [],
+  capabilityScopes: [],
+};
+
+function streamResponse(status: number, body: string) {
+  return {
+    ok: false,
+    status,
+    body: null,
+    text: vi.fn().mockResolvedValue(body),
+  };
+}
+
+describe("consent SSE stops retrying a permanent refusal", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mocks.auth.user = mocks.user;
+    mocks.platform = { value: "web", native: false };
+    mocks.navigation = { pathname: "/one/setup", search: "" };
+    mocks.getState.mockResolvedValue(EMPTY_LOCATION_STATE);
+    mocks.getVaultOwnerToken?.mockReturnValue?.("vault-owner-token");
+    // Web with notifications never granted -- the default state for a signed-in
+    // browser user, and the one that puts the SSE fallback in the path.
+    mocks.initializeFCM.mockResolvedValue({ status: "push_not_requested" });
+    mocks.prepareFCMListeners.mockResolvedValue(undefined);
+    mocks.getPendingConsents?.mockResolvedValue?.({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ pending: [] }),
+    });
+  });
+
+  it("gives up after one 410 instead of reconnecting forever", async () => {
+    mocks.apiFetchStream.mockResolvedValue(
+      streamResponse(
+        410,
+        JSON.stringify({
+          detail: {
+            error_code: "CONSENT_SSE_DISABLED",
+            message: "Consent SSE is disabled. Use FCM notifications.",
+          },
+        }),
+      ),
+    );
+
+    render(
+      <ConsentNotificationProvider>
+        <div>Setup</div>
+      </ConsentNotificationProvider>,
+    );
+
+    // Let the first attempt run.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    expect(mocks.apiFetchStream).toHaveBeenCalledTimes(1);
+
+    // Past the old fixed 3s reconnect and every backoff step after it.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120_000);
+    });
+
+    expect(mocks.apiFetchStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("still retries a status that can genuinely recover, then stops", async () => {
+    // 503 is transient. The fix must not turn every failure into a give-up --
+    // but it must not retry forever either.
+    mocks.apiFetchStream.mockResolvedValue(
+      streamResponse(503, "service unavailable"),
+    );
+
+    render(
+      <ConsentNotificationProvider>
+        <div>Setup</div>
+      </ConsentNotificationProvider>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    expect(mocks.apiFetchStream).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300_000);
+    });
+
+    // 3s, 6s, 12s, 24s, 48s -> six attempts in total, then silence.
+    expect(mocks.apiFetchStream).toHaveBeenCalledTimes(6);
+  });
+});

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -280,7 +280,20 @@ export function PhoneMandatePageContent() {
     { role: "route", routeKey: ROUTES.PHONE_MANDATE },
   );
 
-  if (loading || !user) {
+  // Gate on identity, never on `loading`.
+  //
+  // `loading` is not "the page is still booting" -- the web auth observer sets
+  // it true on every re-validation (lib/firebase/auth-context.tsx:1369), and
+  // starting Firebase phone verification is exactly the kind of event that
+  // triggers one. Returning a fullscreen loader here UNMOUNTS
+  // PhoneVerificationFlow, and its `step` lives in useState, so a person who
+  // had just been sent a code was silently put back on the phone form: the
+  // "Verification code sent" toast had already fired, and the OTP screen they
+  // needed was destroyed before they could type into it.
+  //
+  // A signed-out visitor still sees this loader -- `user` is null -- while the
+  // redirect at the top of this component sends them to /login.
+  if (!user) {
     return (
       <HushhLoader label="Loading phone verification..." variant="fullscreen" />
     );

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -385,7 +385,26 @@ export function PhoneVerificationFlow({
   // double-clicks.
   const phoneFlowInFlightRef = useRef(false);
 
+  // `step` read from an effect that must not re-run when it changes.
+  const stepRef = useRef(step);
   useEffect(() => {
+    stepRef.current = step;
+  }, [step]);
+
+  useEffect(() => {
+    // A sent code outranks a late identity read.
+    //
+    // This effect exists to re-seed the form when the owner's number changes.
+    // But `currentPhoneNumber` comes from the auth context, which resolves the
+    // verified number from the backend in the background, and that can land
+    // AFTER a code has been sent. Re-seeding then wipes `verificationCode` and
+    // moves `step` off "code" -- taking away the only screen that can consume
+    // the code the person is holding, with no way back except sending another.
+    //
+    // While a code is outstanding this screen owns its own state.
+    if (stepRef.current === "code") {
+      return;
+    }
     const nextFields = derivePhoneFields(currentPhoneNumber);
     setSelectedCountry(nextFields.countryValue);
     setLocalPhoneNumber(nextFields.localPhoneNumber);

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -374,6 +374,34 @@ function shouldPrioritizeConsentHydration(pathname: string): boolean {
   return normalized.startsWith("/one/profile") || normalized.startsWith("/ria");
 }
 
+/** An SSE fetch that failed with a status worth keeping. */
+class ConsentSseError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ConsentSseError";
+    this.status = status;
+  }
+}
+
+/**
+ * Statuses that will not change on their own.
+ *
+ * 410 is the live one: consent SSE is deliberately off in production and the
+ * backend answers `CONSENT_SSE_DISABLED` every single time. 401 is absent on
+ * purpose -- a token can refresh -- as are 408, 429 and every 5xx.
+ */
+const PERMANENT_SSE_STATUSES = new Set([400, 403, 404, 410, 501]);
+
+function isPermanentSseStatus(status: number): boolean {
+  return PERMANENT_SSE_STATUSES.has(status);
+}
+
+/** 3s, 6s, 12s, 24s, 48s, then stop. */
+const MAX_SSE_RECONNECT_ATTEMPTS = 5;
+const MAX_SSE_RECONNECT_DELAY_MS = 60_000;
+
 function shouldPrioritizeConsentRealtime(pathname: string): boolean {
   const normalized = String(pathname || "")
     .trim()
@@ -1049,6 +1077,7 @@ export function ConsentNotificationProvider({
     if (!initStatus || initStatus === "push_active") return;
 
     let cancelled = false;
+    let reconnectAttempt = 0;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let idleHandle: number | null = null;
     let delayedConnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1080,10 +1109,19 @@ export function ConsentNotificationProvider({
 
         if (!response.ok || !response.body) {
           const detail = await response.text().catch(() => "");
-          throw new Error(detail || `consent_sse_${response.status}`);
+          // Keep the status. It is the only thing that distinguishes "try
+          // again in a moment" from "this endpoint is switched off". The body
+          // is always non-empty here, so the `consent_sse_${status}` fallback
+          // never fired and the status was being thrown away entirely.
+          throw new ConsentSseError(
+            detail || `consent_sse_${response.status}`,
+            response.status,
+          );
         }
 
         if (cancelled) return;
+
+        reconnectAttempt = 0;
 
         setDeliveryMode(
           initStatus === "push_blocked"
@@ -1151,12 +1189,42 @@ export function ConsentNotificationProvider({
         setDeliveryDetail(
           error instanceof Error ? error.message : "consent_sse_failed",
         );
-        reconnectTimer = globalThis.setTimeout(
-          () => {
-            void connect();
-          },
-          prioritizeRealtime ? 3000 : 6000,
+
+        // A permanent refusal is an answer, not a blip. Consent SSE is off in
+        // production by design (the backend returns 410 with
+        // CONSENT_SSE_DISABLED and tells us to use FCM instead), and it will
+        // return exactly that to attempt one and attempt ten thousand alike.
+        // Reconnecting on a fixed 3s timer turned a settled configuration into
+        // an endless request storm: two Cloud Run invocations, one logged
+        // backend error and one failed api_request_completed metric every
+        // three seconds, per open tab, for as long as the tab stayed open.
+        if (
+          error instanceof ConsentSseError &&
+          isPermanentSseStatus(error.status)
+        ) {
+          console.info(
+            `[NotificationProvider] Consent SSE unavailable (${error.status}); staying on inbox delivery.`,
+          );
+          return;
+        }
+
+        // Everything else may genuinely be transient, so keep trying -- but
+        // back off, and give up rather than retry forever.
+        reconnectAttempt += 1;
+        if (reconnectAttempt > MAX_SSE_RECONNECT_ATTEMPTS) {
+          console.warn(
+            "[NotificationProvider] Consent SSE gave up after " +
+              `${MAX_SSE_RECONNECT_ATTEMPTS} attempts; staying on inbox delivery.`,
+          );
+          return;
+        }
+        const delay = Math.min(
+          3000 * 2 ** (reconnectAttempt - 1),
+          MAX_SSE_RECONNECT_DELAY_MS,
         );
+        reconnectTimer = globalThis.setTimeout(() => {
+          void connect();
+        }, delay);
       }
     };
 


### PR DESCRIPTION
Two live web defects reported from UAT and production. Both are in the same frontend bundle, so they ship together.

---

## 1. Phone verification could not be completed at all

Enter a number, press **Send code**, see *"Verification code sent"* — and the OTP entry screen never appears. You are put back on the phone form. There is no way through.

`setStep("code")` runs **before** the toast, so the toast being visible proves the state advanced. Something took it away afterwards.

### The page tore its own subtree down

`app/register-phone/page.tsx:283` returned a fullscreen loader whenever `useAuth().loading` was true. That **unmounts** `PhoneVerificationFlow`, and its `step` lives in `useState`.

`loading` is not "the page is still booting". `validateActiveSession` sets it true unconditionally whenever a user exists (`auth-context.tsx:1073-1078`), and it is wired to `window` `focus` and `pageshow`. The invisible reCAPTCHA iframe takes and returns focus during `startPhoneVerification` — so pressing Send code fires the very event that destroys the screen you were about to be shown.

**This is a two-day-old regression.** Both the focus listener and that `setLoading(true)` arrived in `441c6bfda` (2026-09-05, *"fix(auth): end deleted-account sessions across devices"*). The `loading || !user` gate is older and was the innocent party until then:

```
git show 441c6bfda^:hushh-webapp/lib/firebase/auth-context.tsx | grep 'addEventListener("focus"' → nothing
```

There is a second consequence that makes it stick. `<div id="recaptcha-container" />` sits **inside** the gated subtree (`page.tsx:398`), so the unmount also destroys the element `RecaptchaVerifier` rendered into while the module singletons still point at the detached node. Retrying then lands on *"reCAPTCHA has already been rendered in this element"*. Gating on identity fixes that too, because the subtree is never torn down.

### A late identity read wiped the step

Separately, the reset effect in `phone-verification-flow.tsx` re-seeds the form when `currentPhoneNumber` changes. That value comes from the auth context, which resolves the verified number from the backend in the background, and the result can land **after** a code has been sent — clearing `verificationCode` and moving `step` off `"code"`.

Only the first defect explains the report: on `/register-phone` `currentPhoneNumber` stays `null`, so the reset could not fire there. The second is real on the profile caller, where the number is non-null. Same failure, one screen over.

## 2. A request storm against an endpoint that is switched off

Every signed-in web tab fired this every 3 seconds, forever:

```
GET /api/consent/events/<uid>  410 (Gone)
[NotificationProvider] Consent SSE fallback failed:
  {"error_code":"CONSENT_SSE_DISABLED","message":"Consent SSE is disabled. Use FCM notifications."}
```

Consent SSE is off in production **on purpose** — `sse.py` returns 410 and points at FCM, and `deploy-production.yml` pins `_CONSENT_SSE_ENABLED=false`. That answer is identical for attempt 1 and attempt 10,000.

The client could not tell. It collapsed every failed response into a bare `Error` carrying only the body text, so `response.status` was discarded — the `consent_sse_${status}` fallback never even fired, because the body is always non-empty. The catch block then reconnected on a fixed 3s timer with no backoff, no cap, and no inspection of the error. The only exits were unmount and effect cleanup, so **nothing the server could say would stop it**.

Cost per retry: two Cloud Run invocations (the Next.js proxy forwards to the backend), one logged backend error, and one `api_request_completed` metric recorded as a failure — which also poisons the API error-rate metric. Per open tab, for as long as the tab is open.

This is the default path, not an edge case: the fallback runs whenever FCM is not active, and a browser that has not granted notification permission reports `push_not_requested` on first load.

Now: keep the status, treat `400/403/404/410/501` as settled and stop, back the rest off (3s → 48s) and give up after five. `401` stays retryable — a token can refresh — as do 408, 429 and every 5xx.

---

## Proof

Every fix here is mutation-checked: reverted, the matching test watched to go red, restored.

| Test | Catches |
|---|---|
| `register-phone-revalidation-remount.test.tsx` (new) | counts mounts across a `loading` flip — two mounts means the OTP screen was destroyed mid-verification |
| `phone-verification-flow-interaction.test.tsx` | the OTP screen survives a late auth-context update, and the reset still works where it is meant to |
| `consent-notification-provider-sse-backoff.test.tsx` (new) | with the old behaviour restored: **41 requests where there should be 1**, and **101 where there should be 6** |

```
71 tests passed (7 files)
tsc --noEmit: clean
eslint --max-warnings=0: clean
```

**One correction worth recording.** My first version of the SSE test passed *with the bug reintroduced* — it waited 250ms against a 3s timer, and installed fake timers after the first reconnect had already been scheduled on a real one. A test that has never been seen to fail is not a test. The numbers above come from the corrected version.

Nothing outside `hushh-webapp/` is touched; no backend, API, schema, route, or analytics change.