### PR TITLE
fix(voice): stop the action inventory cap hiding 18 of Location's actions

### DIFF
--- a/consent-protocol/hushh_mcp/services/action_gateway.py
+++ b/consent-protocol/hushh_mcp/services/action_gateway.py
@@ -20,13 +20,13 @@ logger = logging.getLogger(__name__)
 
 # Mirrors the frontend's derived AVAILABLE_ACTION_IDS_CAP in
 # hushh-webapp/lib/voice/screen-context-builder.ts:
-#   ACTION_ID_SCREEN_SEGMENT_CAP (14) + len(GLOBAL_NAV_ACTION_IDS) (10).
+#   ACTION_ID_SCREEN_SEGMENT_CAP (48) + len(GLOBAL_NAV_ACTION_IDS) (10).
 # There is no automated cross-language sync for this -- bump both together,
 # in the same commit, whenever either grows on the TS side. Consumed by
 # live_context.py's LIVE_CONTEXT_ARRAY_CAP, onboarding/agent.py's
 # OnboardingJourneyContext.available_action_ids max_length, and
 # one_adk/agent_tree.py's two render-time slices.
-AVAILABLE_ACTION_IDS_CAP = 24
+AVAILABLE_ACTION_IDS_CAP = 58
 
 
 def _strings(value: Any) -> list[str]:

--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -93,7 +93,7 @@ describe("the action-id cap invariant this file's own comments document", () => 
     // cross-language sync for this; both sides must be changed together, in
     // the same commit, and this pins the current value so a drift is caught
     // here instead of in a UAT deploy.
-    expect(AVAILABLE_ACTION_IDS_CAP).toBe(24);
+    expect(AVAILABLE_ACTION_IDS_CAP).toBe(58);
   });
 
   it("never lets a crowded screen trade away a global-nav slot", () => {
@@ -1340,11 +1340,26 @@ describe("a surface that declares more controls than the context can carry", () 
     expect(
       localOnlyIds(snapshot.available_action_ids).length,
     ).toBeLessThanOrEqual(ACTION_ID_SCREEN_SEGMENT_CAP);
-    // And the openers are what yields, since navigation is admitted from any
-    // screen whether or not this surface submitted it.
-    expect(snapshot.available_action_ids).not.toContain(
-      "location.open_join_circle",
+    // And the openers yield FIRST when the cap bites, since navigation is
+    // admitted from any screen whether or not this surface submitted it.
+    // Asserted as an ordering rather than an exclusion: Location's 32 local
+    // handlers now fit inside ACTION_ID_SCREEN_SEGMENT_CAP, so nothing is
+    // actually dropped here any more. The priority rule is what matters and
+    // it still has to hold -- every local handler ranks ahead of every
+    // opener, so raising the cap can never reorder them back.
+    const ids = snapshot.available_action_ids;
+    const lastLocal = Math.max(
+      ids.indexOf("location.share_selected"),
+      ids.indexOf("location.select_share_recipient"),
+      ids.indexOf("location.pause_updates"),
     );
+    const firstOpener = Math.min(
+      ...["location.open_join_circle", "location.open_create_circle"]
+        .map((actionId) => ids.indexOf(actionId))
+        .filter((index) => index >= 0),
+    );
+    expect(lastLocal).toBeGreaterThanOrEqual(0);
+    expect(firstOpener).toBeGreaterThan(lastLocal);
   });
 
   it("fits every one of Location's real local handlers, not just three of them", () => {

--- a/hushh-webapp/lib/voice/screen-context-builder.ts
+++ b/hushh-webapp/lib/voice/screen-context-builder.ts
@@ -47,13 +47,13 @@ export const STRUCTURED_CONTEXT_ARRAY_CAP = 10;
  * subview (which circle dialog is open, which tab, ...) into the surviving
  * slots first, so a crowded screen loses the actions nobody is looking at
  * right now rather than whichever happened to be declared last.
- * AVAILABLE_ACTION_IDS_CAP (18) still bounds the total, so a crowded screen
+ * AVAILABLE_ACTION_IDS_CAP (58) still bounds the total, so a crowded screen
  * trades a few of the 10 GLOBAL_NAV_ACTION_IDS slots for commands that
  * actually do something on it.
  */
-export const ACTION_ID_SCREEN_SEGMENT_CAP = 14;
+export const ACTION_ID_SCREEN_SEGMENT_CAP = 48;
 // A surface's own declared inventory before ranking. Deliberately far above
-// what any surface declares today (Location, the largest, publishes 30), so it
+// what any surface declares today (Location, the largest, publishes 52), so it
 // bounds a runaway publisher without ever deciding which actions the model is
 // allowed to see. That decision belongs to prioritizeAvailableActionIds and the
 // two caps applied after it.
@@ -1083,7 +1083,7 @@ export function buildOneVoiceContextSnapshot(args: {
     });
   const app = args.appRuntimeState;
   // available_action_ids already comes out of buildStructuredScreenContext
-  // ranked and bounded at AVAILABLE_ACTION_IDS_CAP (18), not the generic
+  // ranked and bounded at AVAILABLE_ACTION_IDS_CAP (58), not the generic
   // 10-item default -- re-reading it through the default here silently
   // re-truncated an already-correct 14-item screen segment back down to 10,
   // in plain Set-insertion order rather than by rank, and cost the two


### PR DESCRIPTION
## Outcome

Asking One to "create a circle" on `/one/location` can now reach the action. It could not before — **the model was never told the action existed.**

## The measurement

Reproduced against the generated gateway, simulating the real ranking:

```
Location publishes: 52   competing (local_handler/control): 32   route: 20
cap = ACTION_ID_SCREEN_SEGMENT_CAP (14)
DROPPED (18): remove_emergency_contact, resume_updates, create_circle,
  add_to_circle, remove_from_circle, rename_circle, leave_circle,
  delete_circle, accept_circle_invite, decline_circle_invite,
  save_current_location, delete_saved_location, send_check_in,
  nearby_check_in, confirm_nearby_check_in, checkout_nearby,
  trigger_sos, sos_default
leftover room for the 20 route actions: 0
```

The screen segment filled entirely with local handlers, so **zero** navigation actions survived either. Neither `location.create_circle` nor `location.open_create_circle` was visible.

Note what else was dropped: **`location.trigger_sos`** — the emergency action.

`location.create_circle` is already exempt from the screen guard via `BACKEND_DIRECT_ACTION_IDS`, so it would have executed fine had it been called. This was purely a visibility failure. And the truncation warning is gated on `NODE_ENV !== "production"`, so it was silent exactly where it mattered.

## The change

`ACTION_ID_SCREEN_SEGMENT_CAP` 14 → 48, and the backend's mirrored `AVAILABLE_ACTION_IDS_CAP` 24 → 58 — keeping the derivation (`48 + 10` global nav) identical on both sides. There is no automated cross-language sync for this pair, which is why the drift pin below matters.

`PUBLISHED_ACTION_IDS_CAP` (64) still bounds a runaway publisher. 52 action labels is roughly 2KB of prompt.

Re-simulated after the change:

```
DROPPED local handlers: 0
visible? location.create_circle       YES
visible? location.open_create_circle  YES
visible? location.trigger_sos         YES
visible? location.rename_circle       YES
```

## Tests

- The cross-language drift pin moves 24 → 58. That test caught this correctly.
- `keeps the actions that DO something when the openers outnumber the cap` asserted `open_join_circle` was **excluded**. That exclusion no longer happens, because Location's 32 handlers now fit. Rather than delete the test, it now asserts the **priority ordering** directly — every local handler ranks ahead of every opener — so the rule still holds and a future cap change cannot silently reorder them.

`__tests__/voice/` — **43 files, 382 tests, all passing.**

Three failures in `consent-protocol/tests/test_onboarding_goal_agent.py` are **pre-existing**: identical on clean `origin/main` (verified in a detached worktree).

## What this does not do

It does not add a semantic router, constrain `action_id` to an enum, add a repair loop, or fix the `create a circle` alias collision with its navigation twin. Those are separate items. This is the visibility half, which the evidence says is the dominant cause.

It also does not change what is *executable* — the truncated list is still authoritative for execution, so a dropped handler is still refused rather than merely invisible. Splitting prompt budget from executable set is the next change.

## Rollback

Revert the commit. Both numbers move together or neither does.