### PR TITLE
fix(vault): prevent repeated unlock prompts

### DIFF
--- a/hushh-webapp/__tests__/utils/vault-access-policy.test.ts
+++ b/hushh-webapp/__tests__/utils/vault-access-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  resolveLockState,
   resolveVaultAvailabilityState,
   resolveVaultCapabilityState,
 } from "@/lib/vault/vault-access-policy";
@@ -53,6 +54,45 @@ describe("vault access policy", () => {
       vaultUnknown: false,
       needsVaultCreation: true,
       needsUnlock: false,
+    });
+  });
+
+  it("keeps an unresolved presence read in loading instead of setup", () => {
+    expect(
+      resolveLockState({
+        hasVault: null,
+        isVaultUnlocked: false,
+        vaultKey: null,
+        vaultOwnerToken: null,
+      }),
+    ).toBe("loading");
+
+    expect(
+      resolveVaultAvailabilityState({
+        hasVault: null,
+        isVaultUnlocked: false,
+      }),
+    ).toMatchObject({
+      state: "loading",
+      vaultUnknown: true,
+      needsVaultCreation: false,
+      needsUnlock: false,
+      vaultCheckFailed: false,
+    });
+  });
+
+  it("keeps a failed presence read out of both setup and unlock prompts", () => {
+    expect(
+      resolveVaultAvailabilityState({
+        hasVault: false,
+        isVaultUnlocked: false,
+        presenceFailed: true,
+      }),
+    ).toMatchObject({
+      state: "error",
+      needsVaultCreation: false,
+      needsUnlock: false,
+      vaultCheckFailed: true,
     });
   });
 });

--- a/hushh-webapp/app/one/consent/layout.tsx
+++ b/hushh-webapp/app/one/consent/layout.tsx
@@ -1,12 +1,5 @@
 import type { ReactNode } from "react";
 
-import { PhoneMandateGuard } from "@/components/auth/phone-mandate-guard";
-import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
-
 export default function OneConsentLayout({ children }: { children: ReactNode }) {
-  return (
-    <VaultLockGuard>
-      <PhoneMandateGuard>{children}</PhoneMandateGuard>
-    </VaultLockGuard>
-  );
+  return <>{children}</>;
 }

--- a/hushh-webapp/app/one/kyc/page.tsx
+++ b/hushh-webapp/app/one/kyc/page.tsx
@@ -40,7 +40,6 @@ import { AsyncActionStatus } from "@/components/system/async-action-status";
 import { CapabilityExploreCard } from "@/components/onboarding/setup/capability-explore-card";
 import { PkmSectionPreview } from "@/components/profile/pkm-section-preview";
 import { KycIdentityPreface } from "@/components/onboarding/setup/kyc-identity-preface";
-import { CapabilityVaultPrerequisite } from "@/components/vault/capability-vault-prerequisite";
 import {
   isKycIdentityPrefaceComplete,
 } from "@/lib/services/kyc-identity-profile-pkm-service";
@@ -59,7 +58,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
 import { useAuth, useRequireAuth } from "@/hooks/use-auth";
 import { isApplePrivateRelayEmail } from "@/lib/auth/private-relay";
 import {
@@ -371,17 +369,10 @@ export default function OneKycPage({
         }
         dataState={auth.user ? "loaded" : "loading"}
       />
-      <VaultLockGuard>
-        <CapabilityVaultPrerequisite
-          capabilityLabel="KYC"
-          routeKey={ROUTES.ONE_KYC}
-        >
-          <OneKycWorkspace
-            onSetupReadinessChange={onSetupReadinessChange}
-            voicePublisherRole={voicePublisherRole}
-          />
-        </CapabilityVaultPrerequisite>
-      </VaultLockGuard>
+      <OneKycWorkspace
+        onSetupReadinessChange={onSetupReadinessChange}
+        voicePublisherRole={voicePublisherRole}
+      />
     </>
   );
 }

--- a/hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx
+++ b/hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx
@@ -328,6 +328,7 @@ export default function PkmAgentLabPageClient() {
   const { user, loading } = useAuth();
   const { isVaultUnlocked, vaultKey, vaultOwnerToken } = useVault();
   const [hasVault, setHasVault] = useState<boolean | null>(null);
+  const [vaultCheckFailed, setVaultCheckFailed] = useState(false);
   const vaultCapability = useMemo(
     () =>
       resolveVaultCapabilityState({
@@ -344,8 +345,17 @@ export default function PkmAgentLabPageClient() {
         isVaultUnlocked,
         vaultKey,
         vaultOwnerToken,
+        authLoading: loading,
+        presenceFailed: vaultCheckFailed,
       }),
-    [hasVault, isVaultUnlocked, vaultKey, vaultOwnerToken]
+    [
+      hasVault,
+      isVaultUnlocked,
+      loading,
+      vaultCheckFailed,
+      vaultKey,
+      vaultOwnerToken,
+    ]
   );
   const environment = resolveAppEnvironment();
   const nonProdLabel = environment === "uat" ? "UAT" : "development";
@@ -403,11 +413,14 @@ export default function PkmAgentLabPageClient() {
         const nextHasVault = await VaultService.checkVault(user.uid);
         if (!cancelled) {
           setHasVault(nextHasVault);
+          setVaultCheckFailed(false);
         }
       } catch (nextError) {
         console.warn("[PkmAgentLab] Failed to check vault existence:", nextError);
         if (!cancelled) {
-          setHasVault(false);
+          // A failed read is not an absent vault. Never offer to create a
+          // second vault because the presence request temporarily failed.
+          setVaultCheckFailed(true);
         }
       }
     }

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -631,6 +631,7 @@ function ProfilePageContent() {
     mode: "push" | "replace";
   } | null>(null);
   const [hasVault, setHasVault] = useState<boolean | null>(null);
+  const [vaultCheckFailed, setVaultCheckFailed] = useState(false);
   const [showVaultCreation, setShowVaultCreation] = useState(false);
   const [pkmMetadata, setPkmMetadata] =
     useState<PersonalKnowledgeModelMetadata | null>(null);
@@ -860,8 +861,17 @@ function ProfilePageContent() {
         isVaultUnlocked,
         vaultKey,
         vaultOwnerToken,
+        authLoading,
+        presenceFailed: vaultCheckFailed,
       }),
-    [hasVault, isVaultUnlocked, vaultKey, vaultOwnerToken],
+    [
+      authLoading,
+      hasVault,
+      isVaultUnlocked,
+      vaultCheckFailed,
+      vaultKey,
+      vaultOwnerToken,
+    ],
   );
   const routeBlockedByVault =
     hasVault === true &&
@@ -1068,10 +1078,15 @@ function ProfilePageContent() {
       if (!user?.uid) return;
       try {
         const next = await VaultService.checkVault(user.uid);
-        if (!cancelled) setHasVault(next);
+        if (!cancelled) {
+          setHasVault(next);
+          setVaultCheckFailed(false);
+        }
       } catch (error) {
         console.warn("[ProfilePage] Failed to check vault existence:", error);
-        if (!cancelled) setHasVault(false);
+        // A failed read is not an absent vault. Treating it as false opens the
+        // creation flow for users who already have a vault.
+        if (!cancelled) setVaultCheckFailed(true);
       }
     }
 

--- a/hushh-webapp/components/app-ui/vault-status-inline.tsx
+++ b/hushh-webapp/components/app-ui/vault-status-inline.tsx
@@ -34,20 +34,18 @@ export function VaultStatusInline({
   const { isVaultUnlocked, vaultKey, vaultOwnerToken } = useVault();
   const [hasVault, setHasVault] = useState<boolean | null>(null);
   const [checkFailed, setCheckFailed] = useState(false);
+  const userId = user?.uid;
 
   useEffect(() => {
-    // No user is not "no lock". Firebase restores a session from disk on every
-    // load, so `user` is null for the whole of that window — and answering
-    // `false` there rendered "Lock required" at somebody who is signed in and
-    // holds a lock. Unknown stays unknown until an identity exists.
-    if (!user) {
+    if (!userId) {
+      // Auth restoration is not proof that the account has no vault.
       setHasVault(null);
       setCheckFailed(false);
       return;
     }
     let isMounted = true;
     setCheckFailed(false);
-    VaultService.checkVault(user.uid)
+    VaultService.checkVault(userId)
       .then((exists) => {
         if (isMounted) setHasVault(exists);
       })
@@ -61,7 +59,7 @@ export function VaultStatusInline({
     return () => {
       isMounted = false;
     };
-  }, [user]);
+  }, [authLoading, userId]);
 
   const availability = resolveVaultAvailabilityState({
     hasVault,
@@ -130,6 +128,21 @@ export function VaultStatusInline({
       >
         <Lock className="h-3.5 w-3.5 shrink-0" />
         Couldn&apos;t check your lock
+      </p>
+    );
+  }
+
+  if (availability.vaultCheckFailed) {
+    return (
+      <p
+        className={cn(
+          "type-footnote flex items-center gap-1.5 text-muted-foreground",
+          mode === "blocking" && "text-amber-700 dark:text-amber-400",
+          className,
+        )}
+      >
+        <Lock className="h-3.5 w-3.5 shrink-0" />
+        Couldn&apos;t check vault status
       </p>
     );
   }


### PR DESCRIPTION
## Summary
- remove duplicate vault lock guards from One consent and KYC surfaces; OneAuthGate remains the canonical app-wide guard
- preserve unknown and failed vault-presence reads instead of treating them as vault absence
- keep same-session Next.js navigation on the in-memory unlock state and avoid repeated credential prompts

## Verification
- npm.cmd run test -- --run __tests__/utils/vault-access-policy.test.ts __tests__/app/one/one-auth-gate.test.tsx __tests__/components/vault-lock-guard.test.tsx __tests__/components/vault-unlock-dialog.test.tsx
- npm.cmd run typecheck
- npm.cmd run lint
- npm.cmd run build
- git diff --cached --check

Signed-off-by: Parth Mawai <parth.mawai.12@gmail.com>

## Related Issues
Fixes #6046
Resolves #6183
