### PR TITLE
fix(ria): show only SEC Form 13F evidence link

### DIFF
--- a/hushh-webapp/__tests__/lib/marketplace/investor-evidence-links.test.ts
+++ b/hushh-webapp/__tests__/lib/marketplace/investor-evidence-links.test.ts
@@ -10,7 +10,7 @@ function evidence(
 }
 
 describe("marketplaceInvestorEvidenceLinks", () => {
-  it("labels distinct SEC evidence surfaces without generic duplicate-looking text", () => {
+  it("renders only the SEC Form 13F filing link from distinct SEC evidence surfaces", () => {
     const links = marketplaceInvestorEvidenceLinks(
       evidence({
         source_urls: [
@@ -24,16 +24,6 @@ describe("marketplaceInvestorEvidenceLinks", () => {
 
     expect(links).toEqual([
       {
-        id: "url:https://data.sec.gov/submissions/CIK0000123456.json",
-        label: "SEC submissions - CIK 0000123456",
-        url: "https://data.sec.gov/submissions/CIK0000123456.json",
-      },
-      {
-        id: "url:https://www.sec.gov/edgar/browse/?CIK=0000123456",
-        label: "SEC company page - CIK 0000123456",
-        url: "https://www.sec.gov/edgar/browse/?CIK=0000123456",
-      },
-      {
         id: "sec-accession:0000123456-26-000001",
         label: "SEC Form 13F - 0000123456-26-000001",
         url: "https://www.sec.gov/Archives/edgar/data/123456/000012345626000001/xslForm13F_X02/primary_doc.xml",
@@ -41,18 +31,18 @@ describe("marketplaceInvestorEvidenceLinks", () => {
     ]);
   });
 
-  it("deduplicates exact repeated source URLs by stable URL identity", () => {
+  it("does not surface submissions or company-page URLs without a 13F filing", () => {
     const links = marketplaceInvestorEvidenceLinks(
       evidence({
         source_urls: [
           "https://data.sec.gov/submissions/CIK0000123456.json",
-          "https://data.sec.gov/submissions/CIK0000123456.json",
+          "https://www.sec.gov/edgar/browse/?CIK=0000123456",
         ],
+        forms: [{ form: "13F", last_filed_at: "2026-03-31" }],
       })
     );
 
-    expect(links).toHaveLength(1);
-    expect(links[0]?.label).toBe("SEC submissions - CIK 0000123456");
+    expect(links).toEqual([]);
   });
 
   it("deduplicates SEC filing URLs that point to the same accession", () => {
@@ -71,7 +61,7 @@ describe("marketplaceInvestorEvidenceLinks", () => {
     expect(links[0]?.label).toBe("SEC Form 13F - 0000123456-26-000001");
   });
 
-  it("keeps multiple distinct SEC filings visible with unique accession labels", () => {
+  it("keeps only the first distinct SEC Form 13F filing visible", () => {
     const links = marketplaceInvestorEvidenceLinks(
       evidence({
         source_urls: [
@@ -84,23 +74,20 @@ describe("marketplaceInvestorEvidenceLinks", () => {
 
     expect(links.map((link) => link.label)).toEqual([
       "SEC Form 13F - 0000123456-26-000001",
-      "SEC Form 13F - 0000123456-26-000002",
     ]);
   });
 
-  it("falls back to numbered filing labels only when no SEC metadata can identify the URL", () => {
+  it("honors an explicit zero-link limit", () => {
     const links = marketplaceInvestorEvidenceLinks(
       evidence({
         source_urls: [
-          "https://example.com/a",
-          "https://example.com/b",
+          "https://www.sec.gov/Archives/edgar/data/123456/000012345626000001/primary_doc.xml",
         ],
-      })
+        forms: [{ form: "13F", last_filed_at: "2026-03-31" }],
+      }),
+      0
     );
 
-    expect(links.map((link) => link.label)).toEqual([
-      "SEC filing 1",
-      "SEC filing 2",
-    ]);
+    expect(links).toEqual([]);
   });
 });

--- a/hushh-webapp/lib/marketplace/investor-discovery.ts
+++ b/hushh-webapp/lib/marketplace/investor-discovery.ts
@@ -201,53 +201,36 @@ function evidenceUrlParts(url: string): URL | null {
   }
 }
 
-function evidenceCikFromUrl(parsed: URL | null): string | null {
-  if (!parsed) return null;
-
-  const queryCik = parsed.searchParams.get("CIK");
-  if (queryCik) return queryCik.trim() || null;
-
-  const pathCik = parsed.pathname.match(/CIK(\d+)\.json$/i)?.[1];
-  return pathCik || null;
-}
-
 function primaryEvidenceForm(
   forms?: Array<{ form?: string | null; last_filed_at?: string | null }>
-): { form: string | null; lastFiledAt: string | null } {
+): string | null {
   const first = Array.isArray(forms) ? forms[0] : null;
-  return {
-    form: String(first?.form || "").trim() || null,
-    lastFiledAt: String(first?.last_filed_at || "").trim() || null,
-  };
+  return String(first?.form || "").trim() || null;
 }
 
-function evidenceLabel(params: {
+function isForm13F(form: string | null): boolean {
+  return Boolean(form && form.toUpperCase().startsWith("13F"));
+}
+
+function isSecForm13FUrl(params: {
   parsed: URL | null;
   url: string;
   forms?: Array<{ form?: string | null; last_filed_at?: string | null }>;
-  fallbackIndex: number;
-}): string {
-  const { form, lastFiledAt } = primaryEvidenceForm(params.forms);
-  const accession = normalizeSecAccession(params.url);
-  if (accession) return form ? `SEC Form ${form} - ${accession}` : `SEC filing - ${accession}`;
-
+}): boolean {
+  const form = primaryEvidenceForm(params.forms);
   const host = params.parsed?.hostname.toLowerCase() || "";
-  const path = params.parsed?.pathname || "";
-  const cik = evidenceCikFromUrl(params.parsed);
+  const path = params.parsed?.pathname.toLowerCase() || "";
 
-  if (host === "data.sec.gov" && /\/submissions\/CIK\d+\.json$/i.test(path)) {
-    return cik ? `SEC submissions - CIK ${cik}` : "SEC submissions";
-  }
+  if (host && !host.endsWith("sec.gov")) return false;
+  if (path.includes("form13f")) return true;
+  return isForm13F(form) && Boolean(normalizeSecAccession(params.url));
+}
 
-  if (host.endsWith("sec.gov") && path.toLowerCase().includes("/edgar/browse/")) {
-    return cik ? `SEC company page - CIK ${cik}` : "SEC company page";
-  }
-
-  if (host.endsWith("sec.gov") && form) {
-    return lastFiledAt ? `SEC Form ${form} - ${lastFiledAt}` : `SEC Form ${form}`;
-  }
-
-  return `SEC filing ${params.fallbackIndex}`;
+function evidenceLabel(params: {
+  url: string;
+}): string {
+  const accession = normalizeSecAccession(params.url);
+  return accession ? `SEC Form 13F - ${accession}` : "SEC Form 13F";
 }
 
 function evidenceIdentity(url: string): string {
@@ -260,8 +243,10 @@ function evidenceIdentity(url: string): string {
 
 export function marketplaceInvestorEvidenceLinks(
   evidence: MarketplaceInvestor["evidence"],
-  limit = 3
+  limit = 1
 ): MarketplaceEvidenceLink[] {
+  if (limit <= 0) return [];
+
   const sourceUrls = Array.isArray(evidence?.source_urls) ? evidence.source_urls : [];
   const links: MarketplaceEvidenceLink[] = [];
   const seen = new Set<string>();
@@ -270,6 +255,9 @@ export function marketplaceInvestorEvidenceLinks(
     const url = normalizeEvidenceUrl(sourceUrl);
     if (!url) continue;
 
+    const parsed = evidenceUrlParts(url);
+    if (!isSecForm13FUrl({ parsed, url, forms: evidence?.forms })) continue;
+
     const id = evidenceIdentity(url);
     if (seen.has(id)) continue;
 
@@ -277,15 +265,12 @@ export function marketplaceInvestorEvidenceLinks(
     links.push({
       id,
       label: evidenceLabel({
-        parsed: evidenceUrlParts(url),
         url,
-        forms: evidence?.forms,
-        fallbackIndex: links.length + 1,
       }),
       url,
     });
 
-    if (links.length >= limit) break;
+    if (links.length >= Math.min(limit, 1)) break;
   }
 
   return links;


### PR DESCRIPTION
## Summary

- Updates RIA Marketplace SEC evidence links so public SEC investor profiles show only one `SEC Form 13F` filing link.
- Removes the submissions and company-page evidence links from the helper output instead of hiding them in the page.
- Updates the helper regression tests to prove only the first distinct 13F filing is rendered.

## Validation

- `npm.cmd test -- __tests__/lib/marketplace/investor-evidence-links.test.ts`
- `npx.cmd eslint lib\marketplace\investor-discovery.ts __tests__\lib\marketplace\investor-evidence-links.test.ts --max-warnings=0`
- `npm.cmd run typecheck`
- `npm.cmd run verify:design-system`
- `npm.cmd run verify:docs`
- `npm.cmd run verify:cache`
- `git diff --check`

## Scope

No page layout, modal behavior, saved-lead behavior, backend/API, or SEC URL source generation changed.
