### PR TITLE
fix(ria): align advisor verification screen on iOS

### DIFF
--- a/hushh-webapp/__tests__/components/ria/onboarding-step-license-details.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/onboarding-step-license-details.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OnboardingShell } from "@/components/ria/onboarding/onboarding-shell";
+import { OnboardingStepLicenseDetails } from "@/components/ria/onboarding/onboarding-step-license-details";
+
+describe("RIA onboarding license details layout", () => {
+  it("renders the verification fields and lets long certifications wrap", () => {
+    render(
+      <OnboardingStepLicenseDetails
+        advisorName="Jane Advisor"
+        firmName="Northstar Wealth Studio"
+        regulator="SEC"
+        regulatorStatus="Not currently registered"
+        licenseExpiry=""
+        certifications={[
+          "Series 66 - Uniform Combined State Law Examination, Series 66",
+        ]}
+        city="Little Rock"
+        pinZip="72211"
+        crdNumber="123456"
+        onAdvisorNameChange={vi.fn()}
+        onCityChange={vi.fn()}
+        onPinZipChange={vi.fn()}
+        isEnriching={false}
+      />,
+    );
+
+    expect(screen.getByText("SEC - Not currently registered")).toBeTruthy();
+    expect(screen.getByDisplayValue("Jane Advisor")).toBeTruthy();
+    expect(screen.getByText("Northstar Wealth Studio")).toBeTruthy();
+    expect(screen.getByText("123456")).toBeTruthy();
+    expect(screen.getByDisplayValue("Little Rock")).toBeTruthy();
+    expect(screen.getByDisplayValue("72211")).toBeTruthy();
+
+    const certification = screen.getByText(
+      "Series 66 - Uniform Combined State Law Examination, Series 66",
+    );
+    expect(certification.className).toContain("whitespace-normal");
+    expect(certification.className).toContain("break-words");
+    expect(certification.className).not.toContain("whitespace-nowrap");
+  });
+
+  it("keeps the Continue action on the same full-width content grid", () => {
+    render(
+      <OnboardingShell
+        currentStepIndex={2}
+        totalSteps={5}
+        eyebrow="Verification"
+        title="Verify your details"
+        description="Prefilled - fix what's off."
+        canContinue
+        saving={false}
+        isFirstStep={false}
+        isLastStep={false}
+        advisoryAccessReady={false}
+        heroImage={{
+          src: "/ria/onboarding/verification.png",
+          variant: "accent",
+          badge: true,
+        }}
+        onBack={vi.fn()}
+        onContinue={vi.fn()}
+      >
+        <div>Verification details</div>
+      </OnboardingShell>,
+    );
+
+    expect(screen.getByRole("button", { name: "Go back to previous step" }))
+      .toBeTruthy();
+    expect(screen.getByText("Verification")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Verify your details" }))
+      .toBeTruthy();
+    expect(screen.getByText("Prefilled - fix what's off.")).toBeTruthy();
+
+    const continueButton = screen.getByRole("button", { name: "Continue" });
+    expect(continueButton).toBeTruthy();
+    expect(continueButton.parentElement?.className).toBe("w-full");
+  });
+});

--- a/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
@@ -64,7 +64,7 @@ export function OnboardingShell({
   const isAccent = heroImage?.variant === "accent";
   useScrollReset(currentStepIndex, { enabled: true });
   return (
-    <div className="mx-auto flex w-full max-w-[54rem] flex-col px-6 pb-[calc(var(--app-bottom-inset)+6rem)]">
+    <div className="mx-auto flex w-full max-w-[54rem] flex-col px-5 pb-[calc(var(--app-bottom-inset)+6rem)] sm:px-6">
       <div className="flex w-full flex-col">
         {/* Progress + step counter share one row (design has no back arrow —
             back/forward is by swipe within the pinned chrome). */}
@@ -136,13 +136,13 @@ export function OnboardingShell({
           className={cn(
             "space-y-2",
             isHero ? "mt-0" : "mt-[30px]",
-            isAccent && "relative min-h-[196px]",
+            isAccent && "relative min-h-[196px] overflow-visible",
           )}
         >
           {isAccent ? (
             <div
-              className="pointer-events-none absolute h-[214px] select-none"
-              style={{ right: "-8px", top: "-13px" }}
+              className="pointer-events-none absolute h-[190px] select-none sm:h-[214px]"
+              style={{ right: "0px", top: "-6px" }}
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
@@ -155,8 +155,8 @@ export function OnboardingShell({
                 <span
                   className="absolute flex flex-col items-center justify-center"
                   style={{
-                    right: "82px",
-                    top: "76px",
+                    right: "72px",
+                    top: "67px",
                     width: "62px",
                     height: "62px",
                     borderRadius: "50%",
@@ -186,12 +186,13 @@ export function OnboardingShell({
               ) : null}
             </div>
           ) : null}
-          <p className="ui-text-section-label mb-2 block px-[6px]">{eyebrow}</p>
+          <p className="ui-text-section-label mb-2 block">{eyebrow}</p>
           <h1
             className={cn(
               "ria-screen-title",
               isHero && "ria-screen-title--hero",
-              isAccent ? "max-w-[212px]" : "max-w-[18ch]", "text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+              isAccent ? "max-w-[212px]" : "max-w-[18ch]",
+              "text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
             )}
           >
             {title}
@@ -210,7 +211,7 @@ export function OnboardingShell({
 
         {!hideTerminal ? (
           <div className="mt-8 space-y-1 pb-[calc(var(--app-bottom-inset)+6rem)]">
-            <div className="mx-auto w-full sm:max-w-[22rem]">
+            <div className="w-full">
               <Button
                 type="button"
                 onClick={onContinue}

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-license-details.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-license-details.tsx
@@ -2,13 +2,11 @@
 
 import { Pencil, Shield } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 
 function EnrichingPlaceholder() {
   return <span className="h-5 w-28 animate-pulse rounded bg-muted/50" />;
 }
-
-
-
 
 function InfoRow({
   label,
@@ -23,17 +21,21 @@ function InfoRow({
 }) {
   return (
     <SettingsRow
-      title={<span className="whitespace-nowrap">{label}</span>}
+      stackTrailingOnMobile
+      title={<span>{label}</span>}
       trailing={
-        <span className={cn("text-[15px] font-medium text-foreground", numeric && "tabular-nums")}>
+        <span
+          className={cn(
+            "block w-full min-w-0 whitespace-normal break-words text-left text-[15px] font-medium leading-6 text-foreground sm:text-right",
+            numeric && "tabular-nums",
+          )}
+        >
           {loading ? <EnrichingPlaceholder /> : value?.trim() || "Not returned"}
         </span>
       }
     />
   );
 }
-
-import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 
 function EditableRow({
   label,
@@ -50,17 +52,21 @@ function EditableRow({
 }) {
   return (
     <SettingsRow
-      title={<span className="whitespace-nowrap">{label}</span>}
+      stackTrailingOnMobile
+      title={<span>{label}</span>}
       trailing={
         loading ? (
           <EnrichingPlaceholder />
         ) : (
-          <div className="flex items-center gap-2">
+          <div className="flex w-full min-w-0 items-center gap-2 sm:w-auto">
             <input
               type="text"
               value={value}
               onChange={(e) => onChange(e.target.value)}
-              className={cn("bg-transparent min-w-[120px] max-w-[200px] text-right text-[15px] outline-none text-foreground placeholder:text-muted-foreground", numeric && "tabular-nums")}
+              className={cn(
+                "min-w-0 flex-1 bg-transparent text-left text-[15px] leading-6 text-foreground outline-none placeholder:text-muted-foreground sm:min-w-[120px] sm:max-w-[200px] sm:text-right",
+                numeric && "tabular-nums",
+              )}
             />
             <Pencil className="h-4 w-4 shrink-0 text-muted-foreground" />
           </div>
@@ -107,14 +113,17 @@ export function OnboardingStepLicenseDetails({
       : "Regulator status pending";
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" data-testid="ria-license-details-grid">
       {/* Regulator shield card (full-width, replaces the old status pill). */}
-      <div className="flex items-center gap-3 rounded-2xl border border-border bg-background/80 p-4 shadow-sm backdrop-blur-md">
+      <div
+        className="flex items-start gap-3 rounded-[var(--app-card-radius-compact)] border border-border bg-background/80 p-4 shadow-sm backdrop-blur-md"
+        data-testid="ria-license-regulator-card"
+      >
         <Shield
-          className="h-[19px] w-[19px] shrink-0 text-foreground"
+          className="mt-0.5 h-[19px] w-[19px] shrink-0 text-foreground"
           strokeWidth={1.7}
         />
-        <span className="text-[14px] font-medium leading-[1.3] text-foreground">
+        <span className="min-w-0 text-[14px] font-medium leading-6 text-foreground">
           {regulatorLine}
         </span>
       </div>


### PR DESCRIPTION
## Summary
- aligns the RIA verification/setup hero, cards, and Continue CTA to one mobile content grid
- keeps the decorative advisor image inside the content rhythm instead of drifting past the gutter
- lets long certifications wrap in a stacked mobile SettingsRow layout to prevent collision/clipping

## Validation
- npm.cmd run typecheck
- npm.cmd run verify:design-system
- npm.cmd run verify:docs
- npm.cmd run verify:cache
- npm.cmd test -- __tests__/components/ria/onboarding-step-license-details.test.tsx __tests__/components/ria/onboarding-step-license.test.tsx __tests__/app/ria/onboarding-page.test.tsx __tests__/lib/ria/ria-onboarding-flow.test.ts __tests__/services/ria-onboarding-flow.test.ts
- npx.cmd --cache C:\Users\DIVYA\hushh-research\.npm-cache eslint components\ria\onboarding\onboarding-shell.tsx components\ria\onboarding\onboarding-step-license-details.tsx __tests__\components\ria\onboarding-step-license-details.test.tsx --max-warnings=0
- git diff --check

## Browser note
- localhost root server redirected /ria/onboarding to login in the current unauthenticated browser context, so protected route visual measurement requires reviewer auth.
- npm.cmd run verify:routes was blocked by missing maintainer-only REVIEWER_UID and REVIEWER_VAULT_PASSPHRASE.