### PR TITLE
fix(voice): stop a prompt-ranking decision from becoming a refusal

### DIFF
--- a/consent-protocol/api/routes/one/live_context.py
+++ b/consent-protocol/api/routes/one/live_context.py
@@ -300,10 +300,30 @@ def sanitize_live_context(payload: dict[str, Any]) -> dict[str, Any]:
     interaction_layer = sanitize_interaction_layer(
         payload.get("interaction_layer"), submitted_action_ids
     )
+    # What the model is TOLD about and what it is ALLOWED to run are different
+    # questions, and conflating them made a ranking decision into a refusal.
+    #
+    # submitted_action_ids is the prompt inventory: ranked by the browser and
+    # bounded, because a prompt has a budget. It was also the execution
+    # allowlist, so an action that lost the ranking race came back
+    # action_unavailable -- the app declining to do something it can plainly
+    # do, for no reason the person could see.
+    #
+    # The executable set has no such budget. It is the route index's own
+    # declaration for this exact route: server-derived, already validated
+    # against the generated gateway above, and never client-supplied. Authority
+    # is unchanged -- run_app_action still re-checks screens, guards, vault and
+    # confirmation before parking anything.
+    executable_action_ids = sorted(route_action_ids)
     if interaction_layer and interaction_layer["modality"] in {"modal", "blocking"}:
         layer_action_ids = set(interaction_layer["visible_action_ids"])
         submitted_action_ids = [
             action_id for action_id in submitted_action_ids if action_id in layer_action_ids
+        ]
+        # A blocking layer bounds execution too. Widening the executable set
+        # must not become a way to act behind an open modal.
+        executable_action_ids = [
+            action_id for action_id in executable_action_ids if action_id in layer_action_ids
         ]
     return {
         # The generated index is the server-side source of route policy.  A
@@ -339,6 +359,9 @@ def sanitize_live_context(payload: dict[str, Any]) -> dict[str, Any]:
         "persona": bounded_text(payload.get("persona")),
         "voice_state": bounded_text(payload.get("voice_state"), 32),
         "available_action_ids": submitted_action_ids,
+        # Everything this route may run, unbounded by the prompt budget. See
+        # the note above the interaction-layer filter.
+        "executable_action_ids": executable_action_ids,
         "visible_modules": bounded_text_list(payload.get("visible_modules"), LIVE_MODULE_CAP),
         "visible_control_ids": bounded_text_list(
             payload.get("visible_control_ids"), LIVE_MODULE_CAP

--- a/consent-protocol/hushh_mcp/one_adk/action_tools.py
+++ b/consent-protocol/hushh_mcp/one_adk/action_tools.py
@@ -238,6 +238,27 @@ def _available_action_ids(tool_context: ToolContext) -> set[str] | None:
     return {str(value).strip() for value in ids if isinstance(value, str) and value.strip()}
 
 
+def _executable_action_ids(tool_context: ToolContext) -> set[str] | None:
+    """Everything the current route may run, independent of the prompt budget.
+
+    The browser ranks and truncates what the model is told about, because a
+    prompt has a budget. Execution does not: an action this route declares is
+    runnable whether or not it won a slot in the inventory. Keeping the two
+    apart is what stops a ranking decision from surfacing as a refusal.
+
+    Server-derived, from the generated route orchestration index, so it cannot
+    be widened by a forged frame. Absent for non-live callers and older
+    payloads, where the caller falls back to the declared inventory.
+    """
+    context = _voice_context(tool_context)
+    if not isinstance(context, dict) or "executable_action_ids" not in context:
+        return None
+    ids = context.get("executable_action_ids")
+    if not isinstance(ids, list):
+        return set()
+    return {str(value).strip() for value in ids if isinstance(value, str) and value.strip()}
+
+
 def _voice_settings(tool_context: ToolContext) -> dict[str, Any]:
     """The person's own restrictions on their already-authorized voice agent.
 
@@ -2714,9 +2735,13 @@ async def run_app_action(
     # browser to run a local handler, so there is no screen inventory for
     # them to be missing from -- the person can be looking at anything.
     # All other actions must be declared by the current surface.
+    # An action this route declares is runnable even when it lost the prompt
+    # ranking race -- being un-mentioned is not the same as being unavailable.
+    executable_action_ids = _executable_action_ids(tool_context)
     if (
         available_action_ids is not None
         and clean_id not in available_action_ids
+        and (executable_action_ids is None or clean_id not in executable_action_ids)
         and not is_navigation_action(entry)
         and not _is_backend_direct(clean_id, clean_slots)
     ):

--- a/consent-protocol/tests/test_live_context_executable_split.py
+++ b/consent-protocol/tests/test_live_context_executable_split.py
@@ -1,0 +1,107 @@
+"""What the model is told about and what it may run are different questions.
+
+The browser ranks its screen's actions and truncates the list, because a prompt
+has a budget. That same truncated list was also the execution allowlist, so an
+action that lost the ranking race came back `action_unavailable` -- the app
+declining to do something it can plainly do, for a reason nobody could see. On
+Location that was 18 of 52 actions, `location.create_circle` among them.
+
+`executable_action_ids` carries the route's own declaration instead: uncapped,
+server-derived from the generated route orchestration index, never
+client-supplied. These tests pin the three properties that make widening it
+safe -- it is route-scoped, it cannot be injected into, and a blocking layer
+still bounds it.
+"""
+
+from __future__ import annotations
+
+from api.routes.one.live_context import sanitize_live_context
+
+
+def test_execution_is_not_bounded_by_the_prompt_budget() -> None:
+    """A route's executable set does not shrink to what the prompt mentioned."""
+    context = sanitize_live_context(
+        {
+            "route_family": "/one/location",
+            # One id declared, as if everything else lost the ranking race.
+            "available_action_ids": ["location.refresh"],
+        }
+    )
+
+    assert context["available_action_ids"] == ["location.refresh"]
+    executable = context["executable_action_ids"]
+    assert len(executable) > 40, (
+        "Location declares ~52 actions in the route index; an executable set "
+        f"of {len(executable)} means it collapsed back to the prompt budget."
+    )
+    assert "location.create_circle" in executable, (
+        "create_circle is the action this whole change exists for: it was "
+        "dropped by the cap and then refused at execution."
+    )
+
+
+def test_the_executable_set_stays_scoped_to_the_route() -> None:
+    """Uncapped is not the same as unbounded.
+
+    A Location action must not become runnable because someone is standing on
+    Profile. If this ever passes vacuously -- both sets empty -- the route
+    index lookup is broken and the assertion below is meaningless, so the
+    Location side is checked for content too.
+    """
+    profile = sanitize_live_context({"route_family": "/one/profile", "available_action_ids": []})
+    location = sanitize_live_context({"route_family": "/one/location", "available_action_ids": []})
+
+    assert location["executable_action_ids"], "Location resolved no actions at all"
+    assert "location.create_circle" in location["executable_action_ids"]
+    assert "location.create_circle" not in profile["executable_action_ids"]
+
+
+def test_a_client_cannot_inject_into_the_executable_set() -> None:
+    """The payload describes a screen; it does not get to name what may run."""
+    context = sanitize_live_context(
+        {
+            "route_family": "/one/profile",
+            "available_action_ids": ["not.a.real.action"],
+            # A forged frame trying to hand itself authority directly.
+            "executable_action_ids": ["location.delete_circle", "not.a.real.action"],
+        }
+    )
+
+    assert "not.a.real.action" not in context["executable_action_ids"]
+    assert "location.delete_circle" not in context["executable_action_ids"], (
+        "The executable set must be derived from the route index, never read back from the payload."
+    )
+
+
+def test_a_blocking_layer_still_bounds_execution() -> None:
+    """Widening the executable set must not become a way to act behind a modal."""
+    open_modal = sanitize_live_context(
+        {
+            "route_family": "/one/location",
+            "available_action_ids": ["location.refresh"],
+            # Every field here is load-bearing: sanitize_interaction_layer
+            # returns None unless layer_id, kind, modality, lifecycle_state and
+            # agent_continuity are all present and valid. A partial layer is
+            # silently discarded, which would make this test pass without ever
+            # engaging the filter it claims to check.
+            "interaction_layer": {
+                "layer_id": "location-confirm-dialog",
+                "kind": "dialog",
+                "modality": "blocking",
+                "lifecycle_state": "open",
+                "agent_continuity": "interactive",
+                "visible_action_ids": ["location.refresh"],
+            },
+        }
+    )
+
+    assert open_modal["interaction_layer"] is not None, (
+        "The layer was discarded as malformed, so this test would pass "
+        "without the blocking filter ever running."
+    )
+    executable = open_modal["executable_action_ids"]
+    assert "location.create_circle" not in executable, (
+        "A blocking layer bounds what may run, or the split reopens every "
+        "action behind an open dialog."
+    )
+    assert set(executable) <= {"location.refresh"}

--- a/consent-protocol/tests/test_one_action_search_contract.py
+++ b/consent-protocol/tests/test_one_action_search_contract.py
@@ -1,0 +1,61 @@
+"""The browser's action search and the server that answers it must agree.
+
+The client sent `GET /api/one/actions/search?query=...` with no VAULT_OWNER
+token. The server has always served that path as an authenticated POST. Every
+call was therefore a 405 or a 401, and the single caller
+(`searchKaiActionsSemantic` in lib/voice/kai-action-gateway.ts) catches every
+failure and returns `[]` -- so a broken endpoint and "nothing matched" produced
+the same empty command palette. Nobody could see it.
+
+There is also a second, unmounted implementation of this exact path in
+`api/routes/one/action_proposals.py`, whose router is imported and exported in
+`api/routes/one/__init__.py` but deliberately never included. It returns a
+different response shape (`{results, ranking}`) than the live handler
+(`{status, query, total, results}`). Mounting it would not add an endpoint --
+it would silently replace the one the palette already depends on, because
+FastAPI resolves to the first matching route.
+
+So the invariant worth holding is not "mount everything imported". It is that
+exactly one handler answers this path, and that it stays a POST.
+"""
+
+from __future__ import annotations
+
+import api.routes.one as one_routes
+
+SEARCH_PATH = "/api/one/actions/search"
+
+
+def _routes_for(path: str) -> list[object]:
+    return [route for route in one_routes.router.routes if getattr(route, "path", "") == path]
+
+
+def test_the_action_search_path_is_served_exactly_once() -> None:
+    """A second handler for this path shadows the live one instead of adding to it.
+
+    action_proposals.py declares the same route. If someone "fixes" its unused
+    import by mounting the router, the palette silently starts reading a
+    different response shape from a different implementation -- with no error
+    anywhere, because the caller swallows failures.
+    """
+    matches = _routes_for(SEARCH_PATH)
+    assert len(matches) == 1, (
+        f"expected exactly one handler for {SEARCH_PATH}, found {len(matches)}. "
+        "A duplicate almost certainly means action_proposals_router was mounted; "
+        "it shadows the live agent_chat handler rather than supplementing it."
+    )
+
+
+def test_the_action_search_endpoint_stays_a_post() -> None:
+    """Pinned because the client drifted to GET and nothing said so."""
+    matches = _routes_for(SEARCH_PATH)
+    assert matches, f"{SEARCH_PATH} is not mounted at all"
+    methods: set[str] = set()
+    for route in matches:
+        methods |= set(getattr(route, "methods", set()) or set())
+    assert "POST" in methods, f"expected POST, got {sorted(methods)}"
+    assert "GET" not in methods, (
+        "The client used to send GET here and silently got 405s. If GET is "
+        "genuinely wanted, change the client deliberately rather than widening "
+        "the server to absorb a mistake."
+    )

--- a/consent-protocol/tests/test_one_adk_live_protocol.py
+++ b/consent-protocol/tests/test_one_adk_live_protocol.py
@@ -301,6 +301,11 @@ def test_live_context_keeps_only_bounded_redacted_ui_fields():
         "signed_in": False,
         "context_revision": None,
         "available_action_ids": [],
+        # Empty for this route because the generated index declares no actions
+        # for it. On a route that does (Location declares 52), this is the
+        # uncapped executable set -- see
+        # test_execution_is_not_bounded_by_the_prompt_budget.
+        "executable_action_ids": [],
         "visible_modules": ["Portfolio"],
         "visible_control_ids": [],
         "interaction_layer": None,

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5520,7 +5520,7 @@
     "cache_manifest": "c7a177decdb319d8a8b673ae16f6acdad5aedee5fc98329d2d58470e1726b4e8",
     "data_plane": "a9eab526c377cba31e895e1dd66cad1b365960a06eeb5598215dd041f2708588",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
-    "one_specialist_tools": "9d10e0c11405b068b974090095b702a77ef534f4a7b5996dcd468b337f470261",
+    "one_specialist_tools": "a193bd0a3369f56ffcc1ebd2ce4290c9539ece22365f4099a9e36a4bde3e2abe",
     "route_index": "41dff692a3bb112eefbbe73862dd86deac2d54b093b68d4dbb9318f1c0e64793",
     "route_layout": "b66933c7083fd755f1a8e4a16262996fc7ae6124a4c550725bfdc7144332355f",
     "surface_map": "f5fffd96f19e2c2e949c47840a815f87c0fa0936eff7a50cc9c7a180590ba7b3",

--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -6,6 +6,8 @@ import {
   AVAILABLE_ACTION_IDS_CAP,
   GLOBAL_NAV_ACTION_IDS,
   GLOBAL_SESSION_ACTION_IDS,
+  interleaveByVerbFamily,
+  verbFamilyOf,
   INVALID_ARRAY_TYPE_ERROR,
   STRUCTURED_CONTEXT_ARRAY_CAP,
   buildOneVoiceContextSnapshot,
@@ -131,6 +133,58 @@ describe("the action-id cap invariant this file's own comments document", () => 
     // top-level surface, which is what keeps it auditable.
     expect(GLOBAL_SESSION_ACTION_IDS).toContain("profile.sign_out");
     expect(GLOBAL_NAV_ACTION_IDS).not.toContain("profile.sign_out");
+  });
+
+  it("does not reorder an inventory that fits under the cap", () => {
+    // The fairness pass exists for the screen that outgrows the cap next, not
+    // for any screen shipping today -- Location declares 29 local handlers
+    // against 48 slots. Reordering a list that will be carried in full would
+    // churn the snapshot revision (uiRevision feeds context_revision) for no
+    // benefit, so below the cap this must be the identity function.
+    const ids = Array.from({ length: 5 }, (_, i) => `location.thing_${i}`);
+    expect(interleaveByVerbFamily(ids, () => 1)).toEqual(ids);
+  });
+
+  it("stops one verb family eating every slot on a crowded screen", () => {
+    // 60 circle verbs declared before a single sharing verb. Under plain
+    // insertion order the sharing verb sits at index 60 and is dropped by the
+    // 48-slot cap, so "stop sharing my location" becomes unavailable on a
+    // screen that plainly offers it -- the same class of failure as the
+    // truncation this file's telemetry now reports.
+    const crowded = [
+      ...Array.from({ length: 60 }, (_, i) => `location.rename_circle_${i}`),
+      "location.stop_share",
+    ];
+    const ordered = interleaveByVerbFamily(crowded, () => 1);
+    expect(ordered).toHaveLength(crowded.length);
+    expect(new Set(ordered)).toEqual(new Set(crowded));
+    expect(ordered.indexOf("location.stop_share")).toBeLessThan(
+      ACTION_ID_SCREEN_SEGMENT_CAP,
+    );
+  });
+
+  it("lets rank outrank fairness, never the other way round", () => {
+    // A subview-boosted handler is the one the person is looking at. Fairness
+    // decides ties within a rank; it must not promote an unboosted verb above
+    // a boosted one just because its family is under-represented.
+    const ids = [
+      ...Array.from({ length: 60 }, (_, i) => `location.rename_circle_${i}`),
+      "location.stop_share",
+    ];
+    const rankOf = (id: string) => (id === "location.rename_circle_0" ? 0 : 1);
+    const ordered = interleaveByVerbFamily(ids, rankOf);
+    expect(ordered[0]).toBe("location.rename_circle_0");
+  });
+
+  it("groups verbs by the app object they act on", () => {
+    expect(verbFamilyOf("location.add_to_circle")).toBe("circles");
+    expect(verbFamilyOf("location.stop_share")).toBe("sharing");
+    expect(verbFamilyOf("location.trigger_sos")).toBe("safety");
+    // An unrecognised noun gets its own family rather than being lumped into
+    // a group it would then compete with and lose to.
+    expect(verbFamilyOf("location.frobnicate")).not.toBe(
+      verbFamilyOf("location.wibble"),
+    );
   });
 
   it("keeps every session action backed by a real wired gateway entry", () => {

--- a/hushh-webapp/__tests__/voice/screen-inventory-cap-gate.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-inventory-cap-gate.test.ts
@@ -1,0 +1,79 @@
+/**
+ * A screen that outgrows the context cap must say how it wants to be ranked.
+ *
+ * When a surface declares more cap-competing actions than
+ * ACTION_ID_SCREEN_SEGMENT_CAP, the excess is dropped before the model ever
+ * sees it, and a dropped local handler comes back from the relay as
+ * `action_unavailable` -- indistinguishable from a broken feature. Location
+ * shipped for months in exactly that state: 18 of its 52 actions invisible,
+ * every circle verb among them.
+ *
+ * Raising the cap bought headroom, not immunity. This gate fails the build the
+ * next time a surface crosses the line without declaring, through
+ * SUBVIEW_ACTION_BOOST, which handlers matter on which subview. It is a
+ * deliberately cheap structural check -- it asserts the declaration exists,
+ * not that the ranking is good.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { listKaiActions } from "@/lib/voice/kai-action-gateway";
+import {
+  ACTION_ID_SCREEN_SEGMENT_CAP,
+  SUBVIEW_ACTION_BOOST,
+} from "@/lib/voice/screen-context-builder";
+
+/** Mirrors prioritizeAvailableActionIds: route actions never take a slot. */
+function competesForASlot(action: {
+  execution_target: { status: string; path?: string };
+}): boolean {
+  return (
+    action.execution_target.status === "wired" &&
+    action.execution_target.path !== "route"
+  );
+}
+
+describe("screen inventory cap gate", () => {
+  const byScreen = new Map<string, string[]>();
+  for (const action of listKaiActions()) {
+    if (!competesForASlot(action)) continue;
+    for (const screen of action.reachability.screens) {
+      byScreen.set(screen, [...(byScreen.get(screen) ?? []), action.action_id]);
+    }
+  }
+
+  it("has a non-empty inventory to check", () => {
+    // Without this the whole file passes vacuously if the gateway fails to
+    // load -- the failure mode that made the original bug invisible.
+    expect(byScreen.size).toBeGreaterThan(5);
+  });
+
+  it("requires boost coverage from any screen that outgrows the cap", () => {
+    const uncovered: string[] = [];
+    for (const [screen, actionIds] of byScreen) {
+      if (actionIds.length <= ACTION_ID_SCREEN_SEGMENT_CAP) continue;
+      const hasBoost = Object.keys(SUBVIEW_ACTION_BOOST).some(
+        (key) => key.split(":")[0] === screen,
+      );
+      if (!hasBoost) uncovered.push(`${screen} (${actionIds.length} actions)`);
+    }
+    expect(
+      uncovered,
+      "These screens declare more cap-competing actions than the context can " +
+        "carry and do not declare any SUBVIEW_ACTION_BOOST entry, so which " +
+        "actions survive is decided by declaration order. Add boost entries " +
+        "naming the handlers that matter per subview: " +
+        uncovered.join(", "),
+    ).toEqual([]);
+  });
+
+  it("reports current headroom so the next crossing is not a surprise", () => {
+    const worst = [...byScreen.entries()].sort(
+      (a, b) => b[1].length - a[1].length,
+    )[0];
+    expect(worst).toBeDefined();
+    // Not an assertion about the number itself -- only that the gate above is
+    // measuring something real and the cap has not silently been outgrown.
+    expect(worst[1].length).toBeLessThanOrEqual(ACTION_ID_SCREEN_SEGMENT_CAP);
+  });
+});

--- a/hushh-webapp/components/kai/kai-command-palette.tsx
+++ b/hushh-webapp/components/kai/kai-command-palette.tsx
@@ -50,6 +50,7 @@ import { KAI_MARKET_PATH, ROUTES } from "@/lib/navigation/routes";
 import type { KaiCommandBarIntent } from "@/lib/navigation/kai-command-bar-events";
 import { Icon } from "@/lib/morphy-ux/ui";
 import { cn } from "@/lib/utils";
+import { useVault } from "@/lib/vault/vault-context";
 import {
   RECENT_ACTION_LIMIT,
   readActionUsage,
@@ -315,6 +316,10 @@ export function KaiCommandPalette({
   disabled = false,
   portfolioTickers = [],
 }: KaiCommandPaletteProps) {
+  // The semantic action search is a VAULT_OWNER-authenticated endpoint; the
+  // palette is rendered inside VaultProvider, so the token is available here
+  // without threading it through every caller as a prop.
+  const { vaultOwnerToken } = useVault();
   const [query, setQuery] = useState("");
   const [universe, setUniverse] = useState<TickerUniverseRow[] | null>(
     getTickerUniverseSnapshot(),
@@ -393,6 +398,10 @@ export function KaiCommandPalette({
           limit: 10,
           debounceMs: 180,
           signal: controller.signal,
+          // The semantic endpoint authenticates with a VAULT_OWNER token. A
+          // locked vault means no token, which falls back to local search
+          // rather than failing the palette.
+          vaultOwnerToken,
         });
         if (!cancelled) {
           setSemanticMatches(results);
@@ -406,7 +415,10 @@ export function KaiCommandPalette({
       cancelled = true;
       controller?.abort();
     };
-  }, [open, query, appRuntimeState, surfaceMetadata]);
+    // vaultOwnerToken is a real dependency, not decoration: the effect returns
+    // local-only results while the vault is locked, so unlocking must re-run it
+    // or the palette stays lexical for the rest of the session.
+  }, [open, query, appRuntimeState, surfaceMetadata, vaultOwnerToken]);
 
   useEffect(() => {
     if (!open) return;

--- a/hushh-webapp/lib/voice/kai-action-gateway.ts
+++ b/hushh-webapp/lib/voice/kai-action-gateway.ts
@@ -1195,6 +1195,7 @@ async function searchKaiActionsSemantic(
     appRuntimeState?: AppRuntimeState;
     surfaceMetadata?: VoiceSurfaceMetadata | null;
     limit?: number;
+    vaultOwnerToken?: string | null;
   },
   signal?: AbortSignal,
 ): Promise<Array<{
@@ -1204,9 +1205,12 @@ async function searchKaiActionsSemantic(
   semantic?: true;
 }>> {
   const limit = Math.max(1, Math.min(input.limit ?? 10, 20));
-  const url =
-    `/api/one/actions/search?limit=${encodeURIComponent(String(limit))}` +
-    (input.query.trim() ? `&query=${encodeURIComponent(input.query.trim())}` : "");
+  // The endpoint is authenticated with a VAULT_OWNER token, so without one
+  // every call is a 401 that the catch below turns into an empty result set.
+  // Returning early keeps "the vault is locked" distinguishable from "nothing
+  // matched", which is the distinction this whole path lost.
+  if (!input.vaultOwnerToken) return [];
+  const url = "/api/one/actions/search";
 
   const controller = _pendingSemanticAbort;
   if (controller) controller.abort();
@@ -1222,8 +1226,12 @@ async function searchKaiActionsSemantic(
     // nothing on device -- which is exactly where the Siri handoff runs.
     // apiFetch routes to the real backend base URL on native platforms.
     const res = await ApiService.apiFetch(url, {
-      method: "GET",
-      headers: { "Content-Type": "application/json" },
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Hushh-Consent": `Bearer ${input.vaultOwnerToken}`,
+      },
+      body: JSON.stringify({ query: input.query.trim(), limit }),
       signal: signal ?? abort.signal,
       credentials: "include",
     });
@@ -1279,6 +1287,8 @@ export async function searchKaiActionsAsync(input: {
   limit?: number;
   debounceMs?: number;
   signal?: AbortSignal;
+  /** Required for the semantic pass; without it only local search runs. */
+  vaultOwnerToken?: string | null;
 }): Promise<Array<{
   action: KaiActionDefinition;
   availability: KaiActionAvailability;

--- a/hushh-webapp/lib/voice/screen-context-builder.ts
+++ b/hushh-webapp/lib/voice/screen-context-builder.ts
@@ -529,7 +529,7 @@ function readStringArray(
  * at the ordinary screen-owned tier, so an incomplete or stale mapping can
  * only fail to help -- it cannot make today's insertion-order tiebreak worse.
  */
-const SUBVIEW_ACTION_BOOST: Readonly<Record<string, readonly string[]>> = {
+export const SUBVIEW_ACTION_BOOST: Readonly<Record<string, readonly string[]>> = {
   // Bare /one/location, no open flow: what someone is most likely to ask for
   // without having drilled into a specific circle or share first.
   "one_location:": [
@@ -593,6 +593,80 @@ const SUBVIEW_ACTION_BOOST: Readonly<Record<string, readonly string[]>> = {
  * Set-insertion order previously made the truncation nondeterministic; this
  * keeps the same cap but makes what survives it intentional.
  */
+/**
+ * The family of app-object a verb acts on, derived from the action id.
+ *
+ * Deliberately a heuristic over the id rather than a new authored field: every
+ * surface would have to be re-authored to add one, and the id already carries
+ * the noun. `location.add_to_circle` is a circle verb, `location.stop_share` a
+ * sharing verb. An id whose noun is unrecognised gets its own family, which is
+ * the safe default -- it competes with itself rather than being lumped in with
+ * an unrelated group and starved by it.
+ */
+export function verbFamilyOf(actionId: string): string {
+  const local = actionId.includes(".")
+    ? actionId.slice(actionId.indexOf(".") + 1)
+    : actionId;
+  const NOUNS: Array<[RegExp, string]> = [
+    [/circle/, "circles"],
+    [/share|sharing|updates/, "sharing"],
+    [/request|invite|ask/, "requests"],
+    [/sos|emergency|check_in|checkin|safety/, "safety"],
+    [/contact|connection|people|person/, "people"],
+    [/location|place|map/, "places"],
+  ];
+  for (const [pattern, family] of NOUNS) {
+    if (pattern.test(local)) return family;
+  }
+  return `other:${local}`;
+}
+
+/**
+ * Round-robin the competing ids across verb families, so a crowded screen
+ * cannot let one family eat every slot.
+ *
+ * Applied ONLY when the cap actually binds. Below the cap this returns its
+ * input unchanged, which matters: reordering an inventory that is going to be
+ * carried in full would churn the snapshot revision for no benefit, and every
+ * screen today is comfortably under the cap. It is here for the screen that
+ * outgrows it next, not for any screen that exists now.
+ *
+ * Rank order is preserved as the outer key: a subview-boosted handler still
+ * outranks an unboosted one from a "fairer" family. Fairness decides who wins
+ * a tie, never who outranks whom.
+ */
+export function interleaveByVerbFamily(
+  competing: string[],
+  rankOf: (actionId: string) => number,
+): string[] {
+  if (competing.length <= ACTION_ID_SCREEN_SEGMENT_CAP) return competing;
+  const byRank = new Map<number, Map<string, string[]>>();
+  competing.forEach((actionId) => {
+    const rank = rankOf(actionId);
+    const families = byRank.get(rank) ?? new Map<string, string[]>();
+    const family = verbFamilyOf(actionId);
+    families.set(family, [...(families.get(family) ?? []), actionId]);
+    byRank.set(rank, families);
+  });
+  const out: string[] = [];
+  for (const rank of [...byRank.keys()].sort((a, b) => a - b)) {
+    // Insertion order of the family map is first-appearance order, so the
+    // result stays deterministic for a given input.
+    const queues = [...(byRank.get(rank) ?? new Map()).values()];
+    let drained = false;
+    while (!drained) {
+      drained = true;
+      for (const queue of queues) {
+        const next = queue.shift();
+        if (next === undefined) continue;
+        out.push(next);
+        drained = false;
+      }
+    }
+  }
+  return out;
+}
+
 function prioritizeAvailableActionIds(
   candidateIds: string[],
   screen: string | null,
@@ -682,7 +756,10 @@ function prioritizeAvailableActionIds(
         action.execution_target.path === "route",
     );
   };
-  const capCompeting = ranked.filter((actionId) => !isCapExempt(actionId));
+  const capCompeting = interleaveByVerbFamily(
+    ranked.filter((actionId) => !isCapExempt(actionId)),
+    rankOf,
+  );
   const capExemptActions = ranked.filter(isCapExempt);
   if (capCompeting.length > ACTION_ID_SCREEN_SEGMENT_CAP) {
     // Loud, and it names what was lost. This was a console.debug, and the


### PR DESCRIPTION
Three of the remaining Phase 0 items. Each is the same shape: the app declining to do something it can plainly do.

## C3 — execution split from the prompt budget

The browser ranks a screen's actions and truncates, because a prompt has a budget. **That same truncated list was also the execution allowlist**, so an action that lost the ranking race came back `action_unavailable`. On Location that was 18 of 52 actions, `location.create_circle` among them.

The relay already loads the route orchestration index and intersects the browser's list with it — but the browser's list is capped *before* it arrives, so a dropped handler never reaches the intersection.

`sanitize_live_context` now also returns `executable_action_ids`: the route's own declaration, uncapped, server-derived, never read back from the payload. `run_app_action` accepts an id present in either set.

**Measured, not assumed:**

| Route | executable ids | `location.create_circle` |
|---|---|---|
| `/one/location` | 52 | present |
| `/one/profile` | 9 | absent |

Uncapped *within* a route, still bounded *by* route. A blocking interaction layer bounds both sets, so this cannot become a way to act behind an open modal — pinned by a test that first asserts the layer was not discarded as malformed, because my first version of that test silently never engaged the filter.

## Verb-family fairness + a build gate

Ranking within a rank was insertion order, so one verb family could take every slot. Now round-robins across families, applied **only when the cap actually binds** — below it this is the identity function, since reordering a list that will be carried in full would churn the snapshot revision for no benefit. Rank still outranks fairness: a subview-boosted handler is never demoted for a fairer family.

Raising the cap bought headroom, not immunity. A new gate fails the build when a surface outgrows the cap without declaring `SUBVIEW_ACTION_BOOST` coverage. Mutation-tested by lowering the cap to 3 — it names all eleven offending screens.

## The action search endpoint

The browser sent `GET` with no VAULT_OWNER token; the server serves an authenticated `POST`. Every call was a 405 or 401, and the single caller catches everything and returns `[]` — so a broken endpoint and "nothing matched" were indistinguishable. Now POSTs with `X-Hushh-Consent`, threaded from the palette's vault context, and returns early rather than calling unauthenticated.

### What this deliberately does not do

I nearly mounted `action_proposals_router`, which is imported and exported but never included. **That would have been a regression, not a fix.** It declares the *same* `/api/one/actions/search` path, and FastAPI resolves to the first match — so mounting it would silently replace the live `agent_chat` handler with a different response shape (`{results, ranking}` vs `{status, query, total, results}`).

My mutation test is what caught it: removing my mount changed nothing, because the route already existed via `agent_chat`. A test now pins that **exactly one** handler serves that path and fails if the duplicate is ever mounted.

## Verification

- **400 web voice tests** pass (45 files). Every new assertion mutation-tested.
- **352 python tests** pass across the affected suites.
- `npm run verify:voice-gateway` clean — all three generated voice artifacts, run to a fixed point.
- Pre-existing and unrelated, verified identical on clean `origin/main`: `test_normalizes_screen_names`.

## Still outstanding from Phase 0

Item 5, the `action_id` enum. 178 values / ~4.7 KB; the ADK spike renders `Literal` → `enum` correctly, but a provider-side rejection would break every voice session, so it needs one UAT run before it can be default. Not in this PR.