### PR TITLE
Standardize agent segmented navigation UI

### DIFF
--- a/hushh-webapp/__tests__/components/settings-ui.test.tsx
+++ b/hushh-webapp/__tests__/components/settings-ui.test.tsx
@@ -415,6 +415,31 @@ describe("SegmentedTabs", () => {
     fireEvent.click(brokerage);
     expect(handleValueChange).not.toHaveBeenCalled();
   });
+
+  it("supports the scoped Location-style agent navigation variant", () => {
+    const { container } = render(
+      <SegmentedTabs
+        value="overview"
+        onValueChange={() => {}}
+        variant="agent-top"
+        options={[
+          { value: "overview", label: "Overview" },
+          { value: "receipts", label: "Receipts" },
+        ]}
+      />,
+    );
+
+    const root = container.firstElementChild;
+    const active = screen.getByRole("tab", { name: "Overview" });
+    const label = active.querySelector('[data-ui-contract="required-title"]');
+
+    expect(root).toHaveAttribute("data-ui-variant", "agent-top");
+    expect(root?.className).toContain("h-9");
+    expect(root?.className).toContain("rounded-[10px]");
+    expect(active.className).toContain("rounded-[8px]");
+    expect(active.className).toContain("mx-0.5");
+    expect(label).toHaveClass("ui-text-agent-tab-label");
+  });
 });
 
 describe("SettingsDetailPanel", () => {

--- a/hushh-webapp/app/one/kai/analysis/page.tsx
+++ b/hushh-webapp/app/one/kai/analysis/page.tsx
@@ -1227,6 +1227,7 @@ export function KaiAnalysisPageContent() {
                   value={workspaceTab}
                   onValueChange={handleWorkspaceTabChange}
                   options={workspaceTabOptions}
+                  variant="agent-top"
                   className="mx-auto w-full"
                 />
               </div>

--- a/hushh-webapp/components/gmail/gmail-workspace-navigation.tsx
+++ b/hushh-webapp/components/gmail/gmail-workspace-navigation.tsx
@@ -24,6 +24,7 @@ export function GmailWorkspaceNavigation({
       options={[...OPTIONS]}
       mobileColumns={3}
       ariaLabel="Gmail workspace"
+      variant="agent-top"
     />
   );
 }

--- a/hushh-webapp/components/kai/views/round-tabs-card.tsx
+++ b/hushh-webapp/components/kai/views/round-tabs-card.tsx
@@ -190,6 +190,7 @@ export function RoundTabsCard({
               value: agent,
               label: AGENT_CONFIG[agent].label,
             }))}
+            variant="agent-top"
             className="mb-4 w-full"
             ariaLabel={`${title} analysts`}
           />

--- a/hushh-webapp/components/profile/pkm-natural-panel.tsx
+++ b/hushh-webapp/components/profile/pkm-natural-panel.tsx
@@ -1085,6 +1085,7 @@ export function PkmNaturalPanel({
           onValueChange={(value) => setWorkspaceTab(value as MemoryWorkspaceTab)}
           options={MEMORY_WORKSPACE_TABS}
           mobileColumns={3}
+          variant="agent-top"
         />
         <SwipeViews
           options={MEMORY_WORKSPACE_TABS}

--- a/hushh-webapp/lib/morphy-ux/ui/segmented-tabs.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/segmented-tabs.tsx
@@ -10,6 +10,8 @@ export interface SegmentedTabOption {
   accessibleLabel?: string;
 }
 
+export type SegmentedTabsVariant = "default" | "agent-top";
+
 export function SegmentedTabs({
   value,
   onValueChange,
@@ -18,6 +20,7 @@ export function SegmentedTabs({
   disabled = false,
   className,
   ariaLabel,
+  variant = "default",
 }: {
   value: string;
   onValueChange: (value: string) => void;
@@ -27,6 +30,8 @@ export function SegmentedTabs({
   disabled?: boolean;
   className?: string;
   ariaLabel?: string;
+  /** Opt into the compact Location-style navigation presentation. */
+  variant?: SegmentedTabsVariant;
 }) {
   const resolvedDesktopColumns = Math.max(options.length, 1);
   const resolvedMobileColumns = Math.max(
@@ -38,9 +43,13 @@ export function SegmentedTabs({
     <div
       role="tablist"
       data-ui-role="segmented-tabs"
+      data-ui-variant={variant}
       aria-label={ariaLabel}
       className={cn(
-        "relative grid min-h-11 w-full rounded-[14px] p-0.5 backdrop-blur-xl [grid-template-columns:repeat(var(--segmented-mobile-cols),minmax(0,1fr))] sm:[grid-template-columns:repeat(var(--segmented-desktop-cols),minmax(0,1fr))]",
+        "relative grid w-full p-0.5 [grid-template-columns:repeat(var(--segmented-mobile-cols),minmax(0,1fr))] sm:[grid-template-columns:repeat(var(--segmented-desktop-cols),minmax(0,1fr))]",
+        variant === "agent-top"
+          ? "h-9 min-h-0 rounded-[10px]"
+          : "min-h-11 rounded-[14px] backdrop-blur-xl",
         "border-0 bg-[color:var(--app-segmented-track-surface)] shadow-none",
         className,
       )}
@@ -68,9 +77,15 @@ export function SegmentedTabs({
               if (!disabled && !isActive) onValueChange(option.value);
             }}
             className={cn(
-              "relative isolate flex min-h-10 min-w-0 items-center justify-center overflow-hidden rounded-[12px] border px-3 py-2 text-center transition-[background-color,border-color,box-shadow,color] duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)] sm:px-4",
+              "relative isolate flex min-w-0 items-center justify-center overflow-hidden border text-center transition-[background-color,border-color,box-shadow,color] duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent-ring)]",
+              variant === "agent-top"
+                ? "h-full min-h-0 rounded-[8px] px-1 py-0 min-[360px]:px-2 sm:px-3"
+                : "min-h-10 rounded-[12px] px-3 py-2 sm:px-4",
               isActive
-                ? "z-10 border-transparent bg-[color:var(--app-segmented-active-surface)] text-[color:var(--app-segmented-active-foreground)] font-semibold shadow-[var(--app-segmented-active-shadow)]"
+                ? cn(
+                    "z-10 border-transparent bg-[color:var(--app-segmented-active-surface)] text-[color:var(--app-segmented-active-foreground)] font-semibold shadow-[var(--app-segmented-active-shadow)]",
+                    variant === "agent-top" && "mx-0.5",
+                  )
                 : "border-transparent bg-transparent text-[color:var(--app-secondary-label)] [@media(hover:hover)]:hover:bg-[color:var(--app-neutral-fill)]",
               disabled && "cursor-not-allowed opacity-60",
             )}
@@ -91,7 +106,11 @@ export function SegmentedTabs({
               data-ui-contract="required-title"
               data-ui-truncation="forbid"
               data-ui-id={`segmented-tab-${option.value}`}
-              className="ui-text-form-label relative z-10 block min-w-0 truncate text-center"
+              className={
+                variant === "agent-top"
+                  ? "ui-text-agent-tab-label relative z-10 block min-w-0 truncate text-center"
+                  : "ui-text-form-label relative z-10 block min-w-0 truncate text-center"
+              }
             >
               {option.label}
             </span>


### PR DESCRIPTION
## Summary
- Standardize Gmail Overview / KYC / Receipts, Memory Saved / Add / Sharing, and Finance segmented views on the scoped Location-style presentation.
- Make Finance Fundamental / Sentiment / Valuation responsive without changing state, routing, or agent behavior.
- Leave Finance Market / Portfolio / Analysis underline navigation and unrelated selectors unchanged.

## Verification
- Focused tests, typecheck, lint, design/native static checks, web build, iOS simulator build/launch, and Android debug build/launch were completed locally before this Git/PR workflow.
- No UI builds or implementation work were rerun for this PR workflow.