### PR TITLE
fix(db): retry a busy database instead of failing the deploy

### DIFF
--- a/.claude/skills/safe-changes/SKILL.md
+++ b/.claude/skills/safe-changes/SKILL.md
@@ -1213,3 +1213,84 @@ would have broken.
 The Check line must be a command that **runs in this repo** and returns
 something meaningful. Run it before committing the rule. A rule with a command
 that doesn't work here is worse than no rule.
+
+### R32 — A busy database is not a broken migration: retry contention, never widen the lock wait
+
+**Incident (2026-09-07, six failed UAT deploys — runs 34142917051 and 34143403982.)**
+Replay applies every migration with `lock_timeout_ms = 5_000` and **no retry
+anywhere** — `grep -c 'retry\|backoff\|attempt'` on `db/migration_authority.py`
+returned 0. One unlucky 5-second window against a live UAT killed the whole
+release, and the same commit deployed fine minutes later. R26 named the pattern;
+nothing was done about the immediate cause, so it stayed a coin flip.
+
+The obvious repair is the wrong one. Postgres queues lock requests, so a pending
+`ACCESS EXCLUSIVE` request blocks every **later** reader of that table as well.
+Raising `lock_timeout` to 30s does not buy 30s of patience — it buys 30s of
+queued UAT traffic. The safe shape is the opposite: keep the timeout short, roll
+back, let the queue drain, try again.
+
+**Rule.** Never widen `lock_timeout` to survive contention. Retry it instead,
+bounded and backed off, and only on a contention SQLSTATE — `55P03`
+lock_not_available, `40P01` deadlock_detected, `40001` serialization_failure. A
+`23514` check violation or a `42601` syntax error must still fail on the first
+attempt; retrying a broken migration only reports the same error later, having
+spent the deploy window. Roll back between attempts or the retry runs on an
+aborted connection and reports itself instead of the failure (R28).
+
+**Check.**
+```bash
+cd consent-protocol
+python3 -c "
+import re,pathlib
+s=pathlib.Path('db/migration_authority.py').read_text()
+print('retries only on contention:', '_LOCK_CONTENTION_SQLSTATES' in s)
+print('timeout still short:', '_lock_timeout_ms: int = 5_000' in s or 'lock_timeout_ms: int = 5_000' in s)
+print('rolls back between attempts:', '_rollback_failed_transaction(conn)' in s.split('_is_lock_contention(exc) and attempt')[1][:400])
+"
+../.venv/bin/python -m pytest tests/test_migration_authority.py -q -k "lock or retried or bounded"
+```
+All three must print `True`. Mutation-test before trusting it (R22): set
+`_LOCK_RETRY_ATTEMPTS = 1` and three tests must go red; make
+`_is_lock_contention` return `True` unconditionally and
+`test_a_broken_migration_is_not_retried` must go red.
+
+### R33 — `ledger` mode cannot be switched on today: 152 of 194 migrations open their own transaction
+
+**Incident (2026-09-07, scoping the durable fix R26 recommends.)** R26 says the
+durable answer to replay is `ledger` mode — pending migrations only, after a
+baseline. Acting on that sentence alone would have broken a release. Three
+things block it, and none are visible from the mode flag:
+
+1. **The migration bodies nest transactions.** `ledger` wraps each transactional
+   entry in `async with conn.transaction()` (`migration_authority.py:342`), but
+   `grep -lE '^\s*BEGIN\s*;' db/migrations/*.sql` returns **152 of 194 files**
+   that open their own. A `BEGIN` inside an open transaction warns and is
+   ignored; the body's own `COMMIT` then commits the **outer** transaction, so
+   the ledger row and the migration stop being atomic — exactly the guarantee
+   ledger mode exists to provide.
+2. **The backup tooling the baseline requires does not exist.** `establish_baseline`
+   demands `backup_checksum_sha256` matching `[0-9a-f]{64}` plus `restore_status
+   == "ok"`. There are **zero `pg_dump` references in the repository** — the
+   logical-backup scripts were deleted in `78aaa1e4b`. Nothing can produce the
+   artifact the gate asks for.
+3. **The evidence expires in an hour.** `load_preservation_evidence` rejects a
+   report older than `HUSHH_BASELINE_EVIDENCE_MAX_AGE_SECONDS` (default 3600),
+   so backup, restore-verify and baseline must complete inside one window.
+
+**Rule.** Do not set `UAT_MIGRATION_MODE=ledger`, and do not change the
+hardcoded `replay` in `deploy-production.yml:355` or `deploy-dev.yml:324`, until
+every transactional entry is proven not to open its own transaction. Enabling it
+first is not a smaller step — it is a silent loss of atomicity across 152 files.
+The ordered prerequisites are: strip `BEGIN`/`COMMIT` from the migration bodies
+(or mark those entries `transactional=False`), restore a logical-backup tool,
+provision a clone database, then baseline.
+
+**Check.**
+```bash
+cd consent-protocol
+grep -lE '^\s*BEGIN\s*;' db/migrations/*.sql | wc -l   # must be 0 before ledger mode
+grep -rn "pg_dump" --include="*.py" --include="*.sh" . | grep -v node_modules | head -1
+grep -n "migration-mode" ../.github/workflows/deploy-*.yml
+```
+The first must print `0`. The second must return a tool. Until both hold, every
+lane stays on `replay`.

--- a/consent-protocol/db/migration_authority.py
+++ b/consent-protocol/db/migration_authority.py
@@ -10,6 +10,7 @@ This module never reads application rows and never logs SQL or credentials.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import os
@@ -27,6 +28,37 @@ _ALLOWED_BASELINE_ENVIRONMENTS = {"uat", "test", "local", "development", "dev"}
 # Anything slower than this is named in the deploy log. Lock contention shows
 # up here first, as a migration that used to be instant and now is not.
 _SLOW_MIGRATION_MS = 1_000
+
+# Lock contention is not a broken migration -- it is a busy database. Postgres
+# queues lock requests, so a pending ACCESS EXCLUSIVE request blocks every
+# later reader of that table too: raising ``lock_timeout`` would make a deploy
+# hold the environment down for longer, not succeed more often. The safe shape
+# is the opposite -- keep the timeout short, let go, and try again once the
+# queue has drained.
+#
+# 55P03 lock_not_available   -- our own ``lock_timeout`` fired
+# 40P01 deadlock_detected    -- two transactions crossed
+# 40001 serialization_failure-- lost a concurrency race, retryable by definition
+_LOCK_CONTENTION_SQLSTATES = frozenset({"55P03", "40P01", "40001"})
+_LOCK_RETRY_ATTEMPTS = 4
+_LOCK_RETRY_BASE_DELAY_S = 1.0
+
+
+def _is_lock_contention(exc: BaseException) -> bool:
+    """True only for "the database was busy", never for a broken migration.
+
+    A constraint violation, a syntax error or a missing relation must fail on
+    the first attempt: retrying those just burns the deploy window and reports
+    the same error later. Only a contention SQLSTATE is worth a second try.
+    """
+    sqlstate = getattr(exc, "sqlstate", None)
+    return isinstance(sqlstate, str) and sqlstate in _LOCK_CONTENTION_SQLSTATES
+
+
+def _lock_retry_delay_seconds(attempt: int) -> float:
+    """Exponential backoff: 1s, 2s, 4s. Bounded, and short enough to stay
+    inside a deploy window even if several migrations each need a retry."""
+    return _LOCK_RETRY_BASE_DELAY_S * (2 ** (attempt - 1))
 
 
 class MigrationAuthorityError(RuntimeError):
@@ -302,61 +334,89 @@ async def apply_manifest_entries(
                 if covered_by_baseline or (existing and existing.get("status") == "applied"):
                     continue
 
-            started = time.perf_counter()
-            recorded_applied = False
-            try:
-                if mode is MigrationMode.LEDGER and entry.transactional:
-                    async with conn.transaction():
-                        await conn.execute(f"SET LOCAL lock_timeout = '{entry.lock_timeout_ms}ms'")
+            for attempt in range(1, _LOCK_RETRY_ATTEMPTS + 1):
+                started = time.perf_counter()
+                recorded_applied = False
+                try:
+                    if mode is MigrationMode.LEDGER and entry.transactional:
+                        async with conn.transaction():
+                            await conn.execute(
+                                f"SET LOCAL lock_timeout = '{entry.lock_timeout_ms}ms'"
+                            )
+                            await conn.execute(
+                                f"SET LOCAL statement_timeout = '{entry.statement_timeout_ms}ms'"
+                            )
+                            await conn.execute(entry.sql)
+                            duration_ms = round((time.perf_counter() - started) * 1000)
+                            await _record_result(
+                                conn,
+                                entry=entry,
+                                status="applied",
+                                duration_ms=duration_ms,
+                                deploy_sha=deploy_sha,
+                                failure_class=None,
+                            )
+                            recorded_applied = True
+                    else:
+                        await conn.execute(f"SET lock_timeout = '{entry.lock_timeout_ms}ms'")
                         await conn.execute(
-                            f"SET LOCAL statement_timeout = '{entry.statement_timeout_ms}ms'"
+                            f"SET statement_timeout = '{entry.statement_timeout_ms}ms'"
                         )
                         await conn.execute(entry.sql)
-                        duration_ms = round((time.perf_counter() - started) * 1000)
+                except Exception as exc:
+                    duration_ms = round((time.perf_counter() - started) * 1000)
+                    # A busy database is not a broken migration. Roll back first
+                    # so the connection is usable again, then wait for the lock
+                    # queue to drain and try the same body once more. Only a
+                    # contention SQLSTATE gets this; a constraint violation or a
+                    # syntax error still fails on the first attempt.
+                    if _is_lock_contention(exc) and attempt < _LOCK_RETRY_ATTEMPTS:
+                        await _rollback_failed_transaction(conn)
+                        delay = _lock_retry_delay_seconds(attempt)
+                        print(
+                            f"  lock contention on {entry.filename} after {duration_ms}ms "
+                            f"[{_failure_signature(exc)}]; retry {attempt}/"
+                            f"{_LOCK_RETRY_ATTEMPTS - 1} in {delay:.0f}s",
+                            file=sys.stderr,
+                            flush=True,
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+                    # Say which migration failed, and say it before anything else can
+                    # go wrong. Nothing in this function named the entry, so six UAT
+                    # deploys failed against a 173-file replay with no way to tell
+                    # which file stopped it.
+                    print(
+                        f"MIGRATION FAILED: {entry.filename} after {duration_ms}ms "
+                        f"[{_failure_signature(exc)}]"
+                        + (
+                            f" (gave up after {attempt} lock attempts)"
+                            if _is_lock_contention(exc)
+                            else ""
+                        ),
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    # Return the connection to a usable state in EVERY mode. This
+                    # used to be inside the `if` below, so a REPLAY failure left the
+                    # transaction aborted and the `finally: await _unlock(conn)` at
+                    # the end of this function then raised InFailedSQLTransactionError
+                    # -- which replaced the real error in the traceback. The UAT
+                    # workflow reported "current transaction is aborted" when the
+                    # actual failure was "canceling statement due to lock timeout".
+                    await _rollback_failed_transaction(conn)
+                    if mode is not MigrationMode.REPLAY:
                         await _record_result(
                             conn,
                             entry=entry,
-                            status="applied",
+                            status="failed",
                             duration_ms=duration_ms,
                             deploy_sha=deploy_sha,
-                            failure_class=None,
+                            failure_class=_sanitize_failure_class(exc),
                         )
-                        recorded_applied = True
-                else:
-                    await conn.execute(f"SET lock_timeout = '{entry.lock_timeout_ms}ms'")
-                    await conn.execute(f"SET statement_timeout = '{entry.statement_timeout_ms}ms'")
-                    await conn.execute(entry.sql)
-            except Exception as exc:
-                duration_ms = round((time.perf_counter() - started) * 1000)
-                # Say which migration failed, and say it before anything else can
-                # go wrong. Nothing in this function named the entry, so six UAT
-                # deploys failed against a 173-file replay with no way to tell
-                # which file stopped it.
-                print(
-                    f"MIGRATION FAILED: {entry.filename} after {duration_ms}ms "
-                    f"[{_failure_signature(exc)}]",
-                    file=sys.stderr,
-                    flush=True,
-                )
-                # Return the connection to a usable state in EVERY mode. This
-                # used to be inside the `if` below, so a REPLAY failure left the
-                # transaction aborted and the `finally: await _unlock(conn)` at
-                # the end of this function then raised InFailedSQLTransactionError
-                # -- which replaced the real error in the traceback. The UAT
-                # workflow reported "current transaction is aborted" when the
-                # actual failure was "canceling statement due to lock timeout".
-                await _rollback_failed_transaction(conn)
-                if mode is not MigrationMode.REPLAY:
-                    await _record_result(
-                        conn,
-                        entry=entry,
-                        status="failed",
-                        duration_ms=duration_ms,
-                        deploy_sha=deploy_sha,
-                        failure_class=_sanitize_failure_class(exc),
-                    )
-                exc.add_note(f"while applying migration {entry.filename} ({duration_ms}ms)")
-                raise
+                    exc.add_note(f"while applying migration {entry.filename} ({duration_ms}ms)")
+                    raise
+                break
             duration_ms = round((time.perf_counter() - started) * 1000)
             if duration_ms >= _SLOW_MIGRATION_MS:
                 print(

--- a/consent-protocol/tests/test_migration_authority.py
+++ b/consent-protocol/tests/test_migration_authority.py
@@ -358,3 +358,113 @@ async def test_failure_log_never_quotes_the_database_message(tmp_path: Path, cap
     assert "MIGRATION FAILED: 20260721_ABC_new.sql" in stderr
     assert "synthetic migration failure" not in stderr
     assert "RuntimeError" in stderr
+
+
+class _LockTimeout(Exception):
+    """Stands in for asyncpg.exceptions.LockNotAvailableError.
+
+    The retry decision reads ``sqlstate`` and nothing else, so a synthetic
+    exception carrying 55P03 exercises the real branch.
+    """
+
+    sqlstate = "55P03"
+
+
+class _CheckViolation(Exception):
+    """A genuinely broken migration -- 23514, never retryable."""
+
+    sqlstate = "23514"
+
+
+class ContendingConnection(FakeConnection):
+    """Fails the target statement with a lock timeout N times, then succeeds."""
+
+    def __init__(self, target_sql: str, fail_times: int, exc: Exception | None = None) -> None:
+        super().__init__()
+        self.target_sql = target_sql
+        self.fail_times = fail_times
+        self.attempts = 0
+        self.exc = exc or _LockTimeout("canceling statement due to lock timeout")
+
+    async def execute(self, sql: str, *args):
+        if self.target_sql in sql and "lock_timeout" not in sql:
+            self.attempts += 1
+            if self.attempts <= self.fail_times:
+                self.in_transaction = True
+                raise self.exc
+        return await super().execute(sql, *args)
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Record the backoff schedule without spending it."""
+    slept: list[float] = []
+
+    async def _fake_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    monkeypatch.setattr("db.migration_authority.asyncio.sleep", _fake_sleep)
+    return slept
+
+
+@pytest.mark.asyncio
+async def test_lock_contention_retries_and_then_succeeds(tmp_path: Path, no_sleep):
+    """A busy database must not fail the deploy. This is the 2026-09-07 outage:
+    runs 34142917051 and 34143403982 both died on 55P03 with no second attempt."""
+    entries = _entries(tmp_path)
+    conn = ContendingConnection("SELECT 115", fail_times=2)
+
+    applied = await apply_manifest_entries(conn, entries, mode=MigrationMode.REPLAY)
+
+    assert "20260721_ABC_new.sql" in applied
+    assert conn.attempts == 3, "should have retried twice then succeeded"
+    assert no_sleep == [1.0, 2.0], "backoff must be exponential and bounded"
+    assert conn.locked is False
+
+
+@pytest.mark.asyncio
+async def test_a_broken_migration_is_not_retried(tmp_path: Path, no_sleep):
+    """A constraint violation is not contention. Retrying it burns the deploy
+    window and reports the same error later, so it must fail on attempt one."""
+    entries = _entries(tmp_path)
+    conn = ContendingConnection("SELECT 115", fail_times=99, exc=_CheckViolation("violated"))
+
+    with pytest.raises(_CheckViolation):
+        await apply_manifest_entries(conn, entries, mode=MigrationMode.REPLAY)
+
+    assert conn.attempts == 1, "a real SQL error must not be retried"
+    assert no_sleep == [], "no backoff should be spent on a broken migration"
+    assert conn.locked is False
+
+
+@pytest.mark.asyncio
+async def test_retries_are_bounded_and_the_failure_says_so(tmp_path: Path, no_sleep, capsys):
+    """Sustained contention must still end, and the log must say it gave up on
+    locks rather than looking like a broken migration."""
+    entries = _entries(tmp_path)
+    conn = ContendingConnection("SELECT 115", fail_times=99)
+
+    with pytest.raises(_LockTimeout):
+        await apply_manifest_entries(conn, entries, mode=MigrationMode.REPLAY)
+
+    assert conn.attempts == 4, "bounded at _LOCK_RETRY_ATTEMPTS"
+    assert no_sleep == [1.0, 2.0, 4.0]
+    err = capsys.readouterr().err
+    assert "20260721_ABC_new.sql" in err, "must still name the failing migration (R28)"
+    assert "gave up after 4 lock attempts" in err
+    assert "sqlstate=55P03" in err
+    assert conn.locked is False
+
+
+@pytest.mark.asyncio
+async def test_connection_is_rolled_back_between_lock_attempts(tmp_path: Path, no_sleep):
+    """R28: a retry on an aborted connection would raise
+    InFailedSQLTransactionError and mask the real error. Each attempt must start
+    from a usable connection."""
+    entries = _entries(tmp_path)
+    conn = ContendingConnection("SELECT 115", fail_times=1)
+
+    await apply_manifest_entries(conn, entries, mode=MigrationMode.REPLAY)
+
+    assert conn.executed_sql.count("ROLLBACK") >= 1, "must roll back before retrying"
+    assert conn.in_transaction is False


### PR DESCRIPTION
## Outcome

A UAT or production deploy no longer dies because the database happened to be busy for five seconds.

## What broke

Six UAT deploys failed on 2026-09-07. Runs `34142917051` and `34143403982` both died with:

```
asyncpg.exceptions.LockNotAvailableError: canceling statement due to lock timeout
SQLSTATE 55P03
```

…on the same commit that had deployed cleanly minutes earlier. `replay` re-applies all 174 migrations against a live database with `lock_timeout_ms = 5_000` and **zero retry logic anywhere** — `grep -c 'retry\|backoff\|attempt'` on `migration_authority.py` returned `0`. One unlucky window kills the release.

## The fix, and the fix I deliberately did not make

Retry **only** on contention — `55P03` lock_not_available, `40P01` deadlock_detected, `40001` serialization_failure — bounded at 4 attempts with 1s/2s/4s backoff, rolling back between attempts so the retry never runs on an aborted connection (R28).

A `23514` check violation or a syntax error still fails on attempt one. Retrying a broken migration just reports the same error later, having spent the deploy window.

**I did not raise `lock_timeout`, and that is deliberate.** Postgres queues lock requests, so a pending `ACCESS EXCLUSIVE` request blocks every *later* reader of that table too. Widening the wait to 30s does not buy 30s of patience — it buys 30s of queued UAT traffic. Short timeout, release, retry is the safe shape.

## Blast radius

Shared code, so this reaches all three lanes. That is intended: production (`deploy-production.yml:355`) and dev (`deploy-dev.yml:324`) both hardcode `replay`, and prod's Cloud SQL is the *smaller* tier (R12), so both are more exposed to this than UAT was.

## Why the "durable fix" isn't in this PR

R26 names `ledger` mode as the real answer. It cannot be switched on yet, and R33 now records why:

- **152 of 194 migration files open their own `BEGIN`.** Ledger wraps each transactional entry in `async with conn.transaction()`; the body's own `COMMIT` would commit the *outer* transaction and silently break ledger/migration atomicity — the one guarantee ledger mode exists to give.
- **The backup tooling its baseline requires no longer exists.** `establish_baseline` demands a `[0-9a-f]{64}` backup checksum and `restore_status == "ok"`. There are zero `pg_dump` references in the repo; the logical-backup scripts were deleted in `78aaa1e4b`.
- The authorizing evidence expires after 1 hour by default.

Enabling it first would not be a smaller step. It would be a silent loss of atomicity across 152 files.

## Validation

- `pytest tests/test_migration_authority.py` — **14 passed** (10 existing, 4 new)
- `ruff check` and `ruff format --check` — clean on both changed files
- Mutation-tested per R22:
  - `_LOCK_RETRY_ATTEMPTS = 1` (the original bug) → **3 tests go red**
  - `_is_lock_contention` returning `True` unconditionally → **`test_a_broken_migration_is_not_retried` goes red**
  - restored → 14 pass

One unrelated failure, `test_kai_market_public_cache.py::test_market_home_cache_key_uses_shared_baseline_and_user_scoped_personalization`, is **pre-existing** — it fails identically on a clean `origin/main` worktree. It matched my `-k` filter only because its name contains "baseline".

## Not verified

Unit tests prove the loop's shape and the R28 invariants. Only a real deploy proves it clears real contention — and per R26 that has to be a deploy in the 14:00–22:00 window where the failures cluster, since a green 02:00 deploy just means nothing was contending.

## Rollback

Revert the commit. No schema, config, secret, or IAM change; behaviour on a non-contended database is byte-identical to today.