### PR TITLE
docs(ios): correct R29 — the Google frameworks do ship as dynamic libraries

### DIFF
--- a/.claude/skills/safe-changes/SKILL.md
+++ b/.claude/skills/safe-changes/SKILL.md
@@ -1135,11 +1135,23 @@ FirebaseAnalytics.framework with the UUIDs [...]` — also for `GoogleAppMeasure
 `GoogleAppMeasurementIdentitySupport` and `GoogleAdsOnDeviceConversion`. It was reported as
 "not something this change introduced" and left alone, which was accurate and useless.
 
-The warning is genuinely unfixable. Those four arrive through Swift Package Manager as binary
-targets under `SourcePackages/artifacts/`; `file` reports **`current ar archive`**, so they are
-static libraries in a `.framework` wrapper, and `find` returns **no `.dSYM` anywhere inside the
-`.xcframework`**. They are linked into `App` and never ship as a separate image. There is no dSYM
-to supply and never will be — Google strips them before publishing.
+The warning is unfixable from here, but **not** for the reason first written down. The original
+version of this rule claimed those four were static libraries linked into `App` that never ship as
+their own image, so nothing was lost. That was wrong, and the guard's own first real run disproved
+it: all four appear in `App.app/Frameworks/`, and the signed `.ipa` shows each is `MH_DYLIB` with
+its own UUID (`FirebaseAnalytics` = `CC492DC7-…`). They are separately loaded dynamic libraries.
+
+The claim came from reading `SourcePackages/artifacts/` in **local** DerivedData, where `file` said
+`current ar archive`. That local checkout did not match what CI resolves and ships. R19's lesson
+again, in a new place: when a local reading and a measurement of the real artifact disagree, the
+artifact wins.
+
+What *is* true, and is what makes it unfixable: Google publishes **no dSYM** for any of the four —
+none inside the `.xcframework`, none reaching `App.xcarchive/dSYMs` (the archive holds 8 dSYMs:
+`App.app` plus Capacitor, Cordova, four Facebook SDK frameworks, and IONCameraLib — none Google).
+So there is nothing to supply, and **crash frames inside those four libraries genuinely will not
+symbolicate**. That is a real accepted loss, not a harmless one. Say so plainly rather than
+implying the warning costs nothing.
 
 The danger is not the warning. It is that **our own dSYM going missing prints the same sentence**.
 Flip `DEBUG_INFORMATION_FORMAT` from `dwarf-with-dsym` to `dwarf` on Release and the log grows a
@@ -1154,19 +1166,22 @@ shipped binary**), name each known-unfixable exception in an allow-list with the
 on anything outside it. Apply it to every lane that exports an archive, not just the one where it
 was noticed (R14).
 
-**Check.** Prove the vendor binaries really are static and dSYM-less rather than assuming it:
+**Check.** Measure the **shipped artifact**, never the local package checkout — that is the whole
+mistake above. Download the `.ipa` a dry run produces and read it:
 
 ```bash
-DD=$(ls -d ~/Library/Developer/Xcode/DerivedData/App-*/SourcePackages/artifacts 2>/dev/null | head -1)
-for n in firebase-ios-sdk/FirebaseAnalytics/FirebaseAnalytics \
-         googleappmeasurement/GoogleAppMeasurement/GoogleAppMeasurement; do
-  b="$DD/$n.xcframework"; s=$(basename "$n")
-  echo "== $s"
-  [ -n "$(find "$b" -name '*.dSYM' 2>/dev/null)" ] && echo "  ships a dSYM" || echo "  ships NO dSYM"
-  file "$b/ios-arm64/$s.framework/$s" | sed 's/.*: /  /'
+gh run download <RUN_ID> --repo hushh-labs/hushh-research -n ios-testflight-<N> -D /tmp/art
+cd /tmp/art/export && mkdir -p ipa && unzip -qq *.ipa -d ipa
+APP=$(find ipa/Payload -maxdepth 1 -name '*.app' | head -1)
+for fw in "$APP"/Frameworks/*.framework; do
+  n=$(basename "$fw" .framework)
+  printf '  %-38s %s\n' "$n" "$(file -b "$fw/$n" | tail -1)"
 done
-# "current ar archive" + "ships NO dSYM" == nothing to upload, permanently. Do not chase it.
+ls /tmp/art/App.xcarchive/dSYMs
 ```
+
+Every framework listed must either have a matching `.framework.dSYM` in that `dSYMs` listing or be
+one of the four Google names. A dynamic library that is neither is a real symbolication gap.
 
 Then mutation-test the guard, because a passing new check proves nothing (R22). Against a mock
 archive, all five must hold: healthy passes; a deleted `App.app.dSYM` fails; a dSYM whose UUIDs no

--- a/.github/workflows/release-ios-appstore.yml
+++ b/.github/workflows/release-ios-appstore.yml
@@ -405,14 +405,15 @@ jobs:
           APP_BIN="${ARCHIVE}/Products/Applications/App.app/App"
           APP_DSYM="${ARCHIVE}/dSYMs/App.app.dSYM"
 
-          # Google ships FirebaseAnalytics, GoogleAppMeasurement,
-          # GoogleAppMeasurementIdentitySupport and GoogleAdsOnDeviceConversion as
-          # STATIC frameworks -- `file` reports "current ar archive" -- and the
-          # .xcframework contains no dSYM at all. They are linked into App and never
-          # ship as separate images, so no dSYM can exist for them, and exportArchive
-          # logs "Upload Symbols Failed" for each on every single run. That is
-          # unfixable upstream (see R29). This step exists so that permanent noise can
-          # never hide the one failure that matters: OUR dSYM going missing.
+          # FirebaseAnalytics, GoogleAppMeasurement, GoogleAppMeasurementIdentitySupport
+          # and GoogleAdsOnDeviceConversion DO ship as their own dynamic libraries in
+          # App.app/Frameworks (verified against the signed .ipa: MH_DYLIB, real UUIDs),
+          # but Google publishes no dSYM for any of them -- the .xcframework contains
+          # none, and none reaches the archive. So exportArchive logs "Upload Symbols
+          # Failed" for each on every run, and crash frames inside those four libraries
+          # genuinely will not symbolicate. That is an accepted loss we cannot close
+          # from here (see R29), not a harmless one. This step exists so that permanent
+          # noise can never hide the failure that matters: OUR dSYM going missing.
           ALLOWED_WITHOUT_DSYM="FirebaseAnalytics GoogleAppMeasurement GoogleAppMeasurementIdentitySupport GoogleAdsOnDeviceConversion"
 
           test -f "$APP_BIN" || { echo "::error::No app binary at $APP_BIN"; exit 1; }

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -407,14 +407,15 @@ jobs:
           APP_BIN="${ARCHIVE}/Products/Applications/App.app/App"
           APP_DSYM="${ARCHIVE}/dSYMs/App.app.dSYM"
 
-          # Google ships FirebaseAnalytics, GoogleAppMeasurement,
-          # GoogleAppMeasurementIdentitySupport and GoogleAdsOnDeviceConversion as
-          # STATIC frameworks -- `file` reports "current ar archive" -- and the
-          # .xcframework contains no dSYM at all. They are linked into App and never
-          # ship as separate images, so no dSYM can exist for them, and exportArchive
-          # logs "Upload Symbols Failed" for each on every single run. That is
-          # unfixable upstream (see R29). This step exists so that permanent noise can
-          # never hide the one failure that matters: OUR dSYM going missing.
+          # FirebaseAnalytics, GoogleAppMeasurement, GoogleAppMeasurementIdentitySupport
+          # and GoogleAdsOnDeviceConversion DO ship as their own dynamic libraries in
+          # App.app/Frameworks (verified against the signed .ipa: MH_DYLIB, real UUIDs),
+          # but Google publishes no dSYM for any of them -- the .xcframework contains
+          # none, and none reaches the archive. So exportArchive logs "Upload Symbols
+          # Failed" for each on every run, and crash frames inside those four libraries
+          # genuinely will not symbolicate. That is an accepted loss we cannot close
+          # from here (see R29), not a harmless one. This step exists so that permanent
+          # noise can never hide the failure that matters: OUR dSYM going missing.
           ALLOWED_WITHOUT_DSYM="FirebaseAnalytics GoogleAppMeasurement GoogleAppMeasurementIdentitySupport GoogleAdsOnDeviceConversion"
 
           test -f "$APP_BIN" || { echo "::error::No app binary at $APP_BIN"; exit 1; }


### PR DESCRIPTION
## Outcome

R29 and both workflow comments stated a fact that the guard's own first real run disproved. This corrects it. **No behaviour change — the workflow diffs are comment-only.**

## What I got wrong

I wrote that `FirebaseAnalytics`, `GoogleAppMeasurement`, `GoogleAppMeasurementIdentitySupport` and `GoogleAdsOnDeviceConversion` are static libraries linked into `App` that never ship as their own image, so their missing dSYMs cost nothing.

Measured against the signed `.ipa` from dry run 34160082709, all four are in `App.app/Frameworks/` and each is `MH_DYLIB` with its own UUID:

```
FirebaseAnalytics     Mach-O 64-bit dynamically linked shared library arm64   CC492DC7-943C-3436-A2B7-F6786266F535
GoogleAppMeasurement  Mach-O 64-bit dynamically linked shared library arm64   9C11A2AF-713F-3693-ABF8-3C5551DD7FFE
```

They are separately loaded dynamic libraries. **Crash frames inside them genuinely will not symbolicate** — a real accepted loss, not a harmless one, and the rule now says so.

## Where the error came from

I read `SourcePackages/artifacts/` in local DerivedData, where `file` reported `current ar archive`, and generalised from it. That local checkout did not match what CI resolves and ships. This is R19 in a new place: when a local reading and a measurement of the real artifact disagree, the artifact wins. The R29 Check is rewritten to measure the shipped `.ipa` instead of the package checkout, since trusting the checkout *is* the mistake being recorded.

## What still holds

Google publishes no dSYM for any of the four — none inside the `.xcframework`, none reaching the archive. The archive carries 8 dSYMs (`App.app`, Capacitor, Cordova, four Facebook SDK frameworks, IONCameraLib) and not one of them is Google's.

So the guard and its allow-list are unchanged and correct. Only the stated reason was wrong.

## Validation

Both workflows parse (js-yaml); the guard still sits between `Archive` and `Export` in each. Diff filtered for non-comment lines in `.github/workflows/` is empty, confirming behaviour is untouched.

The guard itself is now proven on a real archive, not just a mock:

```
app binary UUIDs:   6AB777D7-8794-3C19-8AC9-32CF90F79F5F
App.app.dSYM UUIDs: 6AB777D7-8794-3C19-8AC9-32CF90F79F5F
  ok    Capacitor / Cordova / FBAEMKit / FBSDKCoreKit_Basics / FBSDKCoreKit / FBSDKLoginKit / IONCameraLib
  skip  FirebaseAnalytics, GoogleAdsOnDeviceConversion, GoogleAppMeasurement, GoogleAppMeasurementIdentitySupport
OK: App.app.dSYM present and matching; every separately shipped image has symbols or a named exception.
```

## Rollback

Revert the commit. Documentation and comments only.