### PR TITLE
fix(ria): remove redundant top breadcrumb

### DIFF
--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -993,6 +993,29 @@ describe("top shell breadcrumbs", () => {
     });
   });
 
+  it("keeps primary RIA pages on back-arrow-only top chrome", () => {
+    expect(resolveTopShellBreadcrumb("/ria/profile")).toEqual({
+      backHref: "/one",
+      width: "content",
+      align: "center",
+      items: [],
+    });
+
+    expect(resolveTopShellBreadcrumb("/ria/clients")).toEqual({
+      backHref: "/ria/profile",
+      width: "profile",
+      align: "center",
+      items: [],
+    });
+
+    expect(resolveTopShellBreadcrumb("/ria/picks")).toEqual({
+      backHref: "/ria/profile",
+      width: "content",
+      align: "center",
+      items: [],
+    });
+  });
+
   it("keeps bare Picks regardless of any ?view= value", () => {
     // Picks has no sub-view left to deepen into (the Debate config view was
     // removed as a duplicate of Screening), so every ?view= value -- known,
@@ -1001,11 +1024,7 @@ describe("top shell breadcrumbs", () => {
       backHref: "/ria/profile",
       width: "content" as const,
       align: "center" as const,
-      items: [
-        { label: "One", href: "/one" },
-        { label: "RIA", href: "/ria/profile" },
-        { label: "Picks" },
-      ],
+      items: [],
     };
 
     expect(resolveTopShellBreadcrumb("/ria/picks")).toEqual(barePicks);

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -483,11 +483,16 @@ function resolveTopShellBreadcrumbInner(
       backHref: ROUTES.ONE_HOME,
       width: "content",
       align: "center",
-      items: [
-        { label: "One", href: ROUTES.ONE_HOME },
-        { label: "RIA" },
-        { label: "Profile" },
-      ],
+      items: [],
+    };
+  }
+
+  if (pathname === ROUTES.RIA_PICKS) {
+    return {
+      backHref: ROUTES.RIA_PROFILE,
+      width: "content",
+      align: "center",
+      items: [],
     };
   }
 
@@ -638,7 +643,7 @@ function resolveTopShellBreadcrumbInner(
       backHref: ROUTES.RIA_PROFILE,
       width: "profile",
       align: "center",
-      items: [{ label: "RIA", href: ROUTES.RIA_PROFILE }, { label: "Clients" }],
+      items: [],
     };
   }
 


### PR DESCRIPTION
## Summary
- removes the redundant RIA breadcrumb trail beside the top-left back button on RIA Profile, Clients, and Picks
- preserves each route's existing back target and top-shell back affordance
- leaves nested RIA workspace breadcrumbs and all page content/selectors untouched

## Validation
- npm.cmd run typecheck
- npm.cmd run verify:design-system
- npm.cmd run verify:docs
- npm.cmd run verify:cache
- npm.cmd test -- __tests__/utils/top-shell-breadcrumbs.test.ts __tests__/components/top-app-bar.contract.test.ts __tests__/app/ria/header-regression.contract.test.ts __tests__/app/ria/profile-page.test.tsx __tests__/app/ria/clients-page.test.tsx __tests__/app/ria/picks-page.test.tsx
- npx.cmd --cache C:\Users\DIVYA\hushh-research\.npm-cache eslint lib\navigation\top-shell-breadcrumbs.ts __tests__\utils\top-shell-breadcrumbs.test.ts --max-warnings=0
- git diff --check

## Browser QA
- http://localhost:3001/ria/profile: back=1, breadcrumb trail=0
- http://localhost:3001/ria/clients: back=1, breadcrumb trail=0
- http://localhost:3001/ria/picks: back=1, breadcrumb trail=0
- checked at 1440x900, 1366x768, 440x956, 393x852, 375x812

## Note
- npm.cmd run verify:routes requires maintainer-only REVIEWER_UID and REVIEWER_VAULT_PASSPHRASE and was blocked in this local environment.