### PR TITLE
fix(ria): align selector with page hierarchy

### DIFF
--- a/hushh-webapp/__tests__/app/ria/clients-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/clients-page.test.tsx
@@ -8,6 +8,7 @@ const { push } = vi.hoisted(() => ({
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push }),
+  usePathname: () => "/ria/clients",
 }));
 
 vi.mock("@/hooks/use-auth", () => ({
@@ -38,9 +39,15 @@ vi.mock("@/lib/voice/voice-surface-metadata", () => ({
 }));
 
 vi.mock("@/components/app-ui/app-page-shell", () => ({
-  AppPageShell: ({ children }: { children?: React.ReactNode }) => <main>{children}</main>,
-  AppPageHeaderRegion: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  AppPageContentRegion: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  AppPageShell: ({ children }: { children?: React.ReactNode }) => (
+    <main>{children}</main>
+  ),
+  AppPageHeaderRegion: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AppPageContentRegion: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
 }));
 
 vi.mock("@/components/app-ui/page-sections", () => ({
@@ -59,7 +66,9 @@ vi.mock("@/components/app-ui/page-sections", () => ({
 }));
 
 vi.mock("@/components/app-ui/surfaces", () => ({
-  SurfaceStack: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  SurfaceStack: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
 }));
 
 vi.mock("@/components/profile/settings-ui", () => ({
@@ -104,7 +113,9 @@ vi.mock("@/components/profile/settings-ui", () => ({
 
 vi.mock("@/components/ria/ria-page-shell", () => ({
   RiaCompatibilityState: ({ title }: { title: string }) => <div>{title}</div>,
-  RiaVerificationGate: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  RiaVerificationGate: ({ children }: { children?: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 vi.mock("@/components/ria/nearby/nearby-around-you", () => ({
@@ -117,15 +128,11 @@ describe("RIA Clients page", () => {
   it("keeps the workspace summary visible when switching to Around You", () => {
     render(<RiaClientsPage />);
 
-    expect(
-      screen.getByText(/One workspace per client/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/One workspace per client/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Around you/i }));
 
-    expect(
-      screen.getByText(/One workspace per client/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/One workspace per client/i)).toBeInTheDocument();
     expect(screen.getByText("Nearby records pane")).toBeInTheDocument();
     expect(push).not.toHaveBeenCalled();
   });

--- a/hushh-webapp/__tests__/app/ria/header-regression.contract.test.ts
+++ b/hushh-webapp/__tests__/app/ria/header-regression.contract.test.ts
@@ -28,7 +28,9 @@ describe("RIA shared header regression contract", () => {
   });
 
   it("keeps the consent workspace on the shared page header", () => {
-    const consentCenterPage = read("components/consent/consent-center-page.tsx");
+    const consentCenterPage = read(
+      "components/consent/consent-center-page.tsx",
+    );
 
     expect(consentCenterPage).toContain("AppPageShell");
     expect(consentCenterPage).toContain("SettingsDetailPanel");
@@ -45,7 +47,7 @@ describe("RIA shared header regression contract", () => {
     expect(globals).toContain("--ria-selected-tint: var(--app-accent-surface)");
   });
 
-  it("gives RiaPageShell an \"agent\"-width default, not the wider \"standard\"", () => {
+  it('gives RiaPageShell an "agent"-width default, not the wider "standard"', () => {
     // The one place this now needs to be right: every caller that does not
     // pass its own `width` -- Profile, the client account/request detail
     // pages, RiaClientWorkspace, and the Marketplace RIA public profile --
@@ -64,7 +66,7 @@ describe("RIA shared header regression contract", () => {
     expect(riaPicks).toContain("SurfaceCard");
     expect(riaPicks).toContain('tableClassName="w-full min-w-[640px]"');
     expect(riaPicks).toContain('tableClassName="w-full min-w-[700px]"');
-    expect(riaPicks).toContain("density=\"compact\"");
+    expect(riaPicks).toContain('density="compact"');
     expect(riaPicks).toContain("stickyHeader");
   });
 
@@ -83,11 +85,42 @@ describe("RIA shared header regression contract", () => {
     expect(riaPicks).not.toContain('width="standard"');
     expect(riaClients).not.toContain('width="expanded"');
     expect(riaPicks).not.toContain('width="expanded"');
-    expect(riaClients).toContain('<AppPageHeaderRegion className="pt-2 sm:pt-3">');
-    expect(riaPicks).toContain('<AppPageHeaderRegion className="pt-2 sm:pt-3">');
+    expect(riaClients).toContain(
+      '<AppPageHeaderRegion className="pt-2 sm:pt-3">',
+    );
+    expect(riaPicks).toContain(
+      '<AppPageHeaderRegion className="pt-2 sm:pt-3">',
+    );
     expect(riaClients).toContain("<SurfaceStack");
     expect(riaClients).toContain('className="gap-8"');
     expect(riaPicks).toContain("<SurfaceStack");
     expect(riaPicks).toContain('className="gap-6"');
+  });
+
+  it("renders the shared RIA route selector after each primary page header", () => {
+    const riaProfile = read("app/ria/profile/page.tsx");
+    const riaClients = read("app/ria/clients/page.tsx");
+    const riaPicks = read("app/ria/picks/page.tsx");
+    const riaShell = read("components/ria/ria-page-shell.tsx");
+    const topShellTabs = read("lib/navigation/top-shell-tabs.ts");
+    const providers = read("app/providers.tsx");
+
+    for (const source of [riaProfile, riaClients, riaPicks]) {
+      expect(source).toContain("RiaRouteSelector");
+    }
+    expect(
+      riaShell.indexOf("<AppPageHeaderRegion") <
+        riaShell.indexOf("<AppPageContentRegion"),
+    ).toBe(true);
+    expect(
+      riaClients.indexOf("<PageHeader") <
+        riaClients.indexOf("<RiaRouteSelector"),
+    ).toBe(true);
+    expect(
+      riaPicks.indexOf("<PageHeader") < riaPicks.indexOf("<RiaRouteSelector"),
+    ).toBe(true);
+
+    expect(topShellTabs).toContain("export function resolveRiaRouteTabSet");
+    expect(providers).toContain("resolveRiaRouteTabSet(");
   });
 });

--- a/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -321,8 +327,15 @@ vi.mock("lucide-react", () => {
 });
 
 vi.mock("@/lib/navigation/routes", () => ({
+  buildKaiMarketRoute: (tab?: string) =>
+    tab ? `/one/kai/market?tab=${tab}` : "/one/kai/market",
+  KAI_MARKET_PATH: "/one/kai/market",
   ROUTES: {
     RIA_ONBOARDING: "/ria/onboarding",
+    ONE: "/one",
+    ONE_PROFILE: "/one/profile",
+    ONE_CONSENT: "/one/consent",
+    WELCOME: "/",
   },
 }));
 

--- a/hushh-webapp/__tests__/components/ria-route-selector.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-route-selector.test.tsx
@@ -1,0 +1,66 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RiaRouteSelector } from "@/components/ria/layout/ria-route-selector";
+
+const navigation = vi.hoisted(() => ({
+  begin: vi.fn(),
+  pathname: "/ria/profile",
+  push: vi.fn(),
+  replace: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => navigation.pathname,
+  useRouter: () => ({
+    push: navigation.push,
+    replace: navigation.replace,
+  }),
+}));
+
+vi.mock("@/lib/interaction/interaction-intent-coordinator", () => ({
+  useInteractionIntents: () => [],
+}));
+
+vi.mock("@/lib/morphy-ux/hooks/use-route-transition", () => ({
+  beginRouteTransition: navigation.begin,
+}));
+
+describe("RiaRouteSelector", () => {
+  beforeEach(() => {
+    navigation.begin.mockClear();
+    navigation.push.mockClear();
+    navigation.replace.mockClear();
+    navigation.pathname = "/ria/profile";
+  });
+
+  it("renders the RIA primary selector with route-driven active state", () => {
+    navigation.pathname = "/ria/picks";
+
+    render(<RiaRouteSelector />);
+
+    expect(
+      screen.getByRole("tablist", { name: "RIA workspace navigation" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Profile" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Clients" })).toBeTruthy();
+    expect(
+      screen.getByRole("tab", { name: "Picks" }).getAttribute("aria-selected"),
+    ).toBe("true");
+  });
+
+  it("navigates through the shared route tab contract", () => {
+    render(<RiaRouteSelector />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Clients" }));
+
+    expect(navigation.begin).toHaveBeenCalledWith(
+      "/ria/clients",
+      expect.any(Function),
+      "tap",
+      "full",
+    );
+  });
+});

--- a/hushh-webapp/__tests__/navigation/top-shell-tabs.test.ts
+++ b/hushh-webapp/__tests__/navigation/top-shell-tabs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   resolvePublicKnowledgeTopShellTabSet,
+  resolveRiaRouteTabSet,
   resolveTopShellTabSet,
 } from "@/lib/navigation/top-shell-tabs";
 import { resolveTopShellRouteProfile } from "@/components/app-ui/top-shell-metrics";
@@ -66,27 +67,31 @@ describe("top shell contextual tabs", () => {
     });
   });
 
-  it("renders RIA workspace tabs through the same fixed top shell", () => {
-    expect(resolveTopShellTabSet("/ria")).toMatchObject({
+  it("keeps RIA workspace tabs below the page header instead of in the fixed top shell", () => {
+    expect(resolveTopShellTabSet("/ria")).toBeNull();
+    expect(resolveTopShellTabSet("/ria/profile")).toBeNull();
+    expect(resolveTopShellTabSet("/ria/clients")).toBeNull();
+    expect(resolveTopShellTabSet("/ria/picks")).toBeNull();
+    expect(resolveTopShellRouteProfile("/ria/clients").model).toMatchObject({
+      mode: "bar",
+    });
+
+    expect(resolveRiaRouteTabSet("/ria")).toMatchObject({
       id: "ria",
       label: "RIA workspace",
       activeValue: "profile",
     });
-    expect(resolveTopShellTabSet("/ria/profile")).toMatchObject({
+    expect(resolveRiaRouteTabSet("/ria/profile")).toMatchObject({
       id: "ria",
       activeValue: "profile",
     });
-    expect(resolveTopShellTabSet("/ria/clients")).toMatchObject({
+    expect(resolveRiaRouteTabSet("/ria/clients")).toMatchObject({
       id: "ria",
       activeValue: "clients",
     });
-    expect(resolveTopShellTabSet("/ria/picks")).toMatchObject({
+    expect(resolveRiaRouteTabSet("/ria/picks")).toMatchObject({
       id: "ria",
       activeValue: "picks",
-    });
-    expect(resolveTopShellRouteProfile("/ria/clients").model).toMatchObject({
-      mode: "bar-with-tabs",
-      tabs: { id: "ria", activeValue: "clients" },
     });
   });
 
@@ -165,7 +170,7 @@ describe("top shell contextual tabs", () => {
     ["/one/location?view=people", "bar"],
     ["/one/kai?tab=analysis", "bar-with-tabs"],
     ["/one/consent?tab=history", "bar-with-tabs"],
-    ["/ria/picks", "bar-with-tabs"],
+    ["/ria/picks", "bar"],
   ] as const)("resolves %s as %s", (routeKey, expectedMode) => {
     const profile = resolveTopShellRouteProfile(routeKey);
     expect(profile.model.mode).toBe(expectedMode);

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -35,6 +35,7 @@ import { AgentVoiceEdgeGlow } from "@/components/agent/agent-voice-edge-glow";
 import { FoundationPublicAmbient } from "@/components/app-ui/foundation-public-ambient";
 import { AppBottomShell } from "@/components/app-ui/app-bottom-shell";
 import { AmbientChromeController } from "@/components/app-ui/ambient-chrome-mask";
+import { resolveRiaRouteTabSet } from "@/lib/navigation/top-shell-tabs";
 import { Toaster } from "@/components/ui/sonner";
 import { StatusBarManager } from "@/components/status-bar-manager";
 import { KeyboardInsetManager } from "@/components/keyboard-inset-manager";
@@ -172,7 +173,8 @@ function AppShellFrame({ children }: ProvidersProps) {
     isFocusedConnectCircleTask(
       searchParams?.get("tab") ?? null,
       searchParams?.get("action") ?? null,
-      searchParams?.get("circleId") ?? null,    );
+      searchParams?.get("circleId") ?? null,
+    );
   // Focused query-scoped Location flows clear the bottom command/navigation
   // stack while keeping the top shell route context.
   const bottomChromeHidden =
@@ -190,12 +192,20 @@ function AppShellFrame({ children }: ProvidersProps) {
     );
   }, [searchParams, shellPathname]);
   const topShellModel = topShellRouteProfile.model;
-  const routeSwipeTabSet =
-    topShellModel.mode === "bar-with-tabs" &&
-    (topShellModel.tabs.queryParam === null ||
-      topShellModel.tabs.id === "consent")
-      ? topShellModel.tabs
-      : null;
+  const routeSwipeTabSet = useMemo(() => {
+    if (
+      topShellModel.mode === "bar-with-tabs" &&
+      (topShellModel.tabs.queryParam === null ||
+        topShellModel.tabs.id === "consent")
+    ) {
+      return topShellModel.tabs;
+    }
+
+    const query = searchParams?.toString() ?? "";
+    return resolveRiaRouteTabSet(
+      query ? `${shellPathname}?${query}` : shellPathname,
+    );
+  }, [searchParams, shellPathname, topShellModel]);
   const topShellMetrics = useMemo(
     () => ({
       shellVisible: topShellModel.mode !== "hidden",
@@ -306,13 +316,11 @@ function AppShellFrame({ children }: ProvidersProps) {
   const foundationVoiceOnlyChrome = isFoundationRoute;
   // RIA and Foundation both use a persistent-but-pinned lower utility. Keep
   // the scroll-hide driver for ordinary signed-in navigation only.
-  const pinnedBottomChrome =
-    isRiaRoute(pathname) || foundationVoiceOnlyChrome;
+  const pinnedBottomChrome = isRiaRoute(pathname) || foundationVoiceOnlyChrome;
   const bottomShellModel = {
     ambientEnabled:
       ambientChromeEnabled && !isFullscreenTopFlow && !bottomChromeHidden,
-    navigationHidden:
-      effectiveHideCommandBar || foundationVoiceOnlyChrome,
+    navigationHidden: effectiveHideCommandBar || foundationVoiceOnlyChrome,
     hidden: bottomChromeHidden,
   };
   // Drive the bottom-chrome hide animation through a CSS variable instead of a

--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -17,6 +17,7 @@ import {
   getKaiTestUserId,
   isKaiTestProfileUser,
 } from "@/components/ria/ria-client-test-profile";
+import { RiaRouteSelector } from "@/components/ria/layout/ria-route-selector";
 import { NearbyAroundYou } from "@/components/ria/nearby/nearby-around-you";
 import { SettingsGroup, SegmentedTabs } from "@/components/profile/settings-ui";
 import { Badge } from "@/components/ui/badge";
@@ -36,7 +37,10 @@ import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metada
 import { RIA_TONE_BADGE } from "@/lib/ria/ria-tone";
 import { RIA_COPY } from "@/lib/ria/ria-screen-copy";
 import { cn } from "@/lib/utils";
-import { RiaCompatibilityState, RiaVerificationGate } from "@/components/ria/ria-page-shell";
+import {
+  RiaCompatibilityState,
+  RiaVerificationGate,
+} from "@/components/ria/ria-page-shell";
 
 type ClientListItem = RiaClientAccess & {
   isTestProfile?: boolean;
@@ -72,44 +76,58 @@ export default function RiaClientsPage() {
   const [view, setView] = useState<ClientsView>("connected");
 
   const clientsResource = useStaleResource<RiaClientListResponse>({
-    cacheKey: user?.uid ? `ria_clients_connected_${user.uid}` : "ria_clients_guest",
+    cacheKey: user?.uid
+      ? `ria_clients_connected_${user.uid}`
+      : "ria_clients_guest",
     enabled: Boolean(user?.uid && riaCapability !== "setup"),
     load: async () => {
       if (!user?.uid) throw new Error("Sign in to access clients");
       const idToken = await user.getIdToken();
-      return RiaService.listClients(idToken, { userId: user.uid, page: 1, limit: 100 });
+      return RiaService.listClients(idToken, {
+        userId: user.uid,
+        page: 1,
+        limit: 100,
+      });
     },
   });
 
   const connectedClients = useMemo(
-    () => (clientsResource.data?.items || []).filter((client) => client.status === "approved"),
-    [clientsResource.data?.items]
+    () =>
+      (clientsResource.data?.items || []).filter(
+        (client) => client.status === "approved",
+      ),
+    [clientsResource.data?.items],
   );
 
   const injectedTestClient = useMemo<ClientListItem | null>(() => {
     if (!allowTestProfiles || !kaiTestUserId) return null;
-    if (connectedClients.some((client) => client.investor_user_id === kaiTestUserId)) return null;
+    if (
+      connectedClients.some(
+        (client) => client.investor_user_id === kaiTestUserId,
+      )
+    )
+      return null;
     return {
       ...buildKaiTestClientAccess(kaiTestUserId),
       isTestProfile: true,
     };
   }, [allowTestProfiles, connectedClients, kaiTestUserId]);
 
-  const clientItems = useMemo<ClientListItem[]>(
-    () => {
-      const normalizedClients = connectedClients.map((client) => ({
-        ...client,
-        isTestProfile: isKaiTestProfileUser(client.investor_user_id),
-      }));
-      return injectedTestClient ? [injectedTestClient, ...normalizedClients] : normalizedClients;
-    },
-    [connectedClients, injectedTestClient]
-  );
+  const clientItems = useMemo<ClientListItem[]>(() => {
+    const normalizedClients = connectedClients.map((client) => ({
+      ...client,
+      isTestProfile: isKaiTestProfileUser(client.investor_user_id),
+    }));
+    return injectedTestClient
+      ? [injectedTestClient, ...normalizedClients]
+      : normalizedClients;
+  }, [connectedClients, injectedTestClient]);
   const voiceSurfaceMetadata = useMemo(
     () => ({
       screenId: "ria_clients",
       title: "RIA Clients",
-      purpose: "Connected investor roster for opening advisor client workspaces.",
+      purpose:
+        "Connected investor roster for opening advisor client workspaces.",
       sections: [
         {
           id: "ria_clients_roster",
@@ -132,7 +150,8 @@ export default function RiaClientsPage() {
         },
         ...clientItems.slice(0, 8).map((client, index) => ({
           id: `ria_clients_client_row_${index + 1}`,
-          label: client.investor_display_name || client.investor_email || "Investor",
+          label:
+            client.investor_display_name || client.investor_email || "Investor",
           type: "button",
           actionId: "ria.clients.open_client_workspace",
           description: client.investor_user_id || null,
@@ -142,14 +161,19 @@ export default function RiaClientsPage() {
       visibleModules: ["Connected investors"],
       selectedObjects: clientItems
         .slice(0, 8)
-        .map((client) => client.investor_display_name || client.investor_email || client.investor_user_id)
+        .map(
+          (client) =>
+            client.investor_display_name ||
+            client.investor_email ||
+            client.investor_user_id,
+        )
         .filter((value): value is string => Boolean(value)),
       screenMetadata: {
         connected_client_count: clientItems.length,
         loading: clientsResource.loading,
       },
     }),
-    [clientItems, clientsResource.loading]
+    [clientItems, clientsResource.loading],
   );
   usePublishVoiceSurfaceMetadata(voiceSurfaceMetadata);
 
@@ -221,102 +245,126 @@ export default function RiaClientsPage() {
       </AppPageHeaderRegion>
 
       <AppPageContentRegion>
-        <RiaVerificationGate>
         <SurfaceStack className="gap-8">
-          {/* Connected is the roster of investors who already granted access.
+          <RiaRouteSelector />
+
+          <RiaVerificationGate>
+            {/* Connected is the roster of investors who already granted access.
               Around you is prospecting against public records — a different
               kind of person entirely, which is why they are separate views on
               one screen rather than one merged list. */}
-          <div data-voice-control-id="ria_clients_view_switch">
-            <SegmentedTabs
-              value={view}
-              onValueChange={(next) => setView(next as ClientsView)}
-              options={[
-                { value: "connected", label: "Connected" },
-                { value: "nearby", label: "Around you" },
-              ]}
-            />
-          </div>
+            <div data-voice-control-id="ria_clients_view_switch">
+              <SegmentedTabs
+                value={view}
+                onValueChange={(next) => setView(next as ClientsView)}
+                options={[
+                  { value: "connected", label: "Connected" },
+                  { value: "nearby", label: "Around you" },
+                ]}
+              />
+            </div>
 
-          {view === "nearby" ? (
-            <NearbyAroundYou />
-          ) : (
-          <SettingsGroup
-            embedded
-            title={RIA_COPY.clients.section.title}
-            description={RIA_COPY.clients.section.description}
-          >
-            {clientsResource.loading ? (
-              <div className="flex items-center gap-2 px-4 py-6 text-sm text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                {RIA_COPY.clients.loading}
-              </div>
-            ) : clientItems.length === 0 ? (
-              <div className="space-y-3 px-4 py-8 text-center">
-                <p className="text-sm text-muted-foreground">{RIA_COPY.clients.empty}</p>
-                <Button
-                  variant="none"
-                  effect="fade"
-                  size="sm"
-                  data-voice-control-id="ria_clients_browse_marketplace"
-                  onClick={() => router.push(ROUTES.MARKETPLACE)}
-                >
-                  {RIA_COPY.clients.browse}
-                </Button>
-              </div>
+            {view === "nearby" ? (
+              <NearbyAroundYou />
             ) : (
-              clientItems.map((client, index) => (
-                <button
-                  key={client.id}
-                  type="button"
-                  data-voice-control-id={`ria_clients_client_row_${index + 1}`}
-                  data-testid={client.isTestProfile ? "ria-client-test-profile" : undefined}
-                  onClick={() =>
-                    router.push(
-                      buildRiaClientWorkspaceRoute(client.investor_user_id || "", {
-                        tab: "overview",
-                        testProfile: client.isTestProfile,
-                      })
-                    )
-                  }
-                  className={cn(
-                    "relative w-full overflow-hidden px-4 py-3 text-left transition-colors hover:bg-muted/35"
-                  )}
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[color:var(--foundation-accent-surface)] text-[color:var(--ria-gold)]">
-                      <UserRound className="h-4 w-4" />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex min-w-0 items-center gap-2">
-                        <p className="truncate text-sm font-semibold text-foreground">
-                          {client.investor_display_name || client.investor_user_id || "Investor"}
-                        </p>
-                        {client.isTestProfile ? (
-                          <span className="shrink-0 rounded-full border border-[color:var(--foundation-accent-border)] bg-[color:var(--foundation-accent-surface)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--ria-gold)]">
-                            Test
-                          </span>
-                        ) : null}
-                      </div>
-                      <p className="truncate text-xs text-muted-foreground">
-                        {client.investor_email || client.investor_secondary_label || "Connected"}
-                      </p>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-2">
-                      <Badge className={cn("text-[10px]", statusBadgeClass(client.status))}>
-                        {formatStatus(client.status)}
-                      </Badge>
-                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                    </div>
+              <SettingsGroup
+                embedded
+                title={RIA_COPY.clients.section.title}
+                description={RIA_COPY.clients.section.description}
+              >
+                {clientsResource.loading ? (
+                  <div className="flex items-center gap-2 px-4 py-6 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    {RIA_COPY.clients.loading}
                   </div>
-                  <MaterialRipple variant="none" effect="fade" className="z-0" />
-                </button>
-              ))
+                ) : clientItems.length === 0 ? (
+                  <div className="space-y-3 px-4 py-8 text-center">
+                    <p className="text-sm text-muted-foreground">
+                      {RIA_COPY.clients.empty}
+                    </p>
+                    <Button
+                      variant="none"
+                      effect="fade"
+                      size="sm"
+                      data-voice-control-id="ria_clients_browse_marketplace"
+                      onClick={() => router.push(ROUTES.MARKETPLACE)}
+                    >
+                      {RIA_COPY.clients.browse}
+                    </Button>
+                  </div>
+                ) : (
+                  clientItems.map((client, index) => (
+                    <button
+                      key={client.id}
+                      type="button"
+                      data-voice-control-id={`ria_clients_client_row_${index + 1}`}
+                      data-testid={
+                        client.isTestProfile
+                          ? "ria-client-test-profile"
+                          : undefined
+                      }
+                      onClick={() =>
+                        router.push(
+                          buildRiaClientWorkspaceRoute(
+                            client.investor_user_id || "",
+                            {
+                              tab: "overview",
+                              testProfile: client.isTestProfile,
+                            },
+                          ),
+                        )
+                      }
+                      className={cn(
+                        "relative w-full overflow-hidden px-4 py-3 text-left transition-colors hover:bg-muted/35",
+                      )}
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[color:var(--foundation-accent-surface)] text-[color:var(--ria-gold)]">
+                          <UserRound className="h-4 w-4" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <p className="truncate text-sm font-semibold text-foreground">
+                              {client.investor_display_name ||
+                                client.investor_user_id ||
+                                "Investor"}
+                            </p>
+                            {client.isTestProfile ? (
+                              <span className="shrink-0 rounded-full border border-[color:var(--foundation-accent-border)] bg-[color:var(--foundation-accent-surface)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--ria-gold)]">
+                                Test
+                              </span>
+                            ) : null}
+                          </div>
+                          <p className="truncate text-xs text-muted-foreground">
+                            {client.investor_email ||
+                              client.investor_secondary_label ||
+                              "Connected"}
+                          </p>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-2">
+                          <Badge
+                            className={cn(
+                              "text-[10px]",
+                              statusBadgeClass(client.status),
+                            )}
+                          >
+                            {formatStatus(client.status)}
+                          </Badge>
+                          <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                        </div>
+                      </div>
+                      <MaterialRipple
+                        variant="none"
+                        effect="fade"
+                        className="z-0"
+                      />
+                    </button>
+                  ))
+                )}
+              </SettingsGroup>
             )}
-          </SettingsGroup>
-          )}
+          </RiaVerificationGate>
         </SurfaceStack>
-        </RiaVerificationGate>
       </AppPageContentRegion>
     </AppPageShell>
   );

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -38,6 +38,7 @@ import {
   SurfaceInset,
   SurfaceStack,
 } from "@/components/app-ui/surfaces";
+import { RiaRouteSelector } from "@/components/ria/layout/ria-route-selector";
 import { SegmentedTabs } from "@/components/profile/settings-ui";
 import { RiaCompatibilityState } from "@/components/ria/ria-page-shell";
 import { TemplatePreviewModal } from "@/components/ria/template-preview-modal";
@@ -2719,6 +2720,8 @@ export default function RiaPicksPage() {
 
       <AppPageContentRegion>
         <SurfaceStack className="gap-6">
+          <RiaRouteSelector />
+
           <div data-testid="ria-picks-primary">
             <SegmentedTabs
               value={source}
@@ -2744,7 +2747,7 @@ export default function RiaPicksPage() {
             mobileColumns={2}
           />
 
-          {(
+          {
             <>
               {showMyListActionRail ? (
                 <SurfaceCard>
@@ -3235,7 +3238,7 @@ export default function RiaPicksPage() {
                 </div>
               ) : null}
             </>
-          )}
+          }
         </SurfaceStack>
       </AppPageContentRegion>
     </AppPageShell>

--- a/hushh-webapp/app/ria/profile/page.tsx
+++ b/hushh-webapp/app/ria/profile/page.tsx
@@ -3,11 +3,15 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { InlineLoadingState } from "@/components/app-ui/inline-loading-state";
+import { RiaRouteSelector } from "@/components/ria/layout/ria-route-selector";
 import { RiaProfileSection } from "@/components/ria/profile/ria-profile-section";
 import { RiaPageShell } from "@/components/ria/ria-page-shell";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
-import { RiaService, type RiaOnboardingStatus } from "@/lib/services/ria-service";
+import {
+  RiaService,
+  type RiaOnboardingStatus,
+} from "@/lib/services/ria-service";
 
 /**
  * Canonical RIA profile management surface. The profile is deliberately owned
@@ -63,16 +67,24 @@ export default function RiaProfilePage() {
       nativeTest={{
         routeId: "ria-profile",
         marker: "ria-profile-page",
-        authState: authLoading ? "pending" : user ? "authenticated" : "anonymous",
+        authState: authLoading
+          ? "pending"
+          : user
+            ? "authenticated"
+            : "anonymous",
         dataState: authLoading || loading ? "loading" : "loaded",
       }}
     >
+      <RiaRouteSelector />
+
       {authLoading || loading ? (
         <InlineLoadingState label="Loading profile…" />
       ) : loadError && !status ? (
         <div className="space-y-4 rounded-[22px] border border-[color:var(--border)] bg-[color:var(--card)] p-5">
           <div>
-            <p className="text-[16px] font-semibold">We couldn&apos;t load your profile</p>
+            <p className="text-[16px] font-semibold">
+              We couldn&apos;t load your profile
+            </p>
             <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
               Check your connection and try again.
             </p>

--- a/hushh-webapp/components/ria/layout/ria-route-selector.tsx
+++ b/hushh-webapp/components/ria/layout/ria-route-selector.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePathname } from "next/navigation";
+
+import { TopShellTabs } from "@/components/app-ui/top-shell-tabs";
+import {
+  resolveRiaRouteTabSet,
+  type TopShellTabSet,
+} from "@/lib/navigation/top-shell-tabs";
+import { cn } from "@/lib/utils";
+
+export function RiaRouteSelector({ className }: { className?: string }) {
+  const pathname = usePathname();
+  const tabSet = useMemo<TopShellTabSet | null>(
+    () => resolveRiaRouteTabSet(pathname || "/ria/profile"),
+    [pathname],
+  );
+
+  if (!tabSet) return null;
+
+  return (
+    <div data-testid="ria-route-selector" className={cn("w-full", className)}>
+      <TopShellTabs tabSet={tabSet} />
+    </div>
+  );
+}

--- a/hushh-webapp/lib/navigation/top-shell-tabs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-tabs.ts
@@ -228,7 +228,7 @@ function resolveSelection(
 
 /**
  * Resolves the one route-owned contextual tab group for the shared top shell.
- * Location and Connect are intentionally excluded here: their hubs render the
+ * Location, Connect, and RIA are intentionally excluded here: their hubs render the
  * same registered tabs directly under their module headers so the local module
  * hierarchy stays intact while retaining shared tab/swipe state.
  */
@@ -264,6 +264,12 @@ export function resolveTopShellTabSet(routeKey: string): TopShellTabSet | null {
     };
   }
 
+  return resolvePublicKnowledgeTopShellTabSet(routeKey);
+}
+
+export function resolveRiaRouteTabSet(routeKey: string): TopShellTabSet | null {
+  const { pathname } = splitRouteKey(routeKey);
+
   if (
     pathname === ROUTES.RIA_HOME ||
     pathname === ROUTES.RIA_PROFILE ||
@@ -279,7 +285,7 @@ export function resolveTopShellTabSet(routeKey: string): TopShellTabSet | null {
     };
   }
 
-  return resolvePublicKnowledgeTopShellTabSet(routeKey);
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- move the RIA Profile / Clients / Picks selector out of the fixed top app bar
- render the selector below each RIA page header and above page-local content
- preserve RIA route swipe navigation through the shared route tab resolver

## Validation
- npm.cmd test -- __tests__/app/ria/header-regression.contract.test.ts __tests__/navigation/top-shell-tabs.test.ts __tests__/components/ria-route-selector.test.tsx __tests__/components/top-shell-route-swipe.test.tsx __tests__/app/ria/clients-page.test.tsx __tests__/app/ria/picks-page.test.tsx
- npx.cmd --cache C:\Users\DIVYA\hushh-research\.npm-cache eslint app\providers.tsx app\ria\profile\page.tsx app\ria\clients\page.tsx app\ria\picks\page.tsx components\ria\layout\ria-route-selector.tsx lib\navigation\top-shell-tabs.ts __tests__\app\ria\header-regression.contract.test.ts __tests__\navigation\top-shell-tabs.test.ts __tests__\components\ria-route-selector.test.tsx __tests__\app\ria\clients-page.test.tsx __tests__\app\ria\picks-page.test.tsx --max-warnings=0
- npm.cmd run typecheck
- npm.cmd run verify:design-system
- npm.cmd run verify:docs
- npm.cmd run verify:cache
- git diff --check