### PR TITLE
fix(ria): align advisor detail cards on mobile

### DIFF
--- a/hushh-webapp/__tests__/components/ria/onboarding-step-review.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/onboarding-step-review.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OnboardingStepReview } from "@/components/ria/onboarding/onboarding-step-review";
+
+const baseProps = {
+  advisorName: "Andrew Garrett Kirkland",
+  firmName: "YOUR WEALTH ADVISORS",
+  crdNumber: "7413463",
+  regulator: "SEC",
+  regulatorStatus:
+    "Not currently registered as an Investment Adviser Representative",
+  certifications: ["Series 66 - Uniform Combined State Law Examination"],
+  servicesOffered: ["Portfolio Management", "Tax Planning"],
+  feeStructure: ["AUM %", "Fee-only"],
+  minEngagementAmount: "250,000",
+  bio: "Andrew Garrett Kirkland is a financial advisor focused on tax-aware planning for high-growth founders.",
+  city: "Little Rock",
+  pinZip: "72211",
+  areaLocality: "AR",
+  fullStreetAddress: "1701 Centerview Dr, STE 121",
+  advisoryAccessReady: false,
+  onEditSection: vi.fn(),
+  onAskKaiUpdateAnything: vi.fn(),
+};
+
+describe("OnboardingStepReview detail card alignment", () => {
+  it("renders licence and services information without removing edit actions", () => {
+    const onEditSection = vi.fn();
+
+    render(
+      <OnboardingStepReview {...baseProps} onEditSection={onEditSection} />,
+    );
+
+    expect(screen.getByText("Andrew Garrett Kirkland")).toBeTruthy();
+    expect(screen.getByText("YOUR WEALTH ADVISORS")).toBeTruthy();
+    expect(screen.getByText("7413463")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "SEC - Not currently registered as an Investment Adviser Representative",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Series 66 - Uniform Combined State Law Examination"),
+    ).toBeTruthy();
+    expect(screen.getByText("Portfolio Management, Tax Planning")).toBeTruthy();
+    expect(screen.getByText("AUM %, Fee-only")).toBeTruthy();
+    expect(screen.getByText("250,000")).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: /edit/i })).toHaveLength(3);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /edit/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /edit/i })[1]);
+
+    expect(onEditSection).toHaveBeenNthCalledWith(1, "license");
+    expect(onEditSection).toHaveBeenNthCalledWith(2, "services");
+  });
+
+  it("uses one value-column grid for long licence, certification, and services rows", () => {
+    const { container } = render(<OnboardingStepReview {...baseProps} />);
+
+    const expectedGrid =
+      "grid-cols-[7.25rem_minmax(0,1fr)] gap-x-4 sm:grid-cols-[8rem_minmax(0,1fr)]";
+    const rowIds = [
+      "ria-review-row-advisor",
+      "ria-review-row-firm",
+      "ria-review-row-crd",
+      "ria-review-row-regulator",
+      "ria-review-row-certifications",
+      "ria-review-row-services",
+      "ria-review-row-fees",
+      "ria-review-row-min-engagement",
+      "ria-review-row-bio",
+    ];
+
+    for (const rowId of rowIds) {
+      const row = screen.getByTestId(rowId);
+      expect(row.className).toContain(expectedGrid);
+      expect(row.querySelector('[data-slot="review-label"]')).toBeTruthy();
+      expect(row.querySelector('[data-slot="review-value"]')).toBeTruthy();
+    }
+
+    const regulatorValue = screen
+      .getByTestId("ria-review-row-regulator")
+      .querySelector('[data-slot="review-value"]');
+    expect(regulatorValue?.className).toContain("text-left");
+    expect(regulatorValue?.className).not.toContain("text-right");
+
+    const certificationValue = screen
+      .getByTestId("ria-review-row-certifications")
+      .querySelector('[data-slot="review-value"]');
+    expect(certificationValue?.textContent).toContain(
+      "Series 66 - Uniform Combined State Law Examination",
+    );
+    expect(certificationValue?.textContent).toContain("Series 66");
+
+    const detachedCertificationChips = Array.from(
+      container.querySelectorAll("span"),
+    ).filter(
+      (node) =>
+        node.textContent === "Series 66" &&
+        !screen
+          .getByTestId("ria-review-row-certifications")
+          .contains(node),
+    );
+    expect(detachedCertificationChips).toHaveLength(0);
+  });
+});

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-review.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-review.tsx
@@ -6,6 +6,9 @@ import { ChevronDown, ChevronUp, Pencil, ShieldCheck } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { RiaChip } from "@/components/ria/ui/ria-primitives";
 
+const DETAIL_ROW_GRID_CLASSNAME =
+  "grid grid-cols-[7.25rem_minmax(0,1fr)] gap-x-4 sm:grid-cols-[8rem_minmax(0,1fr)]";
+
 interface OnboardingStepReviewProps {
   advisorName: string;
   firmName: string;
@@ -36,9 +39,12 @@ function SectionCard({
   children: React.ReactNode;
 }) {
   return (
-    <section className="overflow-hidden rounded-[22px] border border-[color:var(--ria-divider-outer)] bg-[color:var(--card)] shadow-[0_8px_24px_rgba(62,48,30,0.05)]">
+    <section
+      className="overflow-hidden rounded-[22px] border border-[color:var(--ria-divider-outer)] bg-[color:var(--card)] shadow-[0_8px_24px_rgba(62,48,30,0.05)]"
+      data-testid={`ria-review-section-${label.toLowerCase()}`}
+    >
       <div className="flex items-center justify-between gap-3 px-[18px] pb-[11px] pt-[15px]">
-        <span className="ui-text-section-label">
+        <span className="ui-text-section-label min-w-0">
           {label}
         </span>
         <button
@@ -55,7 +61,12 @@ function SectionCard({
           Edit
         </button>
       </div>
-      <div className="px-[18px] pb-2">{children}</div>
+      <div
+        className="px-[18px] pb-2"
+        data-testid={`ria-review-section-${label.toLowerCase()}-rows`}
+      >
+        {children}
+      </div>
     </section>
   );
 }
@@ -69,17 +80,27 @@ function ReviewRow({
 }) {
   const hasValue = Boolean(value?.trim());
   return (
-    <div className="flex min-h-[44px] items-center justify-between gap-4 border-t border-[color:var(--ria-divider-inner)] py-[9px] first:border-t-0">
-      <span className="shrink-0 text-[15px] text-[color:var(--ria-muted)]">
+    <div
+      className={cn(
+        DETAIL_ROW_GRID_CLASSNAME,
+        "min-h-[44px] items-start border-t border-[color:var(--ria-divider-inner)] py-[10px] first:border-t-0",
+      )}
+      data-testid={reviewRowTestId(label)}
+    >
+      <span
+        className="pt-0.5 text-[15px] leading-6 text-[color:var(--ria-muted)]"
+        data-slot="review-label"
+      >
         {label}
       </span>
       <span
         className={cn(
-          "ml-auto min-w-0 max-w-[68%] break-words text-right text-[15px] font-medium leading-6",
+          "block min-w-0 whitespace-normal break-words text-left text-[15px] font-medium leading-6 [overflow-wrap:anywhere]",
           hasValue
             ? "text-[color:var(--ria-ink)]"
             : "text-[color:var(--ria-faint)]",
         )}
+        data-slot="review-value"
       >
         {hasValue ? value : "Not provided"}
       </span>
@@ -87,24 +108,51 @@ function ReviewRow({
   );
 }
 
+function certificationCode(label: string) {
+  return label.match(/\bSeries\s+\d+[A-Z]*\b/i)?.[0] ?? null;
+}
+
+function reviewRowTestId(label: string) {
+  return `ria-review-row-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+}
+
 function ChipRow({ label, items }: { label: string; items: string[] }) {
   return (
-    <div className="flex min-h-[44px] items-start justify-between gap-4 border-t border-[color:var(--ria-divider-inner)] py-[10px] first:border-t-0">
-      <span className="shrink-0 pt-0.5 text-[15px] text-[color:var(--ria-muted)]">
+    <div
+      className={cn(
+        DETAIL_ROW_GRID_CLASSNAME,
+        "min-h-[44px] items-start border-t border-[color:var(--ria-divider-inner)] py-[10px] first:border-t-0",
+      )}
+      data-testid={reviewRowTestId(label)}
+    >
+      <span
+        className="pt-0.5 text-[15px] leading-6 text-[color:var(--ria-muted)]"
+        data-slot="review-label"
+      >
         {label}
       </span>
-      <div className="ml-auto min-w-0 max-w-[68%]">
+      <div className="min-w-0" data-slot="review-value">
         {items.length === 0 ? (
-          <span className="text-[15px] text-[color:var(--ria-faint)]">
+          <span className="block text-left text-[15px] leading-6 text-[color:var(--ria-faint)]">
             Not provided
           </span>
         ) : (
-          <div className="flex flex-wrap justify-end gap-1.5">
-            {items.map((item) => (
-              <RiaChip key={item} variant="outline">
-                {item}
-              </RiaChip>
-            ))}
+          <div className="space-y-2">
+            {items.map((item) => {
+              const code = certificationCode(item);
+              return (
+                <div key={item} className="min-w-0 space-y-1.5">
+                  <span className="block whitespace-normal break-words text-left text-[15px] font-medium leading-6 text-[color:var(--ria-ink)] [overflow-wrap:anywhere]">
+                    {item}
+                  </span>
+                  {code ? (
+                    <RiaChip variant="outline" className="max-w-full">
+                      {code}
+                    </RiaChip>
+                  ) : null}
+                </div>
+              );
+            })}
           </div>
         )}
       </div>
@@ -116,15 +164,27 @@ function BioReviewRow({ bio }: { bio: string }) {
   const [open, setOpen] = useState(false);
   const hasValue = Boolean(bio?.trim());
   return (
-    <div className="flex items-start justify-between gap-4 border-t border-[color:var(--ria-divider-inner)] py-[11px]">
-      <span className="shrink-0 pt-px text-[15px] text-[color:var(--ria-muted)]">
+    <div
+      className={cn(
+        DETAIL_ROW_GRID_CLASSNAME,
+        "items-start border-t border-[color:var(--ria-divider-inner)] py-[11px]",
+      )}
+      data-testid="ria-review-row-bio"
+    >
+      <span
+        className="pt-px text-[15px] leading-6 text-[color:var(--ria-muted)]"
+        data-slot="review-label"
+      >
         Bio
       </span>
-      <div className="ml-auto flex min-w-0 flex-1 flex-col items-end">
+      <div
+        className="flex min-w-0 flex-col items-start"
+        data-slot="review-value"
+      >
         {hasValue ? (
           <p
             className={cn(
-              "text-right text-[14px] leading-[1.5] text-[color:var(--ria-ink)]",
+              "whitespace-normal break-words text-left text-[14px] leading-[1.5] text-[color:var(--ria-ink)] [overflow-wrap:anywhere]",
               !open && "line-clamp-3",
             )}
           >


### PR DESCRIPTION
## Summary
- align RIA onboarding review detail rows on one stable label/value grid
- keep Regulator, Certifications, Services, Bio, and Location rows on the same value-column start
- add focused regression coverage for row structure and edit action availability

## Validation
- npm.cmd test -- __tests__\\components\\ria\\onboarding-step-review.test.tsx __tests__\\components\\ria\\onboarding-step-license-details.test.tsx __tests__\\components\\ria\\onboarding-step-services.test.tsx __tests__\\app\\ria\\onboarding-page.test.tsx __tests__\\lib\\ria\\ria-profile-view-model.test.ts
- npx.cmd eslint components\\ria\\onboarding\\onboarding-step-review.tsx __tests__\\components\\ria\\onboarding-step-review.test.tsx --max-warnings=0
- npm.cmd run typecheck
- npm.cmd run verify:design-system
- npm.cmd run verify:docs
- npm.cmd run verify:cache
- git diff --check