### PR TITLE
fix(ria): align pagination with Connect

### DIFF
--- a/hushh-webapp/__tests__/components/data-table.test.tsx
+++ b/hushh-webapp/__tests__/components/data-table.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -143,5 +143,126 @@ describe("DataTable", () => {
     expect(
       document.querySelector('[data-slot="surface-data-table-shell"]'),
     ).toHaveClass("hidden", "md:block");
+  });
+
+  it("renders compact mobile pagination for card tables", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={makeRows(30)}
+        enableSearch={false}
+        initialPageSize={8}
+        pageSizeOptions={[8, 16, 24]}
+        renderMobileCard={(row) => (
+          <article data-testid="mobile-row-card">{row.name}</article>
+        )}
+      />,
+    );
+
+    const mobilePagination = document.querySelector(
+      '[data-slot="data-table-mobile-pagination"]',
+    );
+    const desktopFooter = document.querySelector(
+      '[data-slot="data-table-page-controls"]',
+    )?.parentElement;
+    const mobile = within(mobilePagination as HTMLElement);
+
+    expect(mobilePagination).toHaveClass("md:hidden");
+    expect(
+      mobile.getByRole("button", { name: "Go to previous page" }),
+    ).toBeTruthy();
+    expect(mobile.getByText("Page 1")).toBeTruthy();
+    expect(mobile.getByRole("button", { name: "Go to next page" })).toBeTruthy();
+    expect(mobilePagination?.textContent).not.toContain("Showing");
+    expect(desktopFooter).toHaveClass("hidden", "md:flex");
+  });
+
+  it("keeps dense page numbers out of mobile card pagination", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={makeRows(30)}
+        enableSearch={false}
+        initialPageSize={8}
+        pageSizeOptions={[8, 16, 24]}
+        renderMobileCard={(row) => (
+          <article data-testid="mobile-row-card">{row.name}</article>
+        )}
+      />,
+    );
+    const mobilePagination = document.querySelector(
+      '[data-slot="data-table-mobile-pagination"]',
+    );
+    const mobilePageNumberLinks = mobilePagination?.querySelectorAll(
+      '[data-slot="pagination-link"]',
+    );
+
+    expect(mobilePageNumberLinks).toHaveLength(0);
+  });
+
+  it("pages compact mobile card tables with previous and next controls", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={makeRows(30)}
+        enableSearch={false}
+        initialPageSize={8}
+        renderMobileCard={(row) => (
+          <article data-testid="mobile-row-card">{row.name}</article>
+        )}
+      />,
+    );
+
+    const mobilePagination = document.querySelector(
+      '[data-slot="data-table-mobile-pagination"]',
+    ) as HTMLElement;
+    const mobileList = document.querySelector(
+      '[data-slot="data-table-mobile-list"]',
+    ) as HTMLElement;
+    const mobile = within(mobilePagination);
+    const mobileRows = within(mobileList);
+
+    expect(mobile.getByText("Page 1")).toBeTruthy();
+    expect(
+      mobile.getByRole("button", { name: "Go to previous page" }),
+    ).toBeDisabled();
+    expect(mobileRows.getByText("Row 1")).toBeTruthy();
+
+    fireEvent.click(mobile.getByRole("button", { name: "Go to next page" }));
+
+    expect(mobile.getByText("Page 2")).toBeTruthy();
+    expect(mobileRows.getByText("Row 9")).toBeTruthy();
+    expect(mobileRows.queryByText("Row 1")).toBeNull();
+
+    fireEvent.click(mobile.getByRole("button", { name: "Go to previous page" }));
+
+    expect(mobile.getByText("Page 1")).toBeTruthy();
+    expect(mobileRows.getByText("Row 1")).toBeTruthy();
+  });
+
+  it("disables compact mobile next on the last card page", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={makeRows(9)}
+        enableSearch={false}
+        initialPageSize={8}
+        renderMobileCard={(row) => (
+          <article data-testid="mobile-row-card">{row.name}</article>
+        )}
+      />,
+    );
+
+    const mobilePagination = document.querySelector(
+      '[data-slot="data-table-mobile-pagination"]',
+    ) as HTMLElement;
+    const mobile = within(mobilePagination);
+
+    fireEvent.click(mobile.getByRole("button", { name: "Go to next page" }));
+
+    expect(mobile.getByText("Page 2")).toBeTruthy();
+    expect(
+      mobile.getByRole("button", { name: "Go to next page" }),
+    ).toBeDisabled();
   });
 });

--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -314,6 +314,51 @@ export function DataTable<TData, TValue>({
         </div>
       ) : null}
 
+      {renderMobileCard && hasMultiplePages ? (
+        <nav
+          aria-label="Table pagination"
+          aria-live="polite"
+          aria-atomic="true"
+          className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 px-1 pt-1 text-sm text-muted-foreground md:hidden"
+          data-no-route-swipe
+          data-slot="data-table-mobile-pagination"
+        >
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={!table.getCanPreviousPage()}
+            onClick={() => {
+              if (table.getCanPreviousPage()) {
+                table.previousPage();
+              }
+            }}
+            aria-label="Go to previous page"
+            className="justify-self-start"
+          >
+            Previous
+          </Button>
+          <span className="whitespace-nowrap text-center font-medium text-foreground">
+            Page {currentPage}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={!table.getCanNextPage()}
+            onClick={() => {
+              if (table.getCanNextPage()) {
+                table.nextPage();
+              }
+            }}
+            aria-label="Go to next page"
+            className="justify-self-end"
+          >
+            Next
+          </Button>
+        </nav>
+      ) : null}
+
       <div
         className={cn(
           surfaceDataTableShellClassName,
@@ -452,7 +497,12 @@ export function DataTable<TData, TValue>({
       </div>
 
       {hasMultiplePages && (
-        <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center sm:justify-between">
+        <div
+          className={cn(
+            "flex flex-col gap-3 pt-2 sm:flex-row sm:items-center sm:justify-between",
+            renderMobileCard && "hidden md:flex",
+          )}
+        >
           <div
             aria-live="polite"
             aria-atomic="true"


### PR DESCRIPTION
## Summary
- add a mobile-only DataTable pagination row for card tables: Previous | Page N | Next
- keep the existing dense desktop DataTable pagination unchanged
- cover the compact card pagination behavior with focused component tests

## Validation
- npx.cmd eslint components/app-ui/data-table.tsx __tests__/components/data-table.test.tsx --max-warnings=0
- npm.cmd run test -- __tests__/components/data-table.test.tsx __tests__/app/ria/picks-page.test.tsx
- npm.cmd run typecheck
- npm.cmd run verify:design-system
- npm.cmd run verify:docs
- npm.cmd run verify:cache
- git diff --check

No backend, API, or data contract changes.