### PR TITLE
fix(ui): consistent blue slider tabs for Location, Connect and Consent

### DIFF
--- a/docs/reference/quality/design-system.md
+++ b/docs/reference/quality/design-system.md
@@ -230,6 +230,11 @@ surface, readable active/inactive labels, and the same focus and motion
 grammar. Location is the visual reference for every tab set; route-specific
 underlines, borders, and alternate active pills are prohibited.
 
+Selected labels use `--app-accent` in both light and dark mode, including
+Location, Connect, and Consent Center. Label typography must preserve that
+selected colour rather than override it with the neutral text token. Dense
+four-tab strips keep every label readable at the supported phone widths.
+
 `SwipeViews` (`@/lib/morphy-ux/ui/swipe-views`) is that paired pager and the
 one canonical primitive for any route or panel with more than one
 locally-selectable content view, whether the selection is query-backed

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1066,11 +1066,8 @@ textarea {
      surface it had been borrowing. */
   --app-segmented-track-surface: var(--app-neutral-fill);
   --app-segmented-active-surface: var(--app-card-surface-default-solid);
-  /* Not the accent. A segmented control marks the selection with the PILL --
-     a second signal in accent tint is what tab bars use, and using both makes
-     a segmented strip read as a tab bar. See the scoped `[role="tab"]` rule
-     further down, which is where Location was getting blue from. */
-  --app-segmented-active-foreground: var(--app-label);
+  /* Selected tabs share the app accent across shell and in-page controls. */
+  --app-segmented-active-foreground: var(--app-accent);
   --app-segmented-active-border: transparent;
   --app-segmented-active-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   --app-shell-surface-bg: var(--app-glass-surface);
@@ -3795,7 +3792,7 @@ body:has([data-testid="one-location-onboarding"])
      alone cannot do that in dark mode -- so here the lift comes from the
      surface being lighter than the track, not from the shadow. */
   --app-segmented-active-surface: var(--app-card-surface-default-solid);
-  --app-segmented-active-foreground: var(--app-label);
+  --app-segmented-active-foreground: var(--app-accent);
   --app-segmented-active-border: transparent;
   --app-segmented-active-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
   --app-shell-surface-bg: var(--app-glass-surface);
@@ -6329,24 +6326,16 @@ body[data-persona-surface="ria"] {
   color: var(--app-label) !important;
 }
 
-/* Accent marks the selection on an UNDERLINE tab bar, where there is no other
-   signal -- Consent Center, RIA, Finance. A segmented strip already marks it
-   with the raised pill, and tinting the label too gave Location's `Now /
-   People / Links` a blue active label while Connect's identical control sat
-   dark, because Connect's label class forces `--app-label`. Two components,
-   two global rules, opposite results, and neither component's own colour ever
-   applied: both lost to these `!important` declarations.
-
-   Scoped by the strip's own `data-top-shell-tab-set`, which `TopShellTabs`
-   already writes, so the underline arm is untouched. */
+/* Selection owns tab-label colour. Typography sets label colours with
+   !important, so inherited component colours alone cannot express selection. */
 [role="tab"][aria-selected="true"] :is(.ui-text-agent-tab-label) {
   color: var(--app-accent) !important;
 }
 
-[data-top-shell-tab-set="location"]
-  [role="tab"][aria-selected="true"]
-  :is(.ui-text-agent-tab-label) {
-  color: var(--app-label) !important;
+[data-ui-role="segmented-tabs"] [role="tab"][aria-selected="true"]
+  :is(.ui-text-form-label) {
+  color: var(--app-segmented-active-foreground) !important;
+  font-weight: 600 !important;
 }
 
 [role="tab"][aria-selected="false"] :is(.ui-text-agent-tab-label) {

--- a/hushh-webapp/components/app-ui/top-shell-tabs.tsx
+++ b/hushh-webapp/components/app-ui/top-shell-tabs.tsx
@@ -264,7 +264,8 @@ export function TopShellTabs({
                 data-ui-role="agent-tab-label"
                 className={cn(
                   "ui-text-agent-tab-label relative truncate transition-colors duration-150",
-                  usesCompactLabels && "[--type-agent-tab-label-size:12px] min-[400px]:[--type-agent-tab-label-size:14px] sm:[--type-agent-tab-label-size:15px]",
+                  usesCompactLabels &&
+                    "[--type-agent-tab-label-size:11px] min-[360px]:[--type-agent-tab-label-size:12px] min-[400px]:[--type-agent-tab-label-size:14px] sm:[--type-agent-tab-label-size:15px]",
                   usesModuleSegmentedTabs
                     ? isActive
                       ? "font-semibold text-[color:var(--app-accent)]"

--- a/hushh-webapp/components/app-ui/top-shell-tabs.tsx
+++ b/hushh-webapp/components/app-ui/top-shell-tabs.tsx
@@ -80,7 +80,11 @@ export function TopShellTabs({
   const tabSwipeState = useTopShellTabSwipeState(tabSet.id);
   const indicatorTransform = `translate3d(calc(var(${topShellTabSwipePositionVariable(tabSet.id)}, ${activeIndex}) * 100%), 0, 0)`;
   const usesModuleSegmentedTabs =
-    tabSet.id === "location" || tabSet.id === "connect" || tabSet.id === "ria";
+    tabSet.id === "location" ||
+    tabSet.id === "connect" ||
+    tabSet.id === "consent" ||
+    tabSet.id === "ria";
+  const usesCompactLabels = usesModuleSegmentedTabs && tabSet.tabs.length > 3;
   const shouldResetScrollOnSelection = tabSet.id === "finance";
 
   const textRefs = useRef<Array<HTMLSpanElement | null>>([]);
@@ -194,7 +198,7 @@ export function TopShellTabs({
               //
               // The cap is now the page column's own content width, so the two
               // cannot drift apart again. Both tokens already exist. Scoped to
-              // Location, Connect, and RIA by the module branch above — the
+              // Location, Connect, Consent, and RIA by the module branch above — the
               // other tab sets take the underline arm and do not move.
               //
               // RIA joined 2026-09 (#6289's follow-up): this wrapper carries
@@ -233,6 +237,7 @@ export function TopShellTabs({
               tabIndex={isActive ? 0 : -1}
               className={cn(
                 "relative z-10 flex h-full flex-1 items-center justify-center px-3 outline-none transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] focus-visible:ring-inset",
+                usesCompactLabels && "min-w-0 px-0.5 sm:px-3",
               )}
               onClick={() => selectIndex(index, false)}
               onKeyDown={(event) => {
@@ -259,6 +264,7 @@ export function TopShellTabs({
                 data-ui-role="agent-tab-label"
                 className={cn(
                   "ui-text-agent-tab-label relative truncate transition-colors duration-150",
+                  usesCompactLabels && "[--type-agent-tab-label-size:12px] min-[400px]:[--type-agent-tab-label-size:14px] sm:[--type-agent-tab-label-size:15px]",
                   usesModuleSegmentedTabs
                     ? isActive
                       ? "font-semibold text-[color:var(--app-accent)]"

--- a/hushh-webapp/lib/morphy-ux/ui/segmented-tabs.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/segmented-tabs.tsx
@@ -37,10 +37,11 @@ export function SegmentedTabs({
   return (
     <div
       role="tablist"
+      data-ui-role="segmented-tabs"
       aria-label={ariaLabel}
       className={cn(
         "relative grid min-h-11 w-full rounded-[14px] p-0.5 backdrop-blur-xl [grid-template-columns:repeat(var(--segmented-mobile-cols),minmax(0,1fr))] sm:[grid-template-columns:repeat(var(--segmented-desktop-cols),minmax(0,1fr))]",
-        "border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] shadow-none",
+        "border-0 bg-[color:var(--app-segmented-track-surface)] shadow-none",
         className,
       )}
       style={
@@ -60,7 +61,8 @@ export function SegmentedTabs({
             role="tab"
             aria-label={option.accessibleLabel}
             aria-selected={isActive}
-            tabIndex={isActive ? 0 : -1}            disabled={disabled}
+            tabIndex={isActive ? 0 : -1}
+            disabled={disabled}
             data-state={isActive ? "active" : "inactive"}
             onClick={() => {
               if (!disabled && !isActive) onValueChange(option.value);
@@ -68,7 +70,7 @@ export function SegmentedTabs({
             className={cn(
               "relative isolate flex min-h-10 min-w-0 items-center justify-center overflow-hidden rounded-[12px] border px-3 py-2 text-center transition-[background-color,border-color,box-shadow,color] duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] sm:px-4",
               isActive
-                ? "z-10 border-[color:var(--app-segmented-active-border)] bg-[color:var(--app-segmented-active-surface)] text-[color:var(--app-segmented-active-foreground)] font-normal shadow-[var(--app-segmented-active-shadow)]"
+                ? "z-10 border-transparent bg-[color:var(--app-segmented-active-surface)] text-[color:var(--app-segmented-active-foreground)] font-semibold shadow-[var(--app-segmented-active-shadow)]"
                 : "border-transparent bg-transparent text-[color:var(--app-secondary-label)] [@media(hover:hover)]:hover:bg-[color:var(--app-neutral-fill)]",
               disabled && "cursor-not-allowed opacity-60",
             )}


### PR DESCRIPTION
Location's selected tab stayed dark because a global typography override defeated the component's blue active colour. Consent also retained a different underline treatment, and the shared in-page segmented control had drifted back to its old bordered material.

This restores blue selected labels in light and dark mode, gives Consent the same grey rail and raised pill as Location and Connect, and restores that material on shared segmented controls. Consent's four labels remain fully readable down to 320px.

Fixes #6323.

## Impact Map

- Routes touched: `/one/location`, `/one/connect`, `/one/consent`, and existing callers of the shared `SegmentedTabs` primitive.
- API/schema/type changes: none.
- Cache keys touched: none.
- Runtime DB data-plane changes: none.
- World-model domain summary effects: none.
- Mobile parity impacts: shared web styling applies to hosted web and the native web view; no plugin or route contracts change.
- Docs updated: `docs/reference/quality/design-system.md` documents selected-label colour and dense-tab readability.
- Top-level/devex/config/generated/ignore files touched: none.
- Trust boundary touched: none; Consent changes are presentation only.
- Caller/proxy/backend pairing: no backend or proxy changes.
- Rollback or safe-failure behavior: revert this PR to restore the previous presentation; navigation and selection state contracts are retained.
- UI browser or Playwright proof: actual `TopShellTabs`, registry, `SegmentedTabs`, and `app/globals.css` rendered in an isolated browser harness with a Next router adapter. All 168 selections passed at 320, 360, 375, 390, 430, 768, and 1280px in light/dark mode: selected blue, inactive neutral, no label clipping, no horizontal overflow. Arrow/Home/End selection, disabled controls, and matching rail colours also passed. This is component/browser proof, not an authenticated account rehearsal.

## Verification

- `npm run verify:design-system`, `npm run verify:docs`, `npm run typecheck`: passed.
- ESLint on both changed components: passed.
- `npm run verify:cache`: 61 tests passed.
- `vitest run __tests__/components/settings-ui.test.tsx __tests__/navigation/top-shell-tabs.test.ts --maxWorkers=1`: 36 tests passed.
- DCO, changed-commit secret scan, skill lint, and live main branch-protection verification: passed.
- Local full pre-PR mirror was attempted; nested `python3` resolution in this Windows host prevents completion. Broader local route suites also encountered host resource limits. Required hosted CI passed on final head `f34e9305861b9d892c7f9854b424dbf4251ffc98` before the maintainer merge.

## Review-Ready Contract

The change extends the existing reachable shared tab primitives, follows the current design-system contract, and completes the remaining gaps after #6324. It adds no parallel component or route. Commits are signed off. This standalone PR was merged into `main` using the requested maintainer bypass after its required checks passed. Main smoke and UAT deployment passed on merged commit `0a7cd9f6414d84d6292b6a02d0e97c305ba43043`.

## Tri-Flow, Privacy, and Licensing

Web presentation only; iOS and Android consume the same styling without native code changes. No user information is accessed, no consent authority changes, and no dependencies or licensing obligations are added.

## Release Verification

- [PR Validation](https://github.com/hushh-labs/hushh-research/actions/runs/34159956825): passed on the final PR head.
- [Main Post-Merge Smoke](https://github.com/hushh-labs/hushh-research/actions/runs/34160473857): passed on the merged commit.
- [UAT deployment](https://github.com/hushh-labs/hushh-research/actions/runs/34160686112): completed successfully; release artifact reports `healthy`. Requested `auto` scope resolved to `all`.
- UAT frontend revision `hushh-webapp-00776-pmf` and backend revision `consent-protocol-01109-zob` both match the merged commit and serve 100% traffic in `us-central1`.
- Deployment provenance, runtime environment parity, functional verification, and the database contract gate passed. The canonical verification plan did not require PKM or reviewer BYOK lanes for these changes.
- Public `https://uat.one.hushh.ai` returned HTTP 200. Its delivered stylesheet contains the accent selected-label token, scoped segmented label rule, and 320px label sizing, with the old Location neutral override absent.
- Issue #6323 is reopened and marked Ready for QA for the testing team's retest.