### PR TITLE
fix(ria): preserve setup progress on resume

### DIFF
--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -814,10 +814,73 @@ describe("RiaOnboardingPage", () => {
     });
   });
 
-  it("loads an existing draft but still opens at the welcome step", async () => {
+  it("restores a saved step 2 draft after remount", async () => {
+    let savedDraft: Record<string, unknown> | null = null;
+    mocks.draftService.load.mockImplementation(async () => savedDraft);
+    mocks.draftService.save.mockImplementation(async (_userId, draft) => {
+      savedDraft = draft;
+    });
+
+    const firstRender = render(<RiaOnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-welcome")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("continue-btn"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-license")).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(savedDraft).toEqual(
+        expect.objectContaining({ currentStepId: "license_number" }),
+      );
+    });
+
+    firstRender.unmount();
+    render(<RiaOnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-license")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("step-welcome")).toBeNull();
+  });
+
+  it("restores a valid saved later setup step and preserves draft fields", async () => {
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "services",
       onboardingType: "firm",
+      licenseNumber: "111222",
+      licenseVerificationStatus: "found",
+      advisorName: "Saved Advisor",
+      verifiedLicensePrefillKey: "auto:111222",
+      servicesOffered: [],
+      feeStructure: [],
+      city: "Austin",
+      pinZip: "78701",
+    });
+
+    render(<RiaOnboardingPage />);
+
+    await waitFor(() => {
+      expect(mocks.draftService.load).toHaveBeenCalledWith("user-ria-1");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-services")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("step-welcome")).toBeNull();
+    expect(screen.getByTestId("services-city").textContent).toBe("Austin");
+    expect(screen.getByTestId("services-pin-zip").textContent).toBe("78701");
+  });
+
+  it("clamps an invalid persisted later step to the nearest valid prerequisite", async () => {
+    mocks.draftService.load.mockResolvedValue({
+      currentStepId: "review",
+      onboardingType: "individual",
       licenseNumber: "111222",
       licenseVerificationStatus: "found",
       advisorName: "Saved Advisor",
@@ -829,17 +892,9 @@ describe("RiaOnboardingPage", () => {
     render(<RiaOnboardingPage />);
 
     await waitFor(() => {
-      expect(mocks.draftService.load).toHaveBeenCalledWith("user-ria-1");
+      expect(screen.getByTestId("step-services")).toBeTruthy();
     });
-
-    // Entering RIA setup never resumes mid-wizard — the saved step pointer is
-    // ignored so step 1 (and its cinematic intro) is never skipped...
-    await waitFor(() => {
-      expect(screen.getByTestId("step-welcome")).toBeTruthy();
-    });
-    expect(screen.queryByTestId("step-services")).toBeNull();
-    // ...while every other saved field still prefills the flow.
-    expect(screen.getByTestId("welcome-type").textContent).toBe("firm");
+    expect(screen.queryByTestId("step-review")).toBeNull();
   });
 
   it("drafts a bio from verified onboarding fields", async () => {

--- a/hushh-webapp/__tests__/lib/ria/ria-onboarding-flow.test.ts
+++ b/hushh-webapp/__tests__/lib/ria/ria-onboarding-flow.test.ts
@@ -10,6 +10,7 @@ import {
   isRiaOnboardingStepId,
   normalizeRiaCapabilities,
   normalizeRiaOnboardingDraft,
+  resolveRestorableRiaOnboardingStepId,
   resolveRiaOnboardingStepId,
   type RiaOnboardingDraft,
 } from "@/lib/ria/ria-onboarding-flow";
@@ -336,6 +337,50 @@ describe("ria-onboarding-flow", () => {
     it("returns first incomplete when no preference", () => {
       const draft = createEmptyRiaOnboardingDraft();
       expect(resolveRiaOnboardingStepId(draft)).toBe("license_number");
+    });
+  });
+
+  describe("resolveRestorableRiaOnboardingStepId", () => {
+    it("restores the persisted in-progress step when prerequisites are satisfied", () => {
+      const draft: RiaOnboardingDraft = {
+        ...createEmptyRiaOnboardingDraft(),
+        currentStepId: "services",
+        licenseNumber: "123456",
+        licenseVerificationStatus: "found",
+        advisorName: "Jane Doe",
+      };
+
+      expect(
+        resolveRestorableRiaOnboardingStepId(draft, draft.currentStepId, {
+          licenseVerificationSatisfied: true,
+        })
+      ).toBe("services");
+    });
+
+    it("clamps a persisted later step to the first unmet prerequisite", () => {
+      const draft: RiaOnboardingDraft = {
+        ...createEmptyRiaOnboardingDraft(),
+        currentStepId: "review",
+        licenseNumber: "123456",
+        licenseVerificationStatus: "found",
+        advisorName: "Jane Doe",
+        servicesOffered: [],
+        feeStructure: [],
+      };
+
+      expect(
+        resolveRestorableRiaOnboardingStepId(draft, draft.currentStepId, {
+          licenseVerificationSatisfied: true,
+        })
+      ).toBe("services");
+    });
+
+    it("falls back to the first incomplete step for invalid persisted values", () => {
+      const draft = createEmptyRiaOnboardingDraft();
+
+      expect(
+        resolveRestorableRiaOnboardingStepId(draft, "bogus" as any)
+      ).toBe("license_number");
     });
   });
 

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -29,6 +29,7 @@ import {
   getRiaOnboardingStepIndex,
   isRiaOnboardingStepId,
   normalizeRiaOnboardingDraft,
+  resolveRestorableRiaOnboardingStepId,
   resolveRiaOnboardingStepId,
   type RiaOnboardingDraft,
   type RiaOnboardingFlowOptions,
@@ -403,19 +404,26 @@ export default function RiaOnboardingPage({
           });
         }
 
-        // Opening RIA setup always lands on step 1. The saved draft still
-        // prefills every field, but its step pointer is deliberately ignored so
-        // entering the flow never drops the user mid-wizard (and never skips the
-        // welcome step's cinematic intro). Only an explicit
-        // ?edit=license / ?step= / ?reinitiate deep-link may land elsewhere.
+        // Resume an incomplete setup from the last locally persisted wizard
+        // step, but clamp it to the first unmet prerequisite so a stale draft
+        // can never skip required verification/service input. Explicit reset
+        // and edit deep-links keep their authored destinations.
         const preferredStepId = requestedStepIdRef.current;
+        const stepResolutionOptions = {
+          licenseVerificationSatisfied:
+            alreadyVerified || resolvedDraft.licenseVerificationStatus === "found",
+        };
         const currentStepId = preferredStepId
-          ? resolveRiaOnboardingStepId(resolvedDraft, preferredStepId, {
-              licenseVerificationSatisfied:
-                alreadyVerified ||
-                resolvedDraft.licenseVerificationStatus === "found",
-            })
-          : "welcome";
+          ? resolveRiaOnboardingStepId(
+              resolvedDraft,
+              preferredStepId,
+              stepResolutionOptions,
+            )
+          : resolveRestorableRiaOnboardingStepId(
+              resolvedDraft,
+              resolvedDraft.currentStepId,
+              stepResolutionOptions,
+            );
 
         setStatus(nextStatus);
         setDraft({ ...resolvedDraft, currentStepId });

--- a/hushh-webapp/lib/ria/ria-onboarding-flow.ts
+++ b/hushh-webapp/lib/ria/ria-onboarding-flow.ts
@@ -306,6 +306,24 @@ export function resolveRiaOnboardingStepId(
   return findFirstIncompleteRiaOnboardingStepId(draft, options);
 }
 
+export function resolveRestorableRiaOnboardingStepId(
+  draft: RiaOnboardingDraft,
+  persistedStepId?: RiaOnboardingStepId | null,
+  options?: RiaOnboardingFlowOptions,
+): RiaOnboardingStepId {
+  const steps = buildRiaOnboardingSteps(draft, options);
+  const fallbackStepId = findFirstIncompleteRiaOnboardingStepId(draft, options);
+  const normalizedPersistedStepId = normalizeRiaOnboardingStepId(persistedStepId);
+  if (!normalizedPersistedStepId) return fallbackStepId;
+
+  const persistedIndex = steps.findIndex((step) => step.id === normalizedPersistedStepId);
+  const fallbackIndex = steps.findIndex((step) => step.id === fallbackStepId);
+  if (persistedIndex < 0) return fallbackStepId;
+  if (fallbackIndex < 0) return normalizedPersistedStepId;
+
+  return steps[Math.min(persistedIndex, fallbackIndex)]?.id || fallbackStepId;
+}
+
 export function findFirstIncompleteRiaOnboardingStepId(
   draft: RiaOnboardingDraft,
   options?: RiaOnboardingFlowOptions,


### PR DESCRIPTION
## Description

In the RIA setup/onboarding flow, the user's current progress is not preserved when the application is minimized or moved to the background.

If the user progresses beyond Step 1, minimizes the app, and then returns to it, the setup flow resets back to Step 1 instead of restoring the previously active step.

This forces the user to repeat already completed steps and creates a broken mobile/iOS experience.

Investigate how the setup wizard currently stores and restores its active step and completed-step state.

The fix should preserve the current progress using the existing application state/persistence architecture rather than introducing an unrelated parallel state mechanism.

## Steps To Reproduce

1. Open the RIA setup/onboarding flow.
2. Complete Step 1 and proceed to a later step.
3. Minimize/background the application.
4. Return to the application.
5. Observe that the setup flow returns to Step 1.

## Expected Behavior

When the user returns to the application, the RIA setup flow should restore the last valid in-progress step.

Already completed steps and entered data should remain intact where the existing product flow supports persistence.

The flow should only restart from Step 1 when:
- the setup has intentionally been reset,
- the relevant state is no longer valid,
- or existing product/business rules explicitly require a restart.

## Environment

- Area: RIA → Setup / Verification
- Platform: iOS / Mobile Web
- Type: State persistence / Resume behavior