### PR TITLE
fix(android): remove ineffective Agents paint containment workaround

### DIFF
--- a/docs/reference/mobile/capacitor-parity-audit-report.md
+++ b/docs/reference/mobile/capacitor-parity-audit-report.md
@@ -31,6 +31,35 @@ The native gate now includes:
 
 Continuity is separately rehearsed against an already-installed normal session with `ios:continuity:local` or `android:continuity:local`; it must not inherit evidence from a cold audit.
 
+## Android Agents Rendered-UI Rehearsal — September 9, 2026
+
+The Pixel 8 emulator running Android 17 and WebView 152.0.7977.64 reproduced
+agent-grid pixels above Search while the DOM contained one correctly positioned
+grid. Chromium's screenshot and Android's display capture disagreed. Removing
+backdrop filters, disabling native overscroll, and disabling HWUI partial redraws
+did not resolve the reproduction; those diagnostic overrides were removed.
+
+The same rebuilt APK reproduced the overlap with the emulator's ANGLE/SwiftShader
+software renderer and cleared it with the host GPU renderer (Apple M5/Metal).
+The affected local AVD now uses `hw.gpu.mode=host`. This is an emulator rendering
+configuration correction, not an application spacing or stacking-order fix.
+When diagnosing this failure, compare the actual renderer reported by
+`adb shell dumpsys SurfaceFlinger`, rather than assuming AVD `auto` selected
+hardware rendering. A cold emulator launch with `-gpu host -no-snapshot-load`
+allows comparison without wiping app storage.
+
+The Android-only roster clipping/paint-containment workaround was removed.
+The header, view controls, and Search remain outside the replaced content subtree.
+After rebuilding and installing the APK, two touch-driven cycles covered both
+views and returns from Connect, Feed, and the Search overlay. Sixteen Android
+display captures were collected. The header/Search region matched across all
+twelve return captures within each view. Component tests separately verify that
+Grid/List replacement preserves the same header, search, and control nodes.
+
+This is dated emulator evidence, not a physical-device or fresh iOS parity claim.
+Do not introduce route-local clipping, offsets, or forced redraw timers to mask
+an emulator compositor defect.
+
 ## Blockers
 
 Current tracked evidence blockers:

--- a/hushh-webapp/__tests__/app/ria/clients-page-switch-to-nearby.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/clients-page-switch-to-nearby.test.tsx
@@ -16,6 +16,7 @@ const handlerHarness = vi.hoisted(() => ({
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/ria/clients",
 }));
 
 vi.mock("@/lib/agent/local-onboarding-actions", () => ({

--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -152,11 +152,11 @@ describe("Navbar bottom chrome contract", () => {
     expect(providers).toContain(
       "const foundationVoiceOnlyChrome = isFoundationRoute;",
     );
-    expect(providers).toContain(
-      "const pinnedBottomChrome =\n    isRiaRoute(pathname) || foundationVoiceOnlyChrome;",
+    expect(providers).toMatch(
+      /const pinnedBottomChrome\s*=\s*isRiaRoute\(pathname\)\s*\|\|\s*foundationVoiceOnlyChrome;/,
     );
-    expect(providers).toContain(
-      "navigationHidden:\n      effectiveHideCommandBar || foundationVoiceOnlyChrome,",
+    expect(providers).toMatch(
+      /navigationHidden:\s*effectiveHideCommandBar\s*\|\|\s*foundationVoiceOnlyChrome,/,
     );
     expect(providers).toContain(
       "!pinnedBottomChrome &&\n      !bottomChromeHidden",

--- a/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
@@ -1,21 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { OneDashboardPage } from "@/components/dashboard/one-dashboard-page";
 import { buildOneSetupCapabilityRoute, ROUTES } from "@/lib/navigation/routes";
 import type { CapabilityStatus } from "@/lib/services/capability-setup-state-service";
 import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
-
-const platformHarness = vi.hoisted(() => ({ isAndroid: false }));
-
-vi.mock("@/lib/capacitor/platform", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@/lib/capacitor/platform")>();
-  return {
-    ...actual,
-    isAndroid: () => platformHarness.isAndroid,
-  };
-});
 
 function status(
   id: string,
@@ -57,7 +46,6 @@ function countRosterMetrics(
 
 describe("OneDashboardPage", () => {
   beforeEach(() => {
-    platformHarness.isAndroid = false;
     window.localStorage.clear();
   });
 
@@ -307,32 +295,30 @@ describe("OneDashboardPage", () => {
     );
   });
 
-  it("clips the roster view paint on Android without changing the controls", () => {
-    platformHarness.isAndroid = true;
+  it("keeps header, search and view controls mounted while replacing only roster content", () => {
     window.localStorage.setItem("hushh:one-agent-roster-view", "grid");
-
     render(<OneDashboardPage displayName="Kushal Trivedi" />);
 
-    const content = screen.getByTestId("one-agents-view-content");
-    expect(content.className).toContain("isolate");
-    expect(content.className).toContain("overflow-hidden");
-    expect(content.className).toContain("[clip-path:inset(0)]");
-    expect(content.className).toContain("[contain:layout_paint]");
-    expect(content).toHaveAttribute("data-no-auto-fade", "true");
-    expect(content).not.toHaveClass("motion-step-enter");
-    expect(screen.getByRole("heading", { name: "Agents (9)" })).toBeTruthy();
-    expect(screen.getByTestId("one-agents-search")).toBeTruthy();
-    expect(screen.getByTestId("one-agents-view-grid")).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-    expect(screen.getByTestId("one-agent-tile-finance")).toBeTruthy();
+    const heading = screen.getByRole("heading", { name: "Agents (9)" });
+    const search = screen.getByTestId("one-agents-search");
+    const gridControl = screen.getByLabelText("Show agent grid view");
+    const listControl = screen.getByLabelText("Show agent list view");
+    const gridContent = screen.getByTestId("one-agents-view-content");
 
-    fireEvent.click(screen.getByLabelText("Show agent list view"));
-    const listContent = screen.getByTestId("one-agents-view-content");
-    expect(listContent).not.toHaveClass("motion-step-enter");
-    expect(listContent).toHaveAttribute("data-no-auto-fade", "true");
+    fireEvent.click(listControl);
+    expect(screen.getByRole("heading", { name: "Agents (9)" })).toBe(heading);
+    expect(screen.getByTestId("one-agents-search")).toBe(search);
+    expect(screen.getByLabelText("Show agent grid view")).toBe(gridControl);
+    expect(screen.getByLabelText("Show agent list view")).toBe(listControl);
+    expect(gridContent.isConnected).toBe(false);
+    expect(screen.queryByTestId("one-agents-grid")).toBeNull();
     expect(screen.getByTestId("one-agents-list")).toBeTruthy();
+
+    fireEvent.click(gridControl);
+    expect(screen.getByRole("heading", { name: "Agents (9)" })).toBe(heading);
+    expect(screen.getByTestId("one-agents-search")).toBe(search);
+    expect(screen.queryByTestId("one-agents-list")).toBeNull();
+    expect(screen.getAllByTestId("one-agents-grid")).toHaveLength(1);
   });
 
   it("filters the local agent roster without opening a second global search surface", () => {

--- a/hushh-webapp/__tests__/navigation/home-shell-contract.test.ts
+++ b/hushh-webapp/__tests__/navigation/home-shell-contract.test.ts
@@ -27,7 +27,8 @@ describe("home shell contract", () => {
     expect(resolveTopShellMetrics("/one/location?action=share").hasTabs).toBe(
       false,
     );
-    expect(resolveTopShellMetrics(ROUTES.RIA_PICKS).hasTabs).toBe(true);
+    // RIA renders its route selector inside the module, like Location.
+    expect(resolveTopShellMetrics(ROUTES.RIA_PICKS).hasTabs).toBe(false);
     expect(resolveTopShellMetrics(ROUTES.PROFILE).hasTabs).toBe(false);
     expect(resolveTopShellMetrics(ROUTES.CONNECT).hasTabs).toBe(false);
   });

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -18,7 +18,6 @@ import {
   getCapabilityStatusDisplay,
   type CapabilityStatusTone,
 } from "@/lib/onboarding/capability-status-display";
-import { isAndroid } from "@/lib/capacitor/platform";
 import { getCapabilitySetupCopy } from "@/lib/onboarding/capability-setup-copy";
 import { buildOneSetupCapabilityRoute } from "@/lib/navigation/routes";
 import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
@@ -119,10 +118,6 @@ function readPersistedRosterView(): AgentRosterView {
   } catch {
     return "list";
   }
-}
-
-function readNativeAndroidRosterSurface(): boolean {
-  return typeof window !== "undefined" && isAndroid();
 }
 
 function positiveNumber(value: unknown): number | null {
@@ -677,9 +672,6 @@ export function OneAgentRoster({
   );
   const modes = buildModes(capabilityStatusById, cachedMetrics, setupDismissed);
   const [view, setView] = useState<AgentRosterView>(readPersistedRosterView);
-  const [usesAndroidCompositorGuard] = useState(
-    readNativeAndroidRosterSurface,
-  );
   const [animateViewChange, setAnimateViewChange] = useState(false);
   const [query, setQuery] = useState("");
   const visibleModes = useMemo(() => {
@@ -744,14 +736,7 @@ export function OneAgentRoster({
       <div
         key={view}
         data-testid="one-agents-view-content"
-        data-no-auto-fade={usesAndroidCompositorGuard ? "true" : undefined}
-        className={cn(
-          usesAndroidCompositorGuard &&
-            "isolate overflow-hidden [clip-path:inset(0)] [contain:layout_paint]",
-          animateViewChange &&
-            !usesAndroidCompositorGuard &&
-            "motion-step-enter",
-        )}
+        className={cn(animateViewChange && "motion-step-enter")}
       >
         {view === "grid" ? (
           <div


### PR DESCRIPTION
## Description

The Android emulator displayed stale agent-grid pixels over the Agents header and Search after navigation, although the DOM contained one correctly positioned grid. The same rebuilt APK reproduced this with ANGLE/SwiftShader and rendered correctly with the host GPU (Apple M5/Metal). The affected local AVD was corrected to `hw.gpu.mode=host`; that machine-local setting is outside this PR.

Remove the ineffective Android-only clipping/paint-containment workaround and restore the existing shared view-change animation. Keep `Agents (9)`, Grid/List controls, and Search outside the keyed content subtree. Replace the workaround-specific assertion with a production-component regression test that proves those nodes remain mounted while only the roster content is replaced. Record the dated diagnosis and rendered-UI evidence.

The verified application implementation is preserved unchanged. A separate test-only CI repair updates three stale baseline contracts: source assertions now tolerate formatting, RIA tabs are expected in their module selector, and the RIA clients test supplies the route pathname required by that selector. No spacing, stacking-order, timing, native lifecycle, or overflow-masking workaround is added.

## Impact map

- Routes / reachable production attach point: `/one` → `OneDashboardPage` → `OneAgentRoster`; existing route structure unchanged.
- API/schema/types, runtime DB data plane, cache keys, and PKM/world-model summaries: no changes.
- Mobile parity: Android returns to the shared roster rendering path. No Capacitor plugin or bridge changes; iOS implementation unchanged. Fresh physical-device and iOS parity are not claimed.
- Trust boundary and caller/proxy/backend pairing: none; presentation-only change, no information access changes.
- Docs: `docs/reference/mobile/capacitor-parity-audit-report.md`.
- Top-level/devex/config/generated/ignore files and dependencies: none. No APK, screenshot, diagnostic script, or local AVD configuration is committed.
- Rollback: revert this single commit; no migration or persistent application state change.
- Licensing: first-party Apache-2.0 compatible; no third-party notice impact.

## Verification

- Android rendered-UI verification was completed before PR preparation: rebuilt/reinstalled APK, two touch-driven Grid/List cycles and One → Connect/Feed/Search → One returns. Sixteen display captures; header/Search regions matched across twelve return captures within each view. User confirmed the fix. Emulator testing was not repeated during this Git/PR workflow.
- `npm test -- --run __tests__/components/one-dashboard-page.test.tsx`: 9 passed; imports and exercises the production component.
- DCO signoff and `git diff --check`: passed.
- Gitleaks scan of the commit: no leaks. The local `./bin/hushh codex pre-pr` wrapper cannot read the account-restricted GitHub secret-alert API (404); hosted Secret Scan remains required.
- Governance, integration, design-system, docs, typecheck, lint, and production web build: passed. Voice gateway, surface map, Capacitor static parity, and plugin contracts: passed.
- Full `npm run test:ci`: 769 files passed, 1 skipped; 6,499 tests passed, 6 skipped. The three stale baseline test repairs also pass in isolation. Hosted checks are required on the final head before merge.

## Tri-flow declaration

- Web: shared React roster rendering and behavioral regression coverage.
- iOS: native layer N/A; no bridge/plugin change and no fresh iOS rehearsal claimed.
- Android: shared roster cleanup plus previously completed emulator evidence; native plugin layer N/A.

This is a standalone, DCO-signed maintainer PR against `main`. Related open PRs were checked; no duplicate Agents compositor correction was found.
