### PR TITLE
fix(ops): repair the backup alarm that never once ran, and gate UAT on a backup

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -509,6 +509,24 @@ jobs:
             -o /usr/local/bin/cloud-sql-proxy
           chmod +x /usr/local/bin/cloud-sql-proxy
 
+      - name: Pre-deploy Cloud SQL backup posture gate
+        # UAT replays all 174 migrations against a live database on every
+        # deploy, and two of them DROP TABLE. Until 2026-09-08 this lane had no
+        # automated backups at all, so a destructive migration here was
+        # unrecoverable. Backups and PITR are now on; this gate is what stops
+        # the lane silently going back to unrecoverable if they are ever turned
+        # off again or start failing. Same script and same shape production
+        # already uses (deploy-production.yml) -- not a second mechanism.
+        if: steps.scope.outputs.deploy_backend == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/cloudsql_backup_freshness_check.py \
+            --project-id hushh-pda-uat \
+            --instance hushh-uat-pg \
+            --max-age-hours 30 \
+            --report-path /tmp/uat-backup-posture-report.json
+
       - name: Install fail-closed account deletion release fence
         id: install-account-deletion-fence
         if: steps.scope.outputs.deploy_backend == 'true'

--- a/.github/workflows/prod-cloudsql-backup-posture.yml
+++ b/.github/workflows/prod-cloudsql-backup-posture.yml
@@ -10,16 +10,35 @@ permissions:
   id-token: write
 
 env:
-  GCP_PROJECT_ID: hushh-pda
-  PROD_CLOUDSQL_INSTANCE_NAME: hushh-vault-db
   BACKUP_MAX_AGE_HOURS: "30"
 
 jobs:
   backup-posture:
-    name: Daily Cloud SQL Backup Posture Check
+    name: Daily Cloud SQL Backup Posture Check (${{ matrix.lane }})
     if: github.repository == 'hushh-labs/hushh-research'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Without this the job resolves `vars.*` at REPOSITORY scope, where neither
+    # variable is defined -- so every run since 2026-07-28 died on the first
+    # step with "Missing repository variable GCP_WORKLOAD_IDENTITY_PROVIDER".
+    # 42 runs, 42 failures, zero successes: the alarm that watches the backups
+    # had never once run. Both variables live at ENVIRONMENT scope.
+    environment: ${{ matrix.environment }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: prod
+            environment: production
+            project: hushh-pda
+            instance: hushh-vault-db
+          # UAT gained automated backups + PITR on 2026-09-08. It replays 174
+          # migrations against a live database on every deploy, two of which
+          # DROP TABLE, so it is the lane most likely to need a restore.
+          - lane: uat
+            environment: uat
+            project: hushh-pda-uat
+            instance: hushh-uat-pg
 
     steps:
       - name: Checkout code
@@ -29,17 +48,21 @@ jobs:
         shell: bash
         env:
           WIF_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          BACKUP_SERVICE_ACCOUNT: ${{ vars.GCP_BACKUP_SERVICE_ACCOUNT }}
+          # GCP_BACKUP_SERVICE_ACCOUNT was referenced but has never existed in
+          # any scope -- repo, production, uat or dev. This reads backup
+          # metadata only, so the lane's existing deploy identity is the right
+          # least-surprise choice rather than a new identity nobody grants.
+          BACKUP_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
         run: |
           set -euo pipefail
-          test -n "$WIF_PROVIDER" || { echo "Missing repository variable GCP_WORKLOAD_IDENTITY_PROVIDER" >&2; exit 1; }
-          test -n "$BACKUP_SERVICE_ACCOUNT" || { echo "Missing repository variable GCP_BACKUP_SERVICE_ACCOUNT" >&2; exit 1; }
+          test -n "$WIF_PROVIDER" || { echo "Missing ${{ matrix.environment }} environment variable GCP_WORKLOAD_IDENTITY_PROVIDER" >&2; exit 1; }
+          test -n "$BACKUP_SERVICE_ACCOUNT" || { echo "Missing ${{ matrix.environment }} environment variable GCP_DEPLOY_SERVICE_ACCOUNT" >&2; exit 1; }
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_BACKUP_SERVICE_ACCOUNT }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -51,10 +74,10 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/ops/cloudsql_backup_freshness_check.py \
-            --project-id "${GCP_PROJECT_ID}" \
-            --instance "${PROD_CLOUDSQL_INSTANCE_NAME}" \
+            --project-id "${{ matrix.project }}" \
+            --instance "${{ matrix.instance }}" \
             --max-age-hours "${BACKUP_MAX_AGE_HOURS}" \
-            --report-path /tmp/prod-backup-posture-report.json
+            --report-path /tmp/${{ matrix.lane }}-backup-posture-report.json
 
       - name: Upload backup posture artifact
         if: always()
@@ -62,4 +85,4 @@ jobs:
         with:
           name: prod-backup-posture-${{ github.run_id }}
           if-no-files-found: ignore
-          path: /tmp/prod-backup-posture-report.json
+          path: /tmp/${{ matrix.lane }}-backup-posture-report.json


### PR DESCRIPTION
## Outcome

The daily check that would warn you production backups had stopped now actually runs — and UAT can no longer run destructive migrations against a database it cannot restore.

## The alarm has never once succeeded

```
{"failure": 42}
```

**42 runs since 2026-07-28. 42 failures. Zero successes.** The thing watching your backups has been broken its entire life.

Two independent causes, both verified:

1. **The job declares no `environment:`**, so `vars.*` resolves at *repository* scope where neither variable exists. Every run died on the first step: `Missing repository variable GCP_WORKLOAD_IDENTITY_PROVIDER`. Both variables live at environment scope.
2. **`vars.GCP_BACKUP_SERVICE_ACCOUNT` has never existed in any scope** — not repo, not production, not uat, not dev. Repointed to the lane's existing `GCP_DEPLOY_SERVICE_ACCOUNT`; this step reads backup metadata only, so inventing an identity nobody remembers to grant is the wrong answer.

Also extended to UAT, matrixed with `fail-fast: false` so one lane failing still reports the other.

## UAT now gates on having a backup

UAT replays all 174 migrations against a live database on every deploy, and two of them `DROP TABLE ... CASCADE`. It had **no backups at all** and no pre-deploy check — while production has both.

This adds **production's own gate**: same script, same shape, positioned before the deletion fence and before migrations. Not a second mechanism.

```
Install Cloud SQL Auth Proxy
Pre-deploy Cloud SQL backup posture gate   <-- new
Install fail-closed account deletion release fence
Apply UAT DB migrations behind account deletion fence
```

Verified it passes right now rather than assuming:

```
"completed_at": "2026-09-08T00:42:44Z", "age_hours": 0.08, "type": "AUTOMATED", "failures": []
```

Enabling backups triggered an immediate first backup, so this does not block the next deploy. I checked this specifically because a 13-day-old backup would have.

## Infrastructure changed outside this repo

Recorded here for the audit trail, since it isn't visible in any diff:

| Instance | Change | Downtime |
|---|---|---|
| `hushh-uat-pg` | automated backups enabled (22:00, 7 retained) | none |
| `hushh-uat-pg` | point-in-time recovery enabled, 7-day logs | **restart** — verified healthy after |
| `hushh-dev-pg` | automated backups enabled (20:00, 7 retained) | none |

Google turns backups **on by default** — `--no-backup` must be passed to disable them. So `enabled: false` on these two was an affirmative choice at some point, not an oversight.

**Production was not touched** and still reads `enabled=True pitr=True retain=30`.

Post-change state, read back live:

| Lane | Backups | PITR | State |
|---|---|---|---|
| prod | True | True | RUNNABLE |
| UAT | True | True | RUNNABLE |
| dev | True | — | RUNNABLE |

UAT verified serving after the restart: `api.uat.hushh.ai/health` 200, `uat.one.hushh.ai` 200.

## Not done here

- **Restore drills.** An untested backup is not a backup — both Google's and AWS's DR guidance say so explicitly. Nothing here proves a restore works.
- **Infrastructure as code.** These were `gcloud` commands. Under Terraform, `enabled = false` would have shown up as a reviewable diff instead of sitting unnoticed.
- **Production is still hard-blocked** by the migration-201 guard, and migration 128 still deletes a live table on every prod deploy. Separate PRs.

## Rollback

Revert the workflow changes. For the infrastructure: `--no-backup` and `--no-enable-point-in-time-recovery` restore the previous state exactly, though I'd want a reason before turning backups back off.