### PR TITLE
fix(ria): simplify Profile header hierarchy

### DIFF
--- a/hushh-webapp/__tests__/app/ria/header-regression.contract.test.ts
+++ b/hushh-webapp/__tests__/app/ria/header-regression.contract.test.ts
@@ -28,7 +28,9 @@ describe("RIA shared header regression contract", () => {
   });
 
   it("keeps the consent workspace on the shared page header", () => {
-    const consentCenterPage = read("components/consent/consent-center-page.tsx");
+    const consentCenterPage = read(
+      "components/consent/consent-center-page.tsx",
+    );
 
     expect(consentCenterPage).toContain("AppPageShell");
     expect(consentCenterPage).toContain("SettingsDetailPanel");
@@ -45,7 +47,7 @@ describe("RIA shared header regression contract", () => {
     expect(globals).toContain("--ria-selected-tint: var(--app-accent-surface)");
   });
 
-  it("gives RiaPageShell an \"agent\"-width default, not the wider \"standard\"", () => {
+  it('gives RiaPageShell an "agent"-width default, not the wider "standard"', () => {
     // The one place this now needs to be right: every caller that does not
     // pass its own `width` -- Profile, the client account/request detail
     // pages, RiaClientWorkspace, and the Marketplace RIA public profile --
@@ -64,7 +66,7 @@ describe("RIA shared header regression contract", () => {
     expect(riaPicks).toContain("SurfaceCard");
     expect(riaPicks).toContain('tableClassName="w-full min-w-[640px]"');
     expect(riaPicks).toContain('tableClassName="w-full min-w-[700px]"');
-    expect(riaPicks).toContain("density=\"compact\"");
+    expect(riaPicks).toContain('density="compact"');
     expect(riaPicks).toContain("stickyHeader");
   });
 
@@ -83,11 +85,29 @@ describe("RIA shared header regression contract", () => {
     expect(riaPicks).not.toContain('width="standard"');
     expect(riaClients).not.toContain('width="expanded"');
     expect(riaPicks).not.toContain('width="expanded"');
-    expect(riaClients).toContain('<AppPageHeaderRegion className="pt-2 sm:pt-3">');
-    expect(riaPicks).toContain('<AppPageHeaderRegion className="pt-2 sm:pt-3">');
+    expect(riaClients).toContain(
+      '<AppPageHeaderRegion className="pt-2 sm:pt-3">',
+    );
+    expect(riaPicks).toContain(
+      '<AppPageHeaderRegion className="pt-2 sm:pt-3">',
+    );
     expect(riaClients).toContain("<SurfaceStack");
     expect(riaClients).toContain('className="gap-8"');
     expect(riaPicks).toContain("<SurfaceStack");
     expect(riaPicks).toContain('className="gap-6"');
+  });
+
+  it("omits the redundant RIA eyebrow from the Profile page header only", () => {
+    const riaProfile = read("app/ria/profile/page.tsx");
+    const riaClients = read("app/ria/clients/page.tsx");
+    const riaPicks = read("app/ria/picks/page.tsx");
+
+    expect(riaProfile).toContain('title="Profile"');
+    expect(riaProfile).toContain(
+      'description="Manage your advisor profile and verification details."',
+    );
+    expect(riaProfile).not.toContain('eyebrow="RIA"');
+    expect(riaClients).toContain("eyebrow={RIA_COPY.clients.eyebrow}");
+    expect(riaPicks).toContain("eyebrow={RIA_COPY.picks.eyebrow}");
   });
 });

--- a/hushh-webapp/app/ria/profile/page.tsx
+++ b/hushh-webapp/app/ria/profile/page.tsx
@@ -7,7 +7,10 @@ import { RiaProfileSection } from "@/components/ria/profile/ria-profile-section"
 import { RiaPageShell } from "@/components/ria/ria-page-shell";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
-import { RiaService, type RiaOnboardingStatus } from "@/lib/services/ria-service";
+import {
+  RiaService,
+  type RiaOnboardingStatus,
+} from "@/lib/services/ria-service";
 
 /**
  * Canonical RIA profile management surface. The profile is deliberately owned
@@ -56,14 +59,17 @@ export default function RiaProfilePage() {
 
   return (
     <RiaPageShell
-      eyebrow="RIA"
       title="Profile"
       description="Manage your advisor profile and verification details."
       titleRole="agent"
       nativeTest={{
         routeId: "ria-profile",
         marker: "ria-profile-page",
-        authState: authLoading ? "pending" : user ? "authenticated" : "anonymous",
+        authState: authLoading
+          ? "pending"
+          : user
+            ? "authenticated"
+            : "anonymous",
         dataState: authLoading || loading ? "loading" : "loaded",
       }}
     >
@@ -72,7 +78,9 @@ export default function RiaProfilePage() {
       ) : loadError && !status ? (
         <div className="space-y-4 rounded-[22px] border border-[color:var(--border)] bg-[color:var(--card)] p-5">
           <div>
-            <p className="text-[16px] font-semibold">We couldn&apos;t load your profile</p>
+            <p className="text-[16px] font-semibold">
+              We couldn&apos;t load your profile
+            </p>
             <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
               Check your connection and try again.
             </p>


### PR DESCRIPTION
## Summary
- remove the redundant RIA eyebrow from the RIA Profile page header
- keep the Profile title and description unchanged
- preserve Clients/Picks header context and existing RIA navigation behavior

## Localhost verification before push
- opened http://localhost:3000/ria/profile from the VS Code checkout
- route returned HTTP 200 after the local runtime picked up the edit
- desktop and mobile headless browser passes showed no horizontal overflow; authenticated header content is gated in this local session

## Validation
- npm.cmd test -- __tests__/app/ria/header-regression.contract.test.ts __tests__/app/ria/profile-page.test.tsx __tests__/components/ria/ria-profile-verification.test.tsx __tests__/components/ria/ria-profile-redirect-loop.test.tsx
- npx.cmd --cache C:\Users\DIVYA\hushh-research\.npm-cache eslint app\ria\profile\page.tsx __tests__\app\ria\header-regression.contract.test.ts --max-warnings=0
- npm.cmd run typecheck
- npm.cmd run verify:design-system
- npm.cmd run verify:docs
- npm.cmd run verify:cache
- git diff --check

## Note
- npm.cmd run verify:routes was attempted, but it requires maintainer-only REVIEWER_UID and REVIEWER_VAULT_PASSPHRASE values that are not present in this local environment.