### PR TITLE
fix(db): bound the migration retry per run, and make its tests actually run

### DIFF
--- a/.claude/skills/safe-changes/SKILL.md
+++ b/.claude/skills/safe-changes/SKILL.md
@@ -1240,19 +1240,19 @@ aborted connection and reports itself instead of the failure (R28).
 **Check.**
 ```bash
 cd consent-protocol
-python3 -c "
-import re,pathlib
-s=pathlib.Path('db/migration_authority.py').read_text()
-print('retries only on contention:', '_LOCK_CONTENTION_SQLSTATES' in s)
-print('timeout still short:', '_lock_timeout_ms: int = 5_000' in s or 'lock_timeout_ms: int = 5_000' in s)
-print('rolls back between attempts:', '_rollback_failed_transaction(conn)' in s.split('_is_lock_contention(exc) and attempt')[1][:400])
-"
-../.venv/bin/python -m pytest tests/test_migration_authority.py -q -k "lock or retried or bounded"
+# The behaviour, not the source text. A string-matching check over this
+# function is worthless: the first version of this Check split on
+# `_is_lock_contention(exc) and attempt`, and died with IndexError the moment
+# that condition became multi-line -- one commit later (R34).
+../.venv/bin/python -m pytest tests/test_migration_authority.py -q
+grep -n "test_migration_authority" scripts/test-ci.manifest.txt
 ```
-All three must print `True`. Mutation-test before trusting it (R22): set
-`_LOCK_RETRY_ATTEMPTS = 1` and three tests must go red; make
-`_is_lock_contention` return `True` unconditionally and
-`test_a_broken_migration_is_not_retried` must go red.
+All 16 must pass, and the grep must return a line -- an unregistered test file
+never runs in CI, and this manifest is the only pytest invocation in any lane.
+Mutation-test before trusting it (R22): `_LOCK_RETRY_ATTEMPTS = 1` turns three
+red; an unconditional `_is_lock_contention` turns the not-retried test red;
+unguarding the reset turns the masking test red; deleting the run-budget
+condition turns the budget test red.
 
 ### R33 — `ledger` mode cannot be switched on today: 152 of 194 migrations open their own transaction
 
@@ -1294,3 +1294,56 @@ grep -n "migration-mode" ../.github/workflows/deploy-*.yml
 ```
 The first must print `0`. The second must return a tool. Until both hold, every
 lane stays on `replay`.
+
+### R34 — A retry bounded per unit is unbounded per run, and a fix's own tests may never run
+
+**Incident (2026-09-08, hours after R32 shipped in PR #6609.)** The retry that
+fixed the lock-timeout outage introduced three defects of its own, none caught
+by review and none catchable by its tests, because its tests did not run.
+
+1. **Unbounded per run.** 4 attempts per migration is bounded; 174 migrations x
+   (4 x 5s lock wait + 7s backoff) is **~78 minutes**, and `deploy-uat.yml` sets
+   no `timeout-minutes` at all (GitHub default 360). The bug being fixed made
+   UAT go red in three minutes. The fix could make it hang for over an hour
+   while holding the migration advisory lock **and** the installed
+   account-deletion release fence. That is a worse availability posture than the
+   defect.
+2. **R28 reintroduced on the new path.** The retry branch called
+   `await _rollback_failed_transaction(conn)` unguarded. That cleanup runs on a
+   connection that has just failed, so it can fail too -- and its exception then
+   replaces the 55P03 as the reported error, which is precisely the masking R28
+   exists to prevent, on a path R28's own check does not reach.
+3. **The tests were decoration.** `tests/test_migration_authority.py` was not in
+   `consent-protocol/scripts/test-ci.manifest.txt`, and that manifest is the only
+   pytest invocation in any lane (its own header says so). R28's masking tests
+   and R32's four retry tests had never executed in CI, on any PR, ever.
+
+And R32's own Check was brittle: it split the source on
+`_is_lock_contention(exc) and attempt`, so it died with `IndexError` as soon as
+that condition became multi-line -- one commit after it was written.
+
+**Rule.** A retry needs two bounds: per unit **and** per run. State the run's
+worst case in seconds before shipping it, and compare that number against the
+job's own timeout -- if the job has no `timeout-minutes`, the worst case is the
+platform default, not the number you hoped for. Any cleanup on the failure path
+goes through one guarded helper, never a bare call, so a second failure cannot
+overwrite the first. And a test file is not coverage until it is in the
+manifest: adding tests and adding them to `test-ci.manifest.txt` are one change,
+not two. Write Checks against behaviour (run the tests) rather than against
+source text, which goes stale on the next refactor.
+
+**Check.**
+```bash
+cd consent-protocol
+grep -n "test_migration_authority" scripts/test-ci.manifest.txt
+python3 -c "
+import pathlib
+s=pathlib.Path('db/migration_authority.py').read_text()
+print('run budget present:', '_LOCK_RETRY_RUN_BUDGET_S' in s)
+print('no bare rollback on a failure path:', s.count('await _rollback_failed_transaction(conn)') == 1)
+"
+grep -n "timeout-minutes" ../.github/workflows/deploy-uat.yml || echo "deploy-uat has NO job timeout"
+```
+The grep must return a line. Both prints must be `True` -- the single remaining
+bare call is the one inside `_reset_connection` itself. The last line records
+whether the lane is still relying on the platform default.

--- a/consent-protocol/db/migration_authority.py
+++ b/consent-protocol/db/migration_authority.py
@@ -42,6 +42,14 @@ _SLOW_MIGRATION_MS = 1_000
 _LOCK_CONTENTION_SQLSTATES = frozenset({"55P03", "40P01", "40001"})
 _LOCK_RETRY_ATTEMPTS = 4
 _LOCK_RETRY_BASE_DELAY_S = 1.0
+# Bound what the RUN may spend retrying, not only what one migration may.
+# The UAT lane is 174 entries; at 4 attempts each that is
+# 174 x (4 x 5s lock wait + 7s backoff) = ~78 minutes, and deploy-uat.yml sets
+# no `timeout-minutes` (GitHub default 360). Unbounded, retry would turn a
+# 3-minute red deploy into a 78-minute hung one holding the advisory lock with
+# the account-deletion release fence installed -- worse than the bug it fixes.
+# Past the budget the next contention failure is reported instead of retried.
+_LOCK_RETRY_RUN_BUDGET_S = 300.0
 
 
 def _is_lock_contention(exc: BaseException) -> bool:
@@ -53,6 +61,27 @@ def _is_lock_contention(exc: BaseException) -> bool:
     """
     sqlstate = getattr(exc, "sqlstate", None)
     return isinstance(sqlstate, str) and sqlstate in _LOCK_CONTENTION_SQLSTATES
+
+
+async def _reset_connection(conn: Any, failure: BaseException) -> bool:
+    """Clear the aborted transaction. Returns False when the connection is gone.
+
+    R28 again, on the new path: this cleanup runs on a connection that has just
+    failed, so it can fail too -- and its failure must never become the reported
+    error. The lock timeout stays the diagnosis; a reset failure becomes a note
+    on it and ends the retrying, because there is nothing left to retry with.
+    """
+    try:
+        await _rollback_failed_transaction(conn)
+        return True
+    except Exception as reset_error:  # noqa: BLE001 - diagnostic only
+        failure.add_note(f"connection reset failed [{_failure_signature(reset_error)}]")
+        print(
+            f"  connection reset failed [{_failure_signature(reset_error)}]",
+            file=sys.stderr,
+            flush=True,
+        )
+        return False
 
 
 def _lock_retry_delay_seconds(attempt: int) -> float:
@@ -306,6 +335,7 @@ async def apply_manifest_entries(
 
     await _try_lock(conn)
     applied: list[str] = []
+    retry_spent_s = 0.0
     try:
         rows: dict[str, dict[str, Any]] = {}
         baseline_through: int | None = None
@@ -370,9 +400,18 @@ async def apply_manifest_entries(
                     # queue to drain and try the same body once more. Only a
                     # contention SQLSTATE gets this; a constraint violation or a
                     # syntax error still fails on the first attempt.
-                    if _is_lock_contention(exc) and attempt < _LOCK_RETRY_ATTEMPTS:
-                        await _rollback_failed_transaction(conn)
-                        delay = _lock_retry_delay_seconds(attempt)
+                    delay = _lock_retry_delay_seconds(attempt)
+                    if (
+                        _is_lock_contention(exc)
+                        and attempt < _LOCK_RETRY_ATTEMPTS
+                        and retry_spent_s + delay <= _LOCK_RETRY_RUN_BUDGET_S
+                        # The next attempt runs on the connection this one left
+                        # behind, so clearing it is part of the decision: if the
+                        # reset fails there is nothing to retry with, and the
+                        # lock error -- not the reset -- stays the diagnosis.
+                        and await _reset_connection(conn, exc)
+                    ):
+                        retry_spent_s += delay
                         print(
                             f"  lock contention on {entry.filename} after {duration_ms}ms "
                             f"[{_failure_signature(exc)}]; retry {attempt}/"
@@ -404,7 +443,10 @@ async def apply_manifest_entries(
                     # -- which replaced the real error in the traceback. The UAT
                     # workflow reported "current transaction is aborted" when the
                     # actual failure was "canceling statement due to lock timeout".
-                    await _rollback_failed_transaction(conn)
+                    # Guarded for the same reason the unlock below is: this reset
+                    # runs on a just-failed connection and can fail itself, and
+                    # its exception must not replace the migration's (R28).
+                    await _reset_connection(conn, exc)
                     if mode is not MigrationMode.REPLAY:
                         await _record_result(
                             conn,

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -184,3 +184,9 @@ tests/test_one_location_nearby_presence_routes.py
 tests/services/test_one_location_nearby_presence_service.py
 tests/test_one_location_nearby_point_contract_migration.py
 tests/test_one_location_nearby_check_in_preferences_migration.py
+
+# The migration authority decides whether every deploy survives a busy
+# database, and none of its tests had ever run: this file was not in this
+# manifest, and this manifest is the only pytest invocation in any lane. R28's
+# masking tests and the lock-contention retry tests were both decoration.
+tests/test_migration_authority.py

--- a/consent-protocol/tests/test_migration_authority.py
+++ b/consent-protocol/tests/test_migration_authority.py
@@ -468,3 +468,48 @@ async def test_connection_is_rolled_back_between_lock_attempts(tmp_path: Path, n
 
     assert conn.executed_sql.count("ROLLBACK") >= 1, "must roll back before retrying"
     assert conn.in_transaction is False
+
+
+class ResetFailsConnection(ContendingConnection):
+    """The lock times out, and the cleanup that follows fails too."""
+
+    async def execute(self, sql: str, *args):
+        if sql == "ROLLBACK":
+            raise RuntimeError("connection is gone")
+        return await super().execute(sql, *args)
+
+
+@pytest.mark.asyncio
+async def test_a_failed_reset_never_replaces_the_lock_error(tmp_path: Path, no_sleep):
+    """R28 on the retry path. The cleanup runs on a just-failed connection, so
+    it can fail too -- and if it did, its RuntimeError would be reported as the
+    cause and the real 55P03 would vanish, exactly as six UAT deploys reported
+    'current transaction is aborted' instead of the lock timeout."""
+    entries = _entries(tmp_path)
+    conn = ResetFailsConnection("SELECT 115", fail_times=99)
+
+    with pytest.raises(_LockTimeout) as caught:
+        await apply_manifest_entries(conn, entries, mode=MigrationMode.REPLAY)
+
+    assert conn.attempts == 1, "a dead connection has nothing to retry with"
+    assert any("connection reset failed" in n for n in getattr(caught.value, "__notes__", []))
+    assert conn.locked is False
+
+
+@pytest.mark.asyncio
+async def test_run_wide_retry_budget_stops_a_long_contended_run(
+    tmp_path: Path, no_sleep, monkeypatch
+):
+    """Per-migration bounds alone let a 174-entry lane spend ~78 minutes
+    retrying while holding the advisory lock and the release fence -- worse
+    availability than the bug. The run budget ends it."""
+    monkeypatch.setattr("db.migration_authority._LOCK_RETRY_RUN_BUDGET_S", 1.0)
+    entries = _entries(tmp_path)
+    conn = ContendingConnection("SELECT 115", fail_times=99)
+
+    with pytest.raises(_LockTimeout):
+        await apply_manifest_entries(conn, entries, mode=MigrationMode.REPLAY)
+
+    assert no_sleep == [1.0], "budget of 1.0s affords exactly the first 1s backoff"
+    assert conn.attempts == 2, "then it reports instead of retrying"
+    assert conn.locked is False


### PR DESCRIPTION
## Outcome

Corrects three defects in #6609, which merged a few hours ago. Two are mine. The third predates me and is why the other two shipped unnoticed.

## 1. The retry was unbounded per run — worse than the bug it fixed

Four attempts *per migration* is bounded. But the UAT lane is 174 migrations, and 174 × (4 × 5s lock wait + 7s backoff) is **~78 minutes**. `deploy-uat.yml` sets no `timeout-minutes` at all, so the real ceiling was GitHub's 360-minute default.

The defect I set out to fix made UAT go red in three minutes. My fix could have hung it for over an hour — while holding the migration advisory lock **and** the installed account-deletion release fence. That is a worse availability posture than the original bug.

Adds `_LOCK_RETRY_RUN_BUDGET_S = 300.0`. Past the budget the next contention failure is reported rather than retried.

## 2. I reintroduced R28 on the path I added

The retry branch called `_rollback_failed_transaction` unguarded. That cleanup runs on a connection that has just failed, so it can fail too — and its exception then replaces the `55P03` as the reported error. That is exactly the masking R28 was written about, on a path R28's own Check does not reach.

Both failure paths now go through one guarded `_reset_connection`, which keeps the lock timeout as the diagnosis and attaches the reset failure as a note. A dead connection ends the retrying instead of retrying onto nothing.

## 3. The tests had never run — not once, on any PR

`tests/test_migration_authority.py` was **not in `consent-protocol/scripts/test-ci.manifest.txt`**, and that manifest is the only pytest invocation in any lane — its own header says so.

So R28's masking tests and #6609's four retry tests were decoration. They passed on my machine and nowhere else. Registered; verified as entry 107 of 107 and green under the CI environment variables.

This is the finding that matters most, because it means the other two were undetectable by design.

## R32's own Check was brittle

It split the source on `_is_lock_contention(exc) and attempt`, so it died with `IndexError` the moment that condition became multi-line — one commit after I wrote it. Rewritten to run the tests rather than match source text, which is what your own rule about Checks-that-actually-run was getting at.

## Validation

- **16 tests pass**, and now actually run in CI
- `ruff check` and `ruff format --check` clean
- All four guards mutation-tested per R22 — each turns exactly one test red:

| Mutation | Test that goes red |
|---|---|
| `_LOCK_RETRY_ATTEMPTS = 1` | 3 retry tests |
| `_is_lock_contention` returns `True` always | `test_a_broken_migration_is_not_retried` |
| unguard the reset | `test_a_failed_reset_never_replaces_the_lock_error` |
| delete the budget condition | `test_run_wide_retry_budget_stops_a_long_contended_run` |

Mutation 3 reproduces the exact defect: `RuntimeError: connection is gone` propagates and the `55P03` vanishes.

## Still not verified

The same gap as #6609: unit tests prove the shape, only a deploy during real contention proves the outcome. Nothing here changes that.

## Also worth knowing

`deploy-uat.yml` has **no `timeout-minutes`**. The run budget bounds the retry, but the job itself is still on the platform's 360-minute default. That is a separate change and not in this PR.

## Rollback

Revert. The retry keeps working exactly as #6609 shipped it, minus the three guards.