### PR TITLE
fix(location): allow SMS Circle in auto-approve settings

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -5293,8 +5293,10 @@ class OneLocationAgentService:
                         CAST(:require_owned_person_circle AS BOOLEAN) IS FALSE
                         OR (
                           owner_user_id = :owner_user_id
-                          AND system_kind IS NULL
-                          AND NOT is_system
+                          AND (
+                            (system_kind IS NULL AND NOT is_system)
+                            OR system_kind = 'sms'
+                          )
                         )
                       )
                     FOR SHARE
@@ -6672,8 +6674,10 @@ class OneLocationAgentService:
                             WHERE id = CAST(:circle_id AS UUID)
                               AND owner_user_id = :user_id
                               AND status = 'active'
-                              AND system_kind IS NULL
-                              AND NOT is_system
+                              AND (
+                                (system_kind IS NULL AND NOT is_system)
+                                OR system_kind = 'sms'
+                              )
                             FOR SHARE
                             """
                         ),
@@ -6698,8 +6702,10 @@ class OneLocationAgentService:
                             WHERE id = ANY(CAST(:circle_ids AS UUID[]))
                               AND owner_user_id = :user_id
                               AND status = 'active'
-                              AND system_kind IS NULL
-                              AND NOT is_system
+                              AND (
+                                (system_kind IS NULL AND NOT is_system)
+                                OR system_kind = 'sms'
+                              )
                             FOR SHARE
                             """
                         ),

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -771,6 +771,81 @@ def test_auto_approve_preference_rejects_circles_not_all_owned(
     assert not any("INSERT INTO one_location_auto_approve_preferences" in sql for sql in calls)
 
 
+def test_auto_approve_preference_accepts_owned_sms_circle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SMS Circle (system_kind='sms') can be selected as auto-approve scope."""
+    sms_circle_id = "550e8400-e29b-41d4-a716-446655440099"
+    enabled_at = datetime.now(timezone.utc)
+
+    class Result:
+        def __init__(self, *, first=None, rows=None):
+            self._first = first
+            self._rows = rows or []
+
+        def mappings(self):
+            return self
+
+        def first(self):
+            return self._first
+
+        def all(self):
+            return self._rows
+
+    class Connection:
+        def __init__(self):
+            self.calls: list[tuple[str, dict]] = []
+
+        def execute(self, statement, params):
+            sql = str(statement)
+            values = dict(params)
+            self.calls.append((sql, values))
+            if "FROM one_location_circles" in sql and "FOR SHARE" in sql:
+                return Result(first={"id": sms_circle_id}, rows=[{"id": sms_circle_id}])
+            if "INSERT INTO one_location_auto_approve_preferences" in sql:
+                return Result(
+                    first={
+                        "enabled": True,
+                        "scope_kind": "circle",
+                        "circle_id": sms_circle_id,
+                        "circle_ids": None,
+                        "enabled_at": enabled_at,
+                        "rule_version": 1,
+                        "updated_at": enabled_at,
+                    }
+                )
+            return Result()
+
+    connection = Connection()
+
+    @contextmanager
+    def fake_connection():
+        yield connection
+
+    monkeypatch.setattr(
+        one_location_service_module,
+        "get_db_connection",
+        fake_connection,
+    )
+
+    preference = OneLocationAgentService().update_auto_approve_preference(
+        user_id="user_a",
+        enabled=True,
+        scope_kind="circle",
+        circle_id=sms_circle_id,
+    )
+
+    ownership_sql, ownership_params = next(
+        (sql, params)
+        for sql, params in connection.calls
+        if "FROM one_location_circles" in sql and "FOR SHARE" in sql
+    )
+    assert "system_kind = 'sms'" in ownership_sql
+    assert ownership_params["circle_id"] == sms_circle_id
+    assert ownership_params["user_id"] == "user_a"
+    assert preference["scope"] == {"kind": "circle", "circleId": sms_circle_id}
+
+
 def test_first_owned_circle_membership_picks_earliest_match_among_the_set() -> None:
     circle_a, circle_b, circle_c = (
         "550e8400-e29b-41d4-a716-446655440000",

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -2149,6 +2149,98 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
   });
 
+  it("shows owned SMS Circle in auto-approve circles list and excludes Trusted Circle", async () => {
+    const circleFamily = {
+      id: "circle_family",
+      name: "Family",
+      kind: "family" as const,
+      role: "owner" as const,
+      memberCount: 3,
+      memberLimit: 20,
+    };
+    const circleSms = {
+      id: "circle_sms",
+      name: "SMS Contacts",
+      kind: "other" as const,
+      role: "owner" as const,
+      memberCount: 2,
+      memberLimit: 10,
+      isSystem: true,
+      systemKind: "sms" as const,
+    };
+    const circleTrusted = {
+      id: "circle_trusted",
+      name: "Trusted",
+      kind: "other" as const,
+      role: "owner" as const,
+      memberCount: 15,
+      isSystem: false,
+      systemKind: "trusted" as const,
+    };
+    let serverPreference = {
+      enabled: false,
+      scope: null as { kind: "circles"; circleIds: string[] } | null,
+      enabledAt: null as string | null,
+      ruleVersion: 0,
+    };
+    mockGetState.mockImplementation(async () => ({
+      ...locationState(),
+      ownerGrants: [],
+      circles: [circleFamily, circleSms, circleTrusted],
+      autoApprovePreference: serverPreference,
+    }));
+    mockUpdateAutoApprovePreference.mockImplementation(async ({ enabled, scope }) => {
+      serverPreference = enabled
+        ? {
+            enabled: true,
+            scope,
+            enabledAt: "2026-08-24T09:00:00.000Z",
+            ruleVersion: 1,
+          }
+        : { enabled: false, scope: null, enabledAt: null, ruleVersion: 2 };
+      return serverPreference;
+    });
+
+    mockLocationSearchParams("action=settings");
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow({ expectMain: false });
+    expect(
+      await screen.findByRole("heading", { name: "Settings" }),
+    ).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Auto-approve requests" }),
+    );
+    expect(
+      screen.getByRole("heading", { name: "Auto-approve for" }),
+    ).toBeTruthy();
+
+    // SMS Contacts and Family circles must be visible as options
+    const smsCheckbox = screen.getByRole("checkbox", { name: /^SMS Contacts/ });
+    const familyCheckbox = screen.getByRole("checkbox", { name: /^Family/ });
+    expect(smsCheckbox).toBeInTheDocument();
+    expect(familyCheckbox).toBeInTheDocument();
+
+    // Trusted Circle must NOT be offered as an auto-approve option
+    expect(screen.queryByRole("checkbox", { name: /^Trusted/ })).not.toBeInTheDocument();
+
+    // Selecting SMS Contacts enables auto-approve for that circle
+    fireEvent.click(smsCheckbox);
+    expect(smsCheckbox).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Turn on" }));
+    await waitFor(() =>
+      expect(mockUpdateAutoApprovePreference).toHaveBeenCalledWith({
+        vaultOwnerToken: "vault-token",
+        enabled: true,
+        scope: {
+          kind: "circles",
+          circleIds: ["circle_sms"],
+        },
+      }),
+    );
+  });
+
   it("stops the automatic queue when the server rule is turned off", async () => {
     let ruleEnabled = true;
     const requests = [

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -2945,7 +2945,7 @@ function ownedUserCircleScopeOptions(
   circles: readonly OneLocationCircleSummary[],
 ): OneLocationCircleSummary[] {
   return circles.filter(
-    (circle) => circle.role === "owner" && circle.systemKind == null,
+    (circle) => circle.role === "owner" && circle.systemKind !== "trusted",
   );
 }
 


### PR DESCRIPTION
## Summary
Fixes the Location Agent auto-approve setting where the SMS Circle was not appearing in the circle selection options list.

The circle filter in \ownedUserCircleScopeOptions\ previously excluded all circles where \systemKind != null\, which inadvertently excluded the owner's SMS Circle (\systemKind = 'sms'\) alongside the Trusted Circle (\systemKind = 'trusted'\).

## Changes
- **Frontend** (\hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx\):
  - Updated \ownedUserCircleScopeOptions\ to filter out only \systemKind === 'trusted'\, allowing the owner's SMS Circle to be displayed and selected.
  - Added unit test in \one-location-agent-page.test.tsx\ verifying that the SMS Circle is displayed and can be enabled for auto-approve, while Trusted Circle remains excluded.
- **Backend** (\consent-protocol/hushh_mcp/services/one_location_agent_service.py\):
  - Updated \update_auto_approve_preference\ and \_lock_circle_share_eligibility\ to allow \system_kind = 'sms'\ alongside non-system user-created circles (\system_kind IS NULL AND NOT is_system\).
  - Added unit test in \	est_one_location_agent_service.py\ confirming that \update_auto_approve_preference\ accepts an owned SMS Circle.

## Related Issues
Fixes #6468 (follow-up bug fix for SMS Circle discoverability in auto-approve settings)

## Verification
- \
px vitest run __tests__/components/one-location-agent-page.test.tsx -t auto-approve\: Passed (2 tests)
- \
px tsc --noEmit\ in hushh-webapp: Passed (0 errors)
- \pytest tests/services/test_one_location_agent_service.py -k auto_approve\: Passed (10 tests)