### PR TITLE
fix(release): use managed Python for UAT voice readiness

### DIFF
--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -215,7 +215,7 @@ jobs:
           EXPECTED_SHA: ${{ needs.preflight.outputs.release_sha }}
         run: |
           set -euo pipefail
-          python3 scripts/ci/verify-one-voice-local-runtime-readiness.py \
+          uv run python scripts/ci/verify-one-voice-local-runtime-readiness.py \
             --backend-url "$NEXT_PUBLIC_BACKEND_URL" \
             --source-sha "$EXPECTED_SHA" \
             > "$RUNNER_TEMP/one-voice-local-runtime-readiness.json"


### PR DESCRIPTION
## Summary
- run the UAT local-runtime readiness gate with the managed uv Python runtime
- preserve the same TestFlight release SHA and capability contract

## Verification
- live UAT readiness verification with the managed runtime
- readiness verifier unit tests
- git diff --check