### PR TITLE
fix(ria): align header and navigation with Location

### DIFF
--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5536,7 +5536,7 @@
     "one_specialist_tools": "2b08273e4fbd5c7967ebc028383c86c93d7eccf599a11013c146915b5f81c288",
     "route_index": "9eed7fb3fb1cb3a5cc6197d846d9c08b45ab07d9bc0734fe24984e8341b00736",
     "route_layout": "b66933c7083fd755f1a8e4a16262996fc7ae6124a4c550725bfdc7144332355f",
-    "surface_map": "537f5dad312a0f23d0e0cea0054ea1adbe26537c78b53d69d08ef832d79678df",
+    "surface_map": "27401d89ecb2ef74609803bb28b9d59a4d1b3825c6c2b80974507437264a6b95",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },

--- a/hushh-webapp/__tests__/app/ria/clients-page-switch-to-nearby.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/clients-page-switch-to-nearby.test.tsx
@@ -46,6 +46,7 @@ vi.mock("@/components/ria/nearby/nearby-around-you", () => ({
 }));
 
 vi.mock("@/components/ria/ria-page-shell", () => ({
+  RiaPageShell: ({ children }: { children: React.ReactNode }) => children,
   RiaCompatibilityState: ({ children }: { children: React.ReactNode }) => children,
   RiaVerificationGate: ({ children }: { children: React.ReactNode }) => children,
 }));

--- a/hushh-webapp/__tests__/app/ria/clients-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/clients-page.test.tsx
@@ -112,6 +112,9 @@ vi.mock("@/components/profile/settings-ui", () => ({
 }));
 
 vi.mock("@/components/ria/ria-page-shell", () => ({
+  RiaPageShell: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
   RiaCompatibilityState: ({ title }: { title: string }) => <div>{title}</div>,
   RiaVerificationGate: ({ children }: { children?: React.ReactNode }) => (
     <>{children}</>
@@ -125,14 +128,13 @@ vi.mock("@/components/ria/nearby/nearby-around-you", () => ({
 import RiaClientsPage from "@/app/ria/clients/page";
 
 describe("RIA Clients page", () => {
-  it("keeps the workspace summary visible when switching to Around You", () => {
+  it("switches between Connected and Around You without routing away", () => {
     render(<RiaClientsPage />);
 
-    expect(screen.getByText(/One workspace per client/i)).toBeInTheDocument();
+    expect(screen.getByText("Connected investors")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Around you/i }));
 
-    expect(screen.getByText(/One workspace per client/i)).toBeInTheDocument();
     expect(screen.getByText("Nearby records pane")).toBeInTheDocument();
     expect(push).not.toHaveBeenCalled();
   });

--- a/hushh-webapp/__tests__/app/ria/header-regression.contract.test.ts
+++ b/hushh-webapp/__tests__/app/ria/header-regression.contract.test.ts
@@ -17,12 +17,12 @@ describe("RIA shared header regression contract", () => {
     const riaPicks = read("app/ria/picks/page.tsx");
 
     // `/ria` deliberately remains a thin compatibility redirect. The canonical
-    // Profile tab owns the shared RIA shell and header contract.
+    // workspace routes all inherit the same RIA shell and header contract.
     expect(riaHome).toContain("ClientRedirect");
     expect(riaHome).toContain("ROUTES.RIA_PROFILE");
     expect(riaProfile).toContain("RiaPageShell");
-    expect(riaClients).toContain("PageHeader");
-    expect(riaPicks).toContain("PageHeader");
+    expect(riaClients).toContain("RiaPageShell");
+    expect(riaPicks).toContain("RiaPageShell");
     expect(riaPicks).toContain("SegmentedTabs");
     expect(riaPicks).toContain("showMyListActionRail");
   });
@@ -43,6 +43,7 @@ describe("RIA shared header regression contract", () => {
 
     expect(riaShell).toContain("<PageHeader");
     expect(riaShell).toContain('accent="ria"');
+    expect(riaShell).toContain("<RiaRouteSelector");
     expect(globals).toContain("--ria-gold: var(--app-accent)");
     expect(globals).toContain("--ria-selected-tint: var(--app-accent-surface)");
   });
@@ -74,30 +75,31 @@ describe("RIA shared header regression contract", () => {
     const riaProfile = read("app/ria/profile/page.tsx");
     const riaClients = read("app/ria/clients/page.tsx");
     const riaPicks = read("app/ria/picks/page.tsx");
+    const riaShell = read("components/ria/ria-page-shell.tsx");
 
     // "agent" (880px), not "standard" (1440px) -- Connect and Marketplace are
     // directory-browsing surfaces at that wider measure; RIA is a workspace,
     // closer in shape to Location's primary surface. See ria-page-shell.tsx.
     expect(riaProfile).toContain("RiaPageShell");
-    expect(riaClients).toContain('width="agent"');
-    expect(riaPicks).toContain('width="agent"');
+    expect(riaClients).toContain("RiaPageShell");
+    expect(riaPicks).toContain("RiaPageShell");
     expect(riaClients).not.toContain('width="standard"');
     expect(riaPicks).not.toContain('width="standard"');
     expect(riaClients).not.toContain('width="expanded"');
     expect(riaPicks).not.toContain('width="expanded"');
-    expect(riaClients).toContain(
-      '<AppPageHeaderRegion className="pt-2 sm:pt-3">',
+    expect(riaClients).not.toContain("<AppPageHeaderRegion");
+    expect(riaPicks).not.toContain("<AppPageHeaderRegion");
+    expect(riaClients).not.toContain("<PageHeader");
+    expect(riaPicks).not.toContain("<PageHeader");
+    expect(riaShell).toContain(
+      '<AppPageHeaderRegion className={cn("pt-2 sm:pt-3", headerClassName)}>',
     );
-    expect(riaPicks).toContain(
-      '<AppPageHeaderRegion className="pt-2 sm:pt-3">',
-    );
-    expect(riaClients).toContain("<SurfaceStack");
-    expect(riaClients).toContain('className="gap-8"');
-    expect(riaPicks).toContain("<SurfaceStack");
-    expect(riaPicks).toContain('className="gap-6"');
+    expect(riaShell).toContain("<SurfaceStack");
+    expect(riaClients).toContain('stackClassName="gap-8"');
+    expect(riaPicks).toContain('stackClassName="gap-6"');
   });
 
-  it("renders the shared RIA route selector after each primary page header", () => {
+  it("renders the shared RIA route selector under the stable shell header", () => {
     const riaProfile = read("app/ria/profile/page.tsx");
     const riaClients = read("app/ria/clients/page.tsx");
     const riaPicks = read("app/ria/picks/page.tsx");
@@ -106,25 +108,22 @@ describe("RIA shared header regression contract", () => {
     const providers = read("app/providers.tsx");
 
     for (const source of [riaProfile, riaClients, riaPicks]) {
-      expect(source).toContain("RiaRouteSelector");
+      expect(source).toContain("showRouteSelector");
+      expect(source).not.toContain("RiaRouteSelector");
     }
     expect(
       riaShell.indexOf("<AppPageHeaderRegion") <
         riaShell.indexOf("<AppPageContentRegion"),
     ).toBe(true);
     expect(
-      riaClients.indexOf("<PageHeader") <
-        riaClients.indexOf("<RiaRouteSelector"),
-    ).toBe(true);
-    expect(
-      riaPicks.indexOf("<PageHeader") < riaPicks.indexOf("<RiaRouteSelector"),
+      riaShell.indexOf("<PageHeader") < riaShell.indexOf("<RiaRouteSelector"),
     ).toBe(true);
 
     expect(topShellTabs).toContain("export function resolveRiaRouteTabSet");
     expect(providers).toContain("resolveRiaRouteTabSet(");
   });
 
-  it("keeps the primary RIA headers clean across Profile, Clients, and Picks", () => {
+  it("keeps one stable RIA heading across Profile, Clients, and Picks", () => {
     const riaProfile = read("app/ria/profile/page.tsx");
     const riaClients = read("app/ria/clients/page.tsx");
     const riaPicks = read("app/ria/picks/page.tsx");
@@ -132,23 +131,27 @@ describe("RIA shared header regression contract", () => {
 
     expect(riaShell).toContain("icon?: LucideIcon | null");
 
-    expect(riaProfile).toContain('title="Profile"');
-    expect(riaProfile).toContain(
+    for (const source of [riaProfile, riaClients, riaPicks]) {
+      expect(source).toContain('title="RIA"');
+      expect(source).toContain("icon={null}");
+      expect(source).toContain("showRouteSelector");
+    }
+    expect(riaProfile).not.toContain('title="Profile"');
+    expect(riaProfile).not.toContain(
       'description="Manage your advisor profile and verification details."',
     );
-    expect(riaProfile).toContain("icon={null}");
     expect(riaProfile).not.toContain('eyebrow="RIA"');
 
-    expect(riaClients).toContain("title={RIA_COPY.clients.title}");
-    expect(riaClients).toContain("description={RIA_COPY.clients.description}");
+    expect(riaClients).not.toContain("title={RIA_COPY.clients.title}");
+    expect(riaClients).not.toContain("description={RIA_COPY.clients.description}");
     expect(riaClients).not.toContain("eyebrow={RIA_COPY.clients.eyebrow}");
     expect(riaClients).not.toContain("icon={UserRound}");
     expect(riaClients).not.toContain(
       '<Badge variant="secondary" className="text-[10px]">',
     );
 
-    expect(riaPicks).toContain("title={RIA_COPY.picks.title}");
-    expect(riaPicks).toContain("description={RIA_COPY.picks.description}");
+    expect(riaPicks).not.toContain("title={RIA_COPY.picks.title}");
+    expect(riaPicks).not.toContain("description={RIA_COPY.picks.description}");
     expect(riaPicks).not.toContain("eyebrow={RIA_COPY.picks.eyebrow}");
     expect(riaPicks).not.toContain("icon={FileSpreadsheet}");
   });

--- a/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
@@ -175,6 +175,9 @@ vi.mock("@/components/profile/settings-ui", () => ({
 }));
 
 vi.mock("@/components/ria/ria-page-shell", () => ({
+  RiaPageShell: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
   RiaCompatibilityState: ({
     title,
     description,

--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -4,20 +4,13 @@ import { ChevronRight, Loader2, UserRound } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 
-import {
-  AppPageContentRegion,
-  AppPageHeaderRegion,
-  AppPageShell,
-} from "@/components/app-ui/app-page-shell";
-import { PageHeader } from "@/components/app-ui/page-sections";
-import { SurfaceStack } from "@/components/app-ui/surfaces";
+import { AppPageShell } from "@/components/app-ui/app-page-shell";
 import {
   buildKaiTestClientAccess,
   canShowKaiTestProfile,
   getKaiTestUserId,
   isKaiTestProfileUser,
 } from "@/components/ria/ria-client-test-profile";
-import { RiaRouteSelector } from "@/components/ria/layout/ria-route-selector";
 import { NearbyAroundYou } from "@/components/ria/nearby/nearby-around-you";
 import { SettingsGroup, SegmentedTabs } from "@/components/profile/settings-ui";
 import { Badge } from "@/components/ui/badge";
@@ -39,6 +32,7 @@ import { RIA_COPY } from "@/lib/ria/ria-screen-copy";
 import { cn } from "@/lib/utils";
 import {
   RiaCompatibilityState,
+  RiaPageShell,
   RiaVerificationGate,
 } from "@/components/ria/ria-page-shell";
 
@@ -209,9 +203,12 @@ export default function RiaClientsPage() {
   }
 
   return (
-    <AppPageShell
-      as="main"
-      width="agent"
+    <RiaPageShell
+      title="RIA"
+      icon={null}
+      titleRole="agent"
+      showRouteSelector
+      stackClassName="gap-8"
       nativeTest={{
         routeId: "/ria/clients",
         marker: "native-route-ria-clients",
@@ -223,20 +220,7 @@ export default function RiaClientsPage() {
             : "empty-valid",
       }}
     >
-      <AppPageHeaderRegion className="pt-2 sm:pt-3">
-        <PageHeader
-          title={RIA_COPY.clients.title}
-          description={RIA_COPY.clients.description}
-          accent="ria"
-          titleRole="agent"
-        />
-      </AppPageHeaderRegion>
-
-      <AppPageContentRegion>
-        <SurfaceStack className="gap-8">
-          <RiaRouteSelector />
-
-          <RiaVerificationGate>
+      <RiaVerificationGate>
             {/* Connected is the roster of investors who already granted access.
               Around you is prospecting against public records — a different
               kind of person entirely, which is why they are separate views on
@@ -351,9 +335,7 @@ export default function RiaClientsPage() {
                 )}
               </SettingsGroup>
             )}
-          </RiaVerificationGate>
-        </SurfaceStack>
-      </AppPageContentRegion>
-    </AppPageShell>
+      </RiaVerificationGate>
+    </RiaPageShell>
   );
 }

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -20,26 +20,21 @@ import {
 import { toast } from "sonner";
 
 import {
-  AppPageContentRegion,
-  AppPageHeaderRegion,
-  AppPageShell,
-} from "@/components/app-ui/app-page-shell";
-import {
   CommandPickerField,
   PopupTextEditorField,
   type CommandPickerOption,
 } from "@/components/app-ui/command-fields";
 import { DataTable } from "@/components/app-ui/data-table";
-import { PageHeader } from "@/components/app-ui/page-sections";
 import {
   SurfaceCard,
   SurfaceCardContent,
   SurfaceInset,
-  SurfaceStack,
 } from "@/components/app-ui/surfaces";
-import { RiaRouteSelector } from "@/components/ria/layout/ria-route-selector";
 import { SegmentedTabs } from "@/components/profile/settings-ui";
-import { RiaCompatibilityState } from "@/components/ria/ria-page-shell";
+import {
+  RiaCompatibilityState,
+  RiaPageShell,
+} from "@/components/ria/ria-page-shell";
 import { TemplatePreviewModal } from "@/components/ria/template-preview-modal";
 import {
   Table,
@@ -2685,13 +2680,12 @@ export default function RiaPicksPage() {
   }
 
   return (
-    <AppPageShell
-      as="main"
-      // Matches RiaPageShell's own default -- see its comment. The wide
-      // tables inside this screen already gate themselves behind
-      // `hidden md:block` and their own horizontal scroll, so narrowing the
-      // shell does not affect them.
-      width="agent"
+    <RiaPageShell
+      title="RIA"
+      icon={null}
+      titleRole="agent"
+      showRouteSelector
+      stackClassName="gap-6"
       nativeTest={{
         routeId: "/ria/picks",
         marker: "native-route-ria-picks",
@@ -2705,19 +2699,6 @@ export default function RiaPicksPage() {
         errorMessage: picksResource.error,
       }}
     >
-      <AppPageHeaderRegion className="pt-2 sm:pt-3">
-        <PageHeader
-          title={RIA_COPY.picks.title}
-          description={RIA_COPY.picks.description}
-          accent="ria"
-          titleRole="agent"
-        />
-      </AppPageHeaderRegion>
-
-      <AppPageContentRegion>
-        <SurfaceStack className="gap-6">
-          <RiaRouteSelector />
-
           <div data-testid="ria-picks-primary">
             <SegmentedTabs
               value={source}
@@ -3235,8 +3216,6 @@ export default function RiaPicksPage() {
               ) : null}
             </>
           }
-        </SurfaceStack>
-      </AppPageContentRegion>
-    </AppPageShell>
+    </RiaPageShell>
   );
 }

--- a/hushh-webapp/app/ria/profile/page.tsx
+++ b/hushh-webapp/app/ria/profile/page.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { InlineLoadingState } from "@/components/app-ui/inline-loading-state";
-import { RiaRouteSelector } from "@/components/ria/layout/ria-route-selector";
 import { RiaProfileSection } from "@/components/ria/profile/ria-profile-section";
 import { RiaPageShell } from "@/components/ria/ria-page-shell";
 import { Button } from "@/components/ui/button";
@@ -60,10 +59,10 @@ export default function RiaProfilePage() {
 
   return (
     <RiaPageShell
-      title="Profile"
-      description="Manage your advisor profile and verification details."
+      title="RIA"
       icon={null}
       titleRole="agent"
+      showRouteSelector
       nativeTest={{
         routeId: "ria-profile",
         marker: "ria-profile-page",
@@ -75,8 +74,6 @@ export default function RiaProfilePage() {
         dataState: authLoading || loading ? "loading" : "loaded",
       }}
     >
-      <RiaRouteSelector />
-
       {authLoading || loading ? (
         <InlineLoadingState label="Loading profile…" />
       ) : loadError && !status ? (

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -25,6 +25,7 @@ import {
   PageHeader,
   SectionHeader,
 } from "@/components/app-ui/page-sections";
+import { RiaRouteSelector } from "@/components/ria/layout/ria-route-selector";
 import {
   SurfaceCard,
   SurfaceInset,
@@ -41,6 +42,7 @@ export function RiaPageShell({
   actions,
   icon = BriefcaseBusiness,
   statusPanel,
+  showRouteSelector = false,
   children,
   // "standard" (90rem / 1440px) matched Connect and Marketplace, but those
   // are directory-browsing surfaces; RIA's own screens are read-and-act
@@ -66,6 +68,7 @@ export function RiaPageShell({
   actions?: ReactNode;
   icon?: LucideIcon | null;
   statusPanel?: ReactNode;
+  showRouteSelector?: boolean;
   children: ReactNode;
   width?: AppPageShellWidth;
   titleRole?: "page" | "agent";
@@ -113,6 +116,9 @@ export function RiaPageShell({
               : undefined
           }
         />
+        {showRouteSelector ? (
+          <RiaRouteSelector className="mt-4 sm:mt-5" />
+        ) : null}
       </AppPageHeaderRegion>
 
       <AppPageContentRegion className={contentClassName}>

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -8821,7 +8821,7 @@
       },
       "shell": {
         "app_page_shell": true,
-        "page_header": true,
+        "page_header": false,
         "settings_ui": true,
         "shared_loader": false,
         "back_button_pattern": "shared-shell"
@@ -9132,8 +9132,8 @@
         ]
       },
       "shell": {
-        "app_page_shell": true,
-        "page_header": true,
+        "app_page_shell": false,
+        "page_header": false,
         "settings_ui": false,
         "shared_loader": false,
         "back_button_pattern": "shared-shell"
@@ -9469,5 +9469,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "86ede78884530b922ad157bdf2feb1a2a3e71b5eac083a77f6dd863b9996807c"
+  "content_sha256": "440c9b7ae01be16b7b960f8afa2b86365aa56be1654f7c1f1a368b3e0f310f1f"
 }


### PR DESCRIPTION
## Summary
- align RIA Profile, Clients, and Picks with the Location agent header pattern
- render one stable RIA heading with Profile / Clients / Picks tabs underneath
- remove redundant route-local Profile/Clients/Picks page headers while preserving route/tab behavior

## Validation
- npm.cmd run typecheck
- npm.cmd run verify:design-system
- npm.cmd run verify:docs
- npm.cmd run verify:cache
- npx.cmd eslint app/ria/clients/page.tsx app/ria/picks/page.tsx app/ria/profile/page.tsx components/ria/ria-page-shell.tsx __tests__/app/ria/header-regression.contract.test.ts __tests__/app/ria/picks-page.test.tsx __tests__/app/ria/clients-page.test.tsx __tests__/app/ria/clients-page-switch-to-nearby.test.tsx --max-warnings=0
- npm.cmd run test -- __tests__/app/ria/header-regression.contract.test.ts __tests__/components/ria-route-selector.test.tsx __tests__/navigation/top-shell-tabs.test.ts __tests__/components/top-shell-route-swipe.test.tsx __tests__/app/ria/profile-page.test.tsx __tests__/app/ria/picks-page.test.tsx __tests__/app/ria/clients-page.test.tsx __tests__/app/ria/clients-page-switch-to-nearby.test.tsx
- git diff --check

## Notes
- frontend-only change; no backend/API/business logic files changed
- localhost stack verified reachable; authenticated RIA page still requires a valid signed-in browser session