### PR TITLE
fix(deploy): make account cleanup scheduler updates repeatable

### DIFF
--- a/consent-protocol/tests/test_account_deletion_release_workflow.py
+++ b/consent-protocol/tests/test_account_deletion_release_workflow.py
@@ -267,10 +267,23 @@ def test_uat_scheduler_service_account_id_is_valid_and_consistent() -> None:
     assert "roles/iam.serviceAccountTokenCreator" not in scheduler_setup
 
 
-def test_scheduler_setup_does_not_require_service_account_policy_admin(
-    tmp_path: Path,
+@pytest.mark.parametrize("job_exists", [False, True])
+@pytest.mark.parametrize("mutation_fails", [False, True])
+def test_scheduler_setup_is_repeatable_without_service_account_policy_admin(
+    tmp_path: Path, job_exists: bool, mutation_fails: bool
 ) -> None:
     environment = os.environ.copy()
+    for name in (
+        "BASH_ENV",
+        "SCHEDULER_SERVICE_ACCOUNT_EMAIL",
+        "SCHEDULER_LOCATION",
+        "JOB_NAME",
+        "CRON",
+        "TIMEZONE",
+        "BATCH_LIMIT",
+        "OIDC_AUDIENCE",
+    ):
+        environment.pop(name, None)
     environment.update(
         {
             "BACKEND_URL": "https://api.uat.example.com",
@@ -279,11 +292,15 @@ def test_scheduler_setup_does_not_require_service_account_policy_admin(
         }
     )
     calls = tmp_path / "gcloud-calls"
+    job_state = tmp_path / "scheduler-job-exists"
+    if job_exists:
+        job_state.touch()
     guards = f'''gcloud() {{
       printf '%s\\n' "$*" >> "{calls.as_posix()}"
       case "$1 $2 $3" in
         "iam service-accounts describe") return 0 ;;
         "scheduler jobs describe")
+          [[ -f "{job_state.as_posix()}" ]] || return 1
           printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' \\
             'ENABLED' '*/2 * * * *' \\
             'https://api.uat.example.com/api/account/deletion-cleanup/drain?limit=10' \\
@@ -292,7 +309,33 @@ def test_scheduler_setup_does_not_require_service_account_policy_admin(
             'https://api.uat.example.com'
           return 0
           ;;
-        "scheduler jobs update") return 0 ;;
+        "scheduler jobs create"|"scheduler jobs update")
+          [[ "$4" == http && "$5" == account-deletion-cleanup-uat ]] || return 95
+          local expected_header forbidden_header argument header_found=false
+          if [[ "$3" == update ]]; then
+            [[ -f "{job_state.as_posix()}" ]] || return 95
+            expected_header='--update-headers=Content-Type=application/json'
+            forbidden_header='--headers='
+          else
+            [[ ! -f "{job_state.as_posix()}" ]] || return 95
+            expected_header='--headers=Content-Type=application/json'
+            forbidden_header='--update-headers='
+          fi
+          for argument in "$@"; do
+            if [[ "$argument" == "$forbidden_header"* ]]; then
+              echo "UNSUPPORTED_HEADER_FLAG: $argument" >&2
+              return 2
+            fi
+            if [[ "$argument" == "$expected_header" ]]; then header_found=true; fi
+          done
+          [[ "$header_found" == true ]] || return 95
+          if [[ "{str(mutation_fails).lower()}" == true ]]; then
+            echo SCHEDULER_MUTATION_FAILED >&2
+            return 42
+          fi
+          : > "{job_state.as_posix()}"
+          return 0
+          ;;
         *) echo "UNEXPECTED_GCLOUD_COMMAND: $*" >&2; return 96 ;;
       esac
     }}
@@ -300,21 +343,40 @@ def test_scheduler_setup_does_not_require_service_account_policy_admin(
     bash = shutil.which("bash")
     assert bash is not None, "Bash is required for the scheduler behavior test"
 
-    result = subprocess.run(  # noqa: S603 - trusted script with guarded cloud commands
-        [bash, "-c", guards + SCHEDULER_SETUP_SCRIPT.read_text(encoding="utf-8")],
-        cwd=ROOT,
-        env=environment,
-        capture_output=True,
-        text=True,
-        timeout=10,
-        check=False,
-    )
+    for _ in range(2):
+        result = subprocess.run(  # noqa: S603 - trusted script with guarded cloud commands
+            [bash, "-c", guards + SCHEDULER_SETUP_SCRIPT.read_text(encoding="utf-8")],
+            cwd=ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
 
-    output = result.stdout + result.stderr
-    assert result.returncode == 0, output
-    assert "Configured and verified Cloud Scheduler job" in result.stdout
-    assert "UNEXPECTED_GCLOUD_COMMAND" not in output
-    assert "add-iam-policy-binding" not in calls.read_text(encoding="utf-8")
+        output = result.stdout + result.stderr
+        assert result.returncode == (42 if mutation_fails else 0), output
+        assert "UNSUPPORTED_HEADER_FLAG" not in output
+        assert "UNEXPECTED_GCLOUD_COMMAND" not in output
+        if mutation_fails:
+            assert "SCHEDULER_MUTATION_FAILED" in result.stderr
+            assert "Configured and verified" not in result.stdout
+        else:
+            assert "Configured and verified Cloud Scheduler job" in result.stdout
+
+    commands = calls.read_text(encoding="utf-8").splitlines()
+    mutations = [
+        line.split()[2]
+        for line in commands
+        if line.startswith(("scheduler jobs create ", "scheduler jobs update "))
+    ]
+    expected = ["update", "update"] if job_exists else ["create", "update"]
+    if mutation_fails and not job_exists:
+        expected = ["create", "create"]
+    assert mutations == expected
+    describes = [line for line in commands if line.startswith("scheduler jobs describe ")]
+    assert len(describes) == (2 if mutation_fails else 4)
+    assert not any("iam-policy" in line for line in commands)
 
 
 @pytest.mark.parametrize(

--- a/deploy/account-deletion/setup_cleanup_scheduler.sh
+++ b/deploy/account-deletion/setup_cleanup_scheduler.sh
@@ -71,7 +71,6 @@ COMMON_ARGS=(
   --time-zone="${TIMEZONE}"
   --uri="${URI}"
   --http-method=POST
-  --headers="Content-Type=application/json"
   --oidc-service-account-email="${SCHEDULER_SERVICE_ACCOUNT_EMAIL}"
   --oidc-token-audience="${OIDC_AUDIENCE}"
   --attempt-deadline=300s
@@ -84,9 +83,13 @@ COMMON_ARGS=(
 if gcloud scheduler jobs describe "${JOB_NAME}" \
   --project="${PROJECT_ID}" \
   --location="${SCHEDULER_LOCATION}" >/dev/null 2>&1; then
-  gcloud scheduler jobs update http "${JOB_NAME}" "${COMMON_ARGS[@]}" >/dev/null
+  # The update command preserves existing headers and uses a different flag
+  # from create. Keep command-specific flags out of the shared arguments.
+  gcloud scheduler jobs update http "${JOB_NAME}" "${COMMON_ARGS[@]}" \
+    --update-headers="Content-Type=application/json" >/dev/null
 else
-  gcloud scheduler jobs create http "${JOB_NAME}" "${COMMON_ARGS[@]}" >/dev/null
+  gcloud scheduler jobs create http "${JOB_NAME}" "${COMMON_ARGS[@]}" \
+    --headers="Content-Type=application/json" >/dev/null
 fi
 
 JOB_EVIDENCE="$(gcloud scheduler jobs describe "${JOB_NAME}" \


### PR DESCRIPTION
# Description

Fix the remaining UAT account-deletion activation failure on repeat backend deployments. Related: #6490. Follow-up to #6556 (valid Scheduler service-account ID) and #6560 (remove unnecessary IAM-policy mutation).

Failed run: https://github.com/hushh-labs/hushh-research/actions/runs/34154374598

Initial Scheduler creation succeeded in release 34029812646. The later existing-job path failed because `gcloud scheduler jobs update http` rejects create-only `--headers`. Use `--update-headers` only for update and `--headers` only for create. All other arguments, OIDC identity/audience, least-privilege permissions, verification and release fencing remain unchanged.

Official command contracts: [create](https://docs.cloud.google.com/sdk/gcloud/reference/scheduler/jobs/create/http), [update](https://docs.cloud.google.com/sdk/gcloud/reference/scheduler/jobs/update/http).

## Impact Map (Required)

- Routes touched: none; deployment script only.
- API / schema / type changes: none.
- Cache keys touched: none.
- Runtime DB data-plane changes: none in this diff. Existing governed activation retains its deletion fence until successful fresh Scheduler HTTP evidence and legacy-revision retirement.
- World-model domain summary effects: none.
- Mobile parity impacts: shared backend deployment recovery; no native or web bundle edits.
- Docs updated: release/QA evidence will be recorded on #6490 after the run concludes.
- Top-level / devex / config / generated / ignore files touched: `deploy/account-deletion/setup_cleanup_scheduler.sh`, called by `deploy-uat.yml` activation; existing behavioral test extended.
- Trust boundary touched: deploy; no new credentials or IAM grants.
- Caller / proxy / backend pairing: Scheduler POST and OIDC configuration unchanged.
- Rollback or safe-failure behavior: command failures still exit immediately, never print successful setup; activation must not remove the fence on failure.
- UI browser or Playwright proof: not applicable to this two-file deploy fix. Physical-device acceptance of the original product change remains on #6490.

## Review-Ready Contract

- [x] Title, body, changed files and tests match this bounded deployment contract.
- [x] Existing implementation and related PRs reviewed; this fixes the update-path gap after #6556 and #6560.
- [x] Reachable production attach point: UAT workflow's `Activate tombstone-aware account deletion` step calls the real setup script.
- [x] Behavioral tests execute the actual Bash script with all cloud commands intercepted; no live test resources are created.
- [x] Independent read-only review found no blocking issues; remaining common flags were checked against both official command contracts.
- [x] Commit has DCO signoff; maintainer edits enabled.
- [ ] Required exact-head Linux CI terminal green before merge.

## Testing

- RED before script correction: 3 failed / 1 passed, reproducing `UNSUPPORTED_HEADER_FLAG: --headers=Content-Type=application/json`, including first-create-then-update.
- GREEN twice: 77 passed, 1 database-dependent skip per run across account-deletion workflow, tombstone migration, detail-leak, lifecycle-service, and Cloud Build argument-limit tests.

```sh
consent-protocol/.venv/Scripts/python.exe -m pytest consent-protocol/tests/test_account_deletion_release_workflow.py consent-protocol/tests/test_account_deletion_tombstone_migration.py consent-protocol/tests/test_account_deletion_detail_leak.py consent-protocol/tests/services/test_account_deletion_lifecycle_service.py consent-protocol/tests/test_cloudbuild_step_arg_limit.py -q
consent-protocol/.venv/Scripts/python.exe -m ruff check consent-protocol
consent-protocol/.venv/Scripts/python.exe -m ruff format --check consent-protocol
bash -n deploy/account-deletion/setup_cleanup_scheduler.sh
git diff --check
bash scripts/ci/check-dco-signoff.sh origin/main HEAD
bash scripts/ci/secret-scan.sh
bash scripts/ci/verify-main-branch-protection.sh
```

- New regression matrix: missing job create→update; existing job update→update; correct header flag required and wrong flag rejected; create/update command failure propagation; no false success or verification after failed mutation; no IAM-policy mutation.
- Full protocol Ruff check and format check: passed (1055 files). Bash syntax and `git diff --check`: passed. Commit hooks and DCO: passed. Gitleaks: no leaks; no open secret-scanning alerts.
- Local full CI/RCA attempted but Windows launcher/encoding limitations prevent full local parity. Exact-head hosted Linux checks remain mandatory; local tool limitations are not represented as green.
- UAT completion requires exact landed-SHA smoke success, governed `scope=auto` release success, existing-job update success, fresh Scheduler HTTP 2xx, zero remaining legacy revisions, removed fence, provenance/schema/semantic gates and live health evidence.

## Tri-Flow Architecture Check

Web / iOS / Android: no client changes in this follow-up. All consume the shared backend. No production or native binary release is included.

## Privacy & Consent

No user-data access added; no consent/auth semantics changed. Existing IAM least privilege and OIDC-only Scheduler authentication preserved. Tests use fixed non-sensitive fixtures.

## Licensing

First-party changes remain Apache-2.0 compatible; no dependencies changed.
