### PR TITLE
fix(deploy): use --update-headers when updating a Cloud Scheduler job

### DIFF
--- a/.claude/skills/safe-changes/SKILL.md
+++ b/.claude/skills/safe-changes/SKILL.md
@@ -1150,3 +1150,61 @@ would have broken.
 The Check line must be a command that **runs in this repo** and returns
 something meaningful. Run it before committing the rule. A rule with a command
 that doesn't work here is worse than no rule.
+
+### R29 — A flag shared between `create` and `update` breaks only on the second run
+
+**Incident (2026-09-07, UAT backend deploy run 34154374598.)** The release was
+healthy — migrations applied, the backend deployed, traffic promoted, provenance
+verified, rollback skipped, the release tagged last known good — and the workflow
+still reported **failure**. The last step died on:
+
+```
+ERROR: (gcloud.scheduler.jobs.update.http) unrecognized arguments:
+  --headers=Content-Type=application/json (did you mean '--clear-headers'?)
+```
+
+`deploy/account-deletion/setup_cleanup_scheduler.sh` built one `COMMON_ARGS`
+array and passed it to **both** `gcloud scheduler jobs create http` and
+`gcloud scheduler jobs update http`. Only `create` accepts `--headers`; `update`
+spells it `--update-headers`. So the script worked perfectly the first time a
+job was created and failed forever afterwards — the failure mode appears only
+once the resource already exists, which is exactly when nobody is watching.
+
+The same idiom had been copied into three more schedulers — One Email KYC
+retention, One Location retention, and the Gmail personal-information-request
+monitor — all with the same latent break.
+
+**Rule.** Never share a flag array between a `create` and an `update`
+subcommand without checking both accept every flag in it. The two are different
+commands with different flag sets, and CLIs routinely rename a flag in the
+update form to express intent (`--update-headers`, `--remove-headers`,
+`--clear-headers`). When a deploy step touches a resource that may already
+exist, the *update* path is the one that runs in steady state — test that one.
+
+And a workflow that fails on a post-deploy configuration step must not be read
+as a failed release. Check where in the step list it died before rolling
+anything back.
+
+**Check.**
+```bash
+cd ~/Desktop/husshOne
+# Any --headers on an `update http` path is the bug. Expect no output.
+for f in $(grep -rl 'scheduler jobs update http' deploy --include='*.sh'); do
+  awk '/jobs update http/,/>\/dev\/null/' "$f" | grep -q -- '--headers=' \
+    && echo "BROKEN: $f"
+done
+# And the two arms must AGREE. A script that sends headers on one path and not
+# the other has lost them; a script that sends none on either is fine (several
+# jobs post `--message-body '{}'` with no Content-Type and never needed one).
+for f in $(grep -rl 'scheduler jobs create http' deploy --include='*.sh'); do
+  c=$(awk '/jobs create http/,/>\/dev\/null/' "$f" | grep -c -- '--headers=')
+  u=$(awk '/jobs update http/,/>\/dev\/null/' "$f" | grep -c -- '--update-headers=')
+  [ "$c" \!= "$u" ] && echo "ASYMMETRIC HEADERS: $f (create=$c update=$u)"
+done
+```
+Both loops must print nothing.
+
+The second loop was wrong when first written: it asserted every `create` sends
+headers, and flagged `setup_investor_replenisher_scheduler.sh` and
+`setup_gcp_observability.sh`, which deliberately send none on either path. A
+check that reports a deliberate choice as a defect trains people to ignore it.

--- a/deploy/account-deletion/setup_cleanup_scheduler.sh
+++ b/deploy/account-deletion/setup_cleanup_scheduler.sh
@@ -71,7 +71,6 @@ COMMON_ARGS=(
   --time-zone="${TIMEZONE}"
   --uri="${URI}"
   --http-method=POST
-  --headers="Content-Type=application/json"
   --oidc-service-account-email="${SCHEDULER_SERVICE_ACCOUNT_EMAIL}"
   --oidc-token-audience="${OIDC_AUDIENCE}"
   --attempt-deadline=300s
@@ -84,9 +83,16 @@ COMMON_ARGS=(
 if gcloud scheduler jobs describe "${JOB_NAME}" \
   --project="${PROJECT_ID}" \
   --location="${SCHEDULER_LOCATION}" >/dev/null 2>&1; then
-  gcloud scheduler jobs update http "${JOB_NAME}" "${COMMON_ARGS[@]}" >/dev/null
+# `create http` takes --headers; `update http` does not -- it takes
+# --update-headers. Sharing one flag between both subcommands made every
+# scheduler REPAIR fail with "unrecognized arguments: --headers=..." while
+# first-time creation kept working, so the break only appeared once the job
+# already existed.
+  gcloud scheduler jobs update http "${JOB_NAME}" "${COMMON_ARGS[@]}" \
+    --update-headers="Content-Type=application/json" >/dev/null
 else
-  gcloud scheduler jobs create http "${JOB_NAME}" "${COMMON_ARGS[@]}" >/dev/null
+  gcloud scheduler jobs create http "${JOB_NAME}" "${COMMON_ARGS[@]}" \
+    --headers="Content-Type=application/json" >/dev/null
 fi
 
 JOB_EVIDENCE="$(gcloud scheduler jobs describe "${JOB_NAME}" \

--- a/deploy/gmail/setup_personal_information_request_monitor_scheduler.sh
+++ b/deploy/gmail/setup_personal_information_request_monitor_scheduler.sh
@@ -57,7 +57,6 @@ COMMON_ARGS=(
   --time-zone="${TIMEZONE}"
   --uri="${URI}"
   --http-method=POST
-  --headers="Content-Type=application/json"
   --message-body="${BODY}"
   --oidc-service-account-email="${SCHEDULER_SERVICE_ACCOUNT_EMAIL}"
   --oidc-token-audience="${BACKEND_URL%/}"
@@ -67,9 +66,16 @@ COMMON_ARGS=(
 if gcloud scheduler jobs describe "${JOB_NAME}" \
   --project="${PROJECT_ID}" \
   --location="${SCHEDULER_LOCATION}" >/dev/null 2>&1; then
-  gcloud scheduler jobs update http "${JOB_NAME}" "${COMMON_ARGS[@]}" >/dev/null
+# `create http` takes --headers; `update http` does not -- it takes
+# --update-headers. Sharing one flag between both subcommands made every
+# scheduler REPAIR fail with "unrecognized arguments: --headers=..." while
+# first-time creation kept working, so the break only appeared once the job
+# already existed.
+  gcloud scheduler jobs update http "${JOB_NAME}" "${COMMON_ARGS[@]}" \
+    --update-headers="Content-Type=application/json" >/dev/null
 else
-  gcloud scheduler jobs create http "${JOB_NAME}" "${COMMON_ARGS[@]}" >/dev/null
+  gcloud scheduler jobs create http "${JOB_NAME}" "${COMMON_ARGS[@]}" \
+    --headers="Content-Type=application/json" >/dev/null
 fi
 
 JOB_EVIDENCE="$(gcloud scheduler jobs describe "${JOB_NAME}" \

--- a/deploy/one-email/setup_kyc_retention_scheduler.sh
+++ b/deploy/one-email/setup_kyc_retention_scheduler.sh
@@ -35,6 +35,11 @@ HEADERS="X-Hushh-Maintenance-Token=${TOKEN},Content-Type=application/json"
 if gcloud scheduler jobs describe "${JOB_NAME}" \
   --project="${PROJECT_ID}" \
   --location="${SCHEDULER_LOCATION}" >/dev/null 2>&1; then
+# `create http` takes --headers; `update http` does not -- it takes
+# --update-headers. Sharing one flag between both subcommands made every
+# scheduler REPAIR fail with "unrecognized arguments: --headers=..." while
+# first-time creation kept working, so the break only appeared once the job
+# already existed.
   gcloud scheduler jobs update http "${JOB_NAME}" \
     --project="${PROJECT_ID}" \
     --location="${SCHEDULER_LOCATION}" \
@@ -42,7 +47,7 @@ if gcloud scheduler jobs describe "${JOB_NAME}" \
     --time-zone="${TIMEZONE}" \
     --uri="${URI}" \
     --http-method=POST \
-    --headers="${HEADERS}" \
+    --update-headers="${HEADERS}" \
     --attempt-deadline=300s >/dev/null
 else
   gcloud scheduler jobs create http "${JOB_NAME}" \

--- a/deploy/one-location/setup_retention_scheduler.sh
+++ b/deploy/one-location/setup_retention_scheduler.sh
@@ -42,16 +42,22 @@ COMMON_ARGS=(
   --time-zone="${TIMEZONE}"
   --uri="${URI}"
   --http-method=POST
-  --headers="${HEADERS}"
   --attempt-deadline=300s
 )
 
 if gcloud scheduler jobs describe "${JOB_NAME}" \
   --project="${PROJECT_ID}" \
   --location="${SCHEDULER_LOCATION}" >/dev/null 2>&1; then
-  gcloud scheduler jobs update http "${JOB_NAME}" "${COMMON_ARGS[@]}" >/dev/null
+# `create http` takes --headers; `update http` does not -- it takes
+# --update-headers. Sharing one flag between both subcommands made every
+# scheduler REPAIR fail with "unrecognized arguments: --headers=..." while
+# first-time creation kept working, so the break only appeared once the job
+# already existed.
+  gcloud scheduler jobs update http "${JOB_NAME}" "${COMMON_ARGS[@]}" \
+    --update-headers="${HEADERS}" >/dev/null
 else
-  gcloud scheduler jobs create http "${JOB_NAME}" "${COMMON_ARGS[@]}" >/dev/null
+  gcloud scheduler jobs create http "${JOB_NAME}" "${COMMON_ARGS[@]}" \
+    --headers="${HEADERS}" >/dev/null
 fi
 
 JOB_EVIDENCE="$(gcloud scheduler jobs describe "${JOB_NAME}" \


### PR DESCRIPTION
The UAT backend deploy reported **failure on a healthy release**.

Run [34154374598](https://github.com/hushh-labs/hushh-research/actions/runs/34154374598) applied the migrations, deployed the backend, promoted traffic, verified exact-SHA provenance, passed the schema contract gate and semantic verification, skipped rollback, and tagged the release last known good — then died on the final step:

```
ERROR: (gcloud.scheduler.jobs.update.http) unrecognized arguments:
  --headers=Content-Type=application/json (did you mean '--clear-headers'?)
```

## Why it only breaks in steady state

`deploy/account-deletion/setup_cleanup_scheduler.sh` built one `COMMON_ARGS` array and passed it to **both** subcommands:

```bash
if gcloud scheduler jobs describe "${JOB_NAME}" ...; then
  gcloud scheduler jobs update http "${JOB_NAME}" "${COMMON_ARGS[@]}"   # --headers rejected
else
  gcloud scheduler jobs create http "${JOB_NAME}" "${COMMON_ARGS[@]}"   # --headers accepted
fi
```

Only `create` accepts `--headers`. `update` spells it `--update-headers` — the CLI renames it to express intent, alongside `--remove-headers` and `--clear-headers`.

So the script worked perfectly **the first time the job was created** and failed every time after. The failure mode appears only once the resource already exists, which is steady state and exactly when nobody is watching.

## One defect, four addresses

The idiom had been copied into three more schedulers, all carrying the same latent break:

| Script | |
|---|---|
| `deploy/account-deletion/setup_cleanup_scheduler.sh` | the one that fired |
| `deploy/one-email/setup_kyc_retention_scheduler.sh` | latent |
| `deploy/one-location/setup_retention_scheduler.sh` | latent |
| `deploy/gmail/setup_personal_information_request_monitor_scheduler.sh` | latent |

Each now sends `--headers` on create and `--update-headers` on update. The create arms are unchanged.

**Deliberately left alone:** `setup_investor_replenisher_scheduler.sh` and `setup_gcp_observability.sh` send no headers on either path — they post `--message-body '{}'` and never needed a `Content-Type`. Consistent, not broken.

## Ledger

Adds **R29** — *a flag shared between `create` and `update` breaks only on the second run*, plus the corollary that a workflow failing on a post-deploy configuration step is not a failed release, so check where in the step list it died before rolling anything back.

**R29's check was wrong when I first wrote it.** It asserted that every `create` arm sends headers, and flagged the two scripts above — a deliberate choice reported as a defect. It now asserts the create and update arms *agree*, which is the real invariant. A check that cries wolf trains people to ignore it, so I fixed the check rather than the scripts.

## Verification

```
bash -n on all four scripts: syntax OK
R29 check: no output (passes)
create arms still send headers: all four confirmed
```

Shell-only change under `deploy/`. No application code, no migration, no IAM, no secret, no workflow YAML.