### PR TITLE
fix(vault): harden unlock flow — RP validation, cancel detection, timeout, stale closure

### DIFF
--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4913,7 +4913,7 @@
   "schema_version": "hushh.runtime_topology_index.v1",
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
-    "action_gateway": "3a541c6f9ce0a53ab5bae98291bba862802988891da91393240dba426810ba9e",
+    "action_gateway": "feb2b36ded39c3cc1ed7cc44167f02b029d001c9bc6077accbda2a7a78dc3bd4",
     "agent_registry": "8f9c669153e52a57c68ca44db8b8419c1ecc8bb489ceee21a6286ca2eba3c207",
     "cache_manifest": "590437b754d2f4b9be78ee55d1854564044bd12f5adb4b44902338e405b70ea2",
     "data_plane": "314c1b4e33e47c02b2438aade82b0b92d09f21404e7dbff62b45463b2f51d70c",

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -19,10 +19,15 @@ import {
   Copy,
   Download,
   Fingerprint,
+  Eye,
+  EyeOff,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { VaultService } from "@/lib/services/vault-service";
+import {
+  VaultAuthSessionNotReadyError,
+  VaultService,
+} from "@/lib/services/vault-service";
 import { downloadTextFile } from "@/lib/utils/native-download";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -41,7 +46,6 @@ import { VaultMethodPromptLocalService } from "@/lib/services/vault-method-promp
 import { resolvePasskeyRpId } from "@/lib/vault/passkey-rp";
 import { checkPrfSupport } from "@/lib/vault/prf-auth";
 import { copyToClipboard } from "@/lib/utils/clipboard";
-import { reloadWindow } from "@/lib/utils/browser-navigation";
 import {
   toInvestorLoading,
   toInvestorMessage,
@@ -76,6 +80,8 @@ interface VaultFlowProps {
    */
   onRecoveryKeyDisclosureChange?: (active: boolean) => void;
   enableGeneratedDefault?: boolean;
+  /** Hard gates own the automatic passkey ceremony when surfaces overlap. */
+  isHardGate?: boolean;
   /**
    * Setup routes may open an existing vault but must never create one before
    * the root "Finish setup" boundary. The post-setup invitation keeps the
@@ -92,6 +98,202 @@ interface VaultFlowProps {
 
 const VAULT_ALTERNATIVE_BUTTON_CLASS =
   "h-11 rounded-full border border-[color:var(--app-accent-border)] px-3 text-[13px] font-medium sm:text-[14px] !bg-[color:var(--app-accent-tint)] !text-[color:var(--app-accent-deep)] hover:!bg-[color:var(--app-accent-surface-strong)]";
+
+// A passkey cancellation is a normal user decision, not an application
+// failure. Keep it in the credential surface so the user can choose a
+// fallback without a disappearing toast or an automatic second ceremony.
+//
+// A bare "cancel" or "cancelled" substring is too broad — it matches
+// aborted fetches, cancelled analytics, and other non-WebAuthn noise.
+// Require at least one WebAuthn-specific context word alongside the
+// cancellation signal so we only silence real passkey dismissals.
+const WEBAUTHN_CANCEL_CONTEXT = [
+  "passkey",
+  "authentication",
+  "credential",
+  "webauthn",
+  "webauth",
+  "user",
+  "operation",
+  "request",
+  "prompt",
+  "securitykey",
+  "security key",
+];
+
+function isWebAuthnCancellationError(value: unknown): boolean {
+  const error = value as { name?: unknown; message?: unknown; code?: unknown } | null;
+  const name = typeof error?.name === "string" ? error.name.toLowerCase() : "";
+  const code = typeof error?.code === "string" ? error.code.toLowerCase() : "";
+  const message =
+    typeof value === "string"
+      ? value.toLowerCase()
+      : typeof error?.message === "string"
+        ? error.message.toLowerCase()
+        : "";
+
+  // AbortError / NotAllowedError from navigator.credentials.get are the
+  // two most reliable signals — they are DOMException names, not strings.
+  if (name === "aborterror" || name === "notallowederror") return true;
+
+  // Structured AbortSignal cancellation codes used by some frameworks.
+  if (code.includes("cancel") || code.includes("abort")) return true;
+
+  // For substring matches, require a WebAuthn context word near the cancel
+  // term so we don't misclassify unrelated cancellations. Match both
+  // British "cancelled" and American "canceled" spellings.
+  const hasCancel = (text: string): boolean =>
+    /cancell?ed?/i.test(text) || /timed out or was not allowed/i.test(text);
+
+  if (hasCancel(message)) {
+    return WEBAUTHN_CANCEL_CONTEXT.some((ctx) => message.includes(ctx));
+  }
+
+  // A few platform-specific cancellation strings that carry their own context.
+  const explicitCancelPhrases = [
+    "passkey request cancelled",
+    "passkey request canceled",
+    "passkey authentication cancelled",
+    "passkey authentication canceled",
+    "user cancelled",
+    "user canceled",
+    "cancelled by user",
+    "canceled by user",
+  ];
+  return explicitCancelPhrases.some((phrase) => message.includes(phrase));
+}
+
+function isDuplicateWebAuthnError(value: unknown): boolean {
+  const error = value as { name?: unknown; message?: unknown } | null;
+  const name = typeof error?.name === "string" ? error.name : "";
+  const message = typeof error?.message === "string" ? error.message : "";
+  return (
+    name === "WebAuthnCeremonyInProgressError" ||
+    message.toLowerCase().includes("already in progress")
+  );
+}
+
+const PASSKEY_UNLOCK_CANCELLED_MESSAGE =
+  "Passkey unlock was cancelled. Choose Passphrase or Recovery key below, or tap Passkey to try again.";
+const GENERATED_UNLOCK_CANCELLED_EVENT = "vault-generated-unlock-cancelled";
+
+type GeneratedUnlockClaim = {
+  owner: symbol;
+  userId: string;
+  mode: GeneratedVaultKeyMode;
+};
+
+type GeneratedUnlockAttemptSource = "automatic" | "user";
+
+function isGeneratedVaultKeyMode(
+  value: string,
+): value is GeneratedVaultKeyMode {
+  return (
+    value === "generated_default_native_biometric" ||
+    value === "generated_default_web_prf" ||
+    value === "generated_default_native_passkey_prf"
+  );
+}
+
+// A locked session can briefly have more than one mounted VaultFlow while a
+// route gate takes ownership. The browser and the native Credential Manager
+// must see one page-wide ceremony, and a user cancellation must follow that
+// session across the handoff instead of being treated as permission to prompt
+// again from the newly mounted flow.
+let activeGeneratedUnlockClaim: GeneratedUnlockClaim | null = null;
+let cancelledGeneratedUnlock: Omit<GeneratedUnlockClaim, "owner"> | null = null;
+const activeGeneratedUnlockSurfaces = new Map<string, number>();
+
+function registerGeneratedUnlockSurface(userId: string): () => void {
+  activeGeneratedUnlockSurfaces.set(
+    userId,
+    (activeGeneratedUnlockSurfaces.get(userId) ?? 0) + 1,
+  );
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+
+    const count = activeGeneratedUnlockSurfaces.get(userId) ?? 0;
+    if (count <= 1) {
+      activeGeneratedUnlockSurfaces.delete(userId);
+    } else {
+      activeGeneratedUnlockSurfaces.set(userId, count - 1);
+    }
+
+    // Once the last unlock surface is gone and no native/browser ceremony is
+    // still settling, the next deliberate unlock is a fresh session.
+    if (activeGeneratedUnlockClaim === null && activeGeneratedUnlockSurfaces.size === 0) {
+      cancelledGeneratedUnlock = null;
+    }
+  };
+}
+
+function isGeneratedUnlockCancelled(
+  userId: string,
+  mode: GeneratedVaultKeyMode,
+): boolean {
+  return (
+    cancelledGeneratedUnlock?.userId === userId &&
+    cancelledGeneratedUnlock.mode === mode
+  );
+}
+
+function clearGeneratedUnlockCancellation(
+  userId: string,
+  mode: GeneratedVaultKeyMode,
+): void {
+  if (isGeneratedUnlockCancelled(userId, mode)) {
+    cancelledGeneratedUnlock = null;
+  }
+}
+
+function claimGeneratedUnlock(
+  owner: symbol,
+  userId: string,
+  mode: GeneratedVaultKeyMode,
+  source: GeneratedUnlockAttemptSource,
+): "claimed" | "busy" | "cancelled" {
+  if (source === "automatic" && isGeneratedUnlockCancelled(userId, mode)) {
+    return "cancelled";
+  }
+  if (source === "user") {
+    clearGeneratedUnlockCancellation(userId, mode);
+  }
+  if (
+    activeGeneratedUnlockClaim &&
+    activeGeneratedUnlockClaim.owner !== owner
+  ) {
+    return "busy";
+  }
+  activeGeneratedUnlockClaim = { owner, userId, mode };
+  return "claimed";
+}
+
+function markGeneratedUnlockCancelled(
+  owner: symbol,
+  userId: string,
+  mode: GeneratedVaultKeyMode,
+): void {
+  if (activeGeneratedUnlockClaim?.owner !== owner) return;
+  cancelledGeneratedUnlock = { userId, mode };
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent(GENERATED_UNLOCK_CANCELLED_EVENT, {
+        detail: { userId, mode },
+      }),
+    );
+  }
+}
+
+function releaseGeneratedUnlock(owner: symbol): void {
+  if (activeGeneratedUnlockClaim?.owner !== owner) return;
+  activeGeneratedUnlockClaim = null;
+  if (activeGeneratedUnlockSurfaces.size === 0) {
+    cancelledGeneratedUnlock = null;
+  }
+}
 
 function VaultFlowHeader({
   icon,
@@ -139,14 +341,19 @@ export function VaultFlow({
   onStepChange,
   onRecoveryKeyDisclosureChange,
   enableGeneratedDefault = false,
+  isHardGate = false,
   allowVaultCreation = true,
   onSignOut,
 }: VaultFlowProps) {
   const [step, setStep] = useState<VaultStep>("checking");
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isRestoringSession, setIsRestoringSession] = useState(false);
+  const [checkAttempt, setCheckAttempt] = useState(0);
   const [passphrase, setPassphrase] = useState("");
+  const [showPassphrase, setShowPassphrase] = useState(false);
   const [confirmPassphrase, setConfirmPassphrase] = useState("");
+  const [showConfirmPassphrase, setShowConfirmPassphrase] = useState(false);
   const [recoveryKey, setRecoveryKey] = useState<string>("");
   const [recoveryKeyInput, setRecoveryKeyInput] = useState("");
   const [copied, setCopied] = useState(false);
@@ -197,6 +404,9 @@ export function VaultFlow({
     "unknown" | "available" | "unavailable"
   >("unknown");
   const autoGeneratedPromptedRef = useRef(false);
+  const generatedUnlockAttemptRef = useRef(false);
+  const generatedUnlockCancelledRef = useRef(false);
+  const flowInstanceRef = useRef(Symbol("vault-flow"));
   const signOutRequestedRef = useRef(false);
   // React state updates after an event. These guards make the underlying vault
   // operation idempotent when Enter and a pointer action land in the same turn.
@@ -213,7 +423,37 @@ export function VaultFlow({
     hostname: hostname,
   });
 
-  const { unlockVault } = useVault();
+  const { isVaultUnlocked, unlockVault } = useVault();
+
+  useEffect(
+    () => registerGeneratedUnlockSurface(user.uid),
+    [user.uid],
+  );
+
+  useEffect(() => {
+    const handleGeneratedUnlockCancelled = (event: Event) => {
+      const detail = (event as CustomEvent<{
+        userId?: unknown;
+        mode?: unknown;
+      }>).detail;
+      if (detail?.userId !== user.uid || detail.mode !== vaultMode) return;
+
+      generatedUnlockCancelledRef.current = true;
+      setUnlockWithPassphraseFallback(true);
+      setError(PASSKEY_UNLOCK_CANCELLED_MESSAGE);
+    };
+
+    window.addEventListener(
+      GENERATED_UNLOCK_CANCELLED_EVENT,
+      handleGeneratedUnlockCancelled,
+    );
+    return () => {
+      window.removeEventListener(
+        GENERATED_UNLOCK_CANCELLED_EVENT,
+        handleGeneratedUnlockCancelled,
+      );
+    };
+  }, [user.uid, vaultMode]);
 
   // Notify parent of step changes
   useEffect(() => {
@@ -313,14 +553,19 @@ export function VaultFlow({
     hasGeneratedUnlockAlternative &&
     !unlockWithPassphraseFallback &&
     !webPasskeyUnsupported;
+  const showPasskeyFallbackAlternative =
+    !webPasskeyUnsupported &&
+    !error &&
+    ((hasActiveGeneratedWrapper && unlockWithPassphraseFallback) ||
+      showPasskeyAlternative);
   const showRecoveryAlternative = true;
   const showUnlockOtherMethods =
-    showVaultKeyAlternative || showPasskeyAlternative || showRecoveryAlternative;
+    showVaultKeyAlternative ||
+    showPasskeyFallbackAlternative ||
+    showRecoveryAlternative;
   const unlockAlternativeCount = [
     showVaultKeyAlternative,
-    !webPasskeyUnsupported &&
-      ((hasActiveGeneratedWrapper && unlockWithPassphraseFallback) ||
-        showPasskeyAlternative),
+    showPasskeyFallbackAlternative,
     showRecoveryAlternative,
   ].filter(Boolean).length;
   const generatedUnlockError =
@@ -353,6 +598,7 @@ export function VaultFlow({
       return;
     }
     signOutRequestedRef.current = true;
+    releaseGeneratedUnlock(flowInstanceRef.current);
     setIsSigningOut(true);
     setIsUnlocking(false);
     try {
@@ -370,8 +616,12 @@ export function VaultFlow({
 
   // Initial Vault Status Check
   useEffect(() => {
-    const checkStatus = async () => {
+    let cancelled = false;
+    const MAX_SESSION_RESTORE_ATTEMPTS = 3;
+
+    const checkStatus = async (restoreAttempt = 0) => {
       try {
+        setIsRestoringSession(false);
         // Start the vault-state read in parallel with the existence check so a
         // cold backend pays a single round-trip latency instead of two
         // sequential cold calls (which made the first unlock feel slow). The
@@ -382,6 +632,7 @@ export function VaultFlow({
         vaultStatePromise.catch(() => undefined);
 
         const hasVault = await VaultService.checkVault(user.uid);
+        if (cancelled) return;
         if (!hasVault) {
           if (!allowVaultCreation) {
             setStep("setup_required");
@@ -401,6 +652,7 @@ export function VaultFlow({
         try {
           setUnlockHint(null);
           const vaultData = await vaultStatePromise;
+          if (cancelled) return;
           const preferPassphraseForAutomation =
             shouldSkipGeneratedVaultUnlockForAutomation();
           const primaryWrapper = VaultService.getPrimaryWrapper(vaultData);
@@ -448,15 +700,33 @@ export function VaultFlow({
             setUnlockWithPassphraseFallback(false);
           }
         } catch (metadataError) {
-          console.warn("Vault mode detection failed, defaulting to passphrase:", metadataError);
-          setVaultMode("passphrase");
-          setAvailableGeneratedMethod(null);
-          setUnlockWithPassphraseFallback(false);
-          setUnlockHint(null);
+          // A failed metadata read is not evidence of a passphrase Vault.
+          // In particular, terminal account errors must never select unlock.
+          throw metadataError;
         }
         setStep("unlock");
       } catch (err) {
+        if (cancelled) return;
+        // A Firebase session still restoring is not a Vault failure -- it is
+        // evidence we asked before a token existed. Show a transient
+        // "restoring" state and retry a bounded number of times instead of
+        // surfacing a hard failure for what is, in most cases, a race that
+        // resolves within a second.
+        if (
+          err instanceof VaultAuthSessionNotReadyError &&
+          restoreAttempt < MAX_SESSION_RESTORE_ATTEMPTS
+        ) {
+          if (cancelled) return;
+          setIsRestoringSession(true);
+          setError(null);
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          if (cancelled) return;
+          await checkStatus(restoreAttempt + 1);
+          return;
+        }
+
         console.error("Vault status check failed:", err);
+        setIsRestoringSession(false);
         const errorCode =
           typeof (err as { code?: unknown } | null | undefined)?.code === "string"
             ? (err as { code: string }).code
@@ -472,8 +742,17 @@ export function VaultFlow({
         }
       }
     };
-    checkStatus();
-  }, [allowVaultCreation, nativeTestConfig.vaultPassphrase, shouldPreferPassphraseUnlock, user.uid]);
+    void checkStatus();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    allowVaultCreation,
+    checkAttempt,
+    nativeTestConfig.vaultPassphrase,
+    shouldPreferPassphraseUnlock,
+    user.uid,
+  ]);
 
   useLayoutEffect(() => {
     if (step !== "unlock") {
@@ -672,65 +951,107 @@ export function VaultFlow({
     user.uid,
   ]);
 
-  const handleUnlockGeneratedDefault = useCallback(async () => {
-    setIsUnlocking(true);
-    try {
-      setError(null);
+  const handleUnlockGeneratedDefault = useCallback(
+    async (source: GeneratedUnlockAttemptSource = "user") => {
       if (
-        Capacitor.isNativePlatform() &&
-        vaultMode === "generated_default_web_prf"
+        generatedUnlockAttemptRef.current ||
+        !isGeneratedVaultKeyMode(vaultMode)
       ) {
-        throw new Error(
-          toInvestorMessage("VAULT_PASSKEY_ENROLL_REQUIRED")
-        );
-      }
-      const vaultData = await VaultService.getVaultState(user.uid);
-      const generatedWrapper = VaultService.getWrapperByMethod(vaultData, vaultMode, {
-        wrapperId:
-          vaultData.primaryMethod === vaultMode
-            ? vaultData.primaryWrapperId
-            : undefined,
-      });
-      if (!generatedWrapper) {
-        throw new Error("Quick unlock is not enabled on this device yet.");
-      }
-      const decryptedKey = await VaultService.unlockGeneratedDefaultVault({
-        userId: user.uid,
-        encryptedVaultKey: generatedWrapper.encryptedVaultKey,
-        salt: generatedWrapper.salt,
-        iv: generatedWrapper.iv,
-        keyMode: generatedWrapper.method,
-        authMethod: generatedWrapper.method,
-        passkeyCredentialId: generatedWrapper.passkeyCredentialId,
-        passkeyPrfSalt: generatedWrapper.passkeyPrfSalt,
-      });
-
-      if (!decryptedKey) {
-        throw new Error("Quick unlock is not ready. Use your passphrase.");
-      }
-
-      await VaultService.assertVaultKeyMatchesState(vaultData, decryptedKey);
-      await finalizeUnlock(decryptedKey);
-      setIsUnlocking(false);
-    } catch (err: any) {
-      // A pending WebAuthn ceremony that was superseded by a newer attempt
-      // rejects with an AbortError. That is expected and not a user-facing
-      // failure: the newer attempt owns the unlocking state, so we bail out
-      // quietly without surfacing an error or resetting isUnlocking (which the
-      // active request still owns).
-      if (err?.name === "AbortError") {
-        console.debug(
-          "Generated vault unlock superseded by a newer attempt; ignoring AbortError."
-        );
         return;
       }
-      console.error("Generated vault unlock failed:", err);
-      const message = toInvestorVaultUnlockError(err);
-      setError(message);
-      toast.error(message);
-      setIsUnlocking(false);
-    }
-  }, [finalizeUnlock, user.uid, vaultMode]);
+      const generatedMode = vaultMode;
+      const claim = claimGeneratedUnlock(
+        flowInstanceRef.current,
+        user.uid,
+        generatedMode,
+        source,
+      );
+      if (claim === "cancelled") {
+        generatedUnlockCancelledRef.current = true;
+        setUnlockWithPassphraseFallback(true);
+        setError(PASSKEY_UNLOCK_CANCELLED_MESSAGE);
+        return;
+      }
+      if (claim === "busy") {
+        return;
+      }
+      generatedUnlockAttemptRef.current = true;
+      setIsUnlocking(true);
+      try {
+        setError(null);
+        if (
+          Capacitor.isNativePlatform() &&
+          generatedMode === "generated_default_web_prf"
+        ) {
+          throw new Error(
+            toInvestorMessage("VAULT_PASSKEY_ENROLL_REQUIRED")
+          );
+        }
+        const vaultData = await VaultService.getVaultState(user.uid);
+        const generatedWrapper = VaultService.getWrapperByMethod(vaultData, generatedMode, {
+          wrapperId:
+            vaultData.primaryMethod === generatedMode
+              ? vaultData.primaryWrapperId
+              : undefined,
+        });
+        if (!generatedWrapper) {
+          throw new Error("Quick unlock is not enabled on this device yet.");
+        }
+        const decryptedKey = await VaultService.unlockGeneratedDefaultVault({
+          userId: user.uid,
+          encryptedVaultKey: generatedWrapper.encryptedVaultKey,
+          salt: generatedWrapper.salt,
+          iv: generatedWrapper.iv,
+          keyMode: generatedWrapper.method,
+          authMethod: generatedWrapper.method,
+          passkeyCredentialId: generatedWrapper.passkeyCredentialId,
+          passkeyPrfSalt: generatedWrapper.passkeyPrfSalt,
+          passkeyRpId: generatedWrapper.passkeyRpId,
+        });
+
+        if (!decryptedKey) {
+          throw new Error("Quick unlock is not ready. Use your passphrase.");
+        }
+
+        await VaultService.assertVaultKeyMatchesState(vaultData, decryptedKey);
+        await finalizeUnlock(decryptedKey);
+      } catch (err: any) {
+        // A duplicate caller is rejected before it can reach the browser. The
+        // original ceremony remains active and owns the visible prompt.
+        if (isDuplicateWebAuthnError(err)) {
+          return;
+        }
+        if (isWebAuthnCancellationError(err)) {
+          generatedUnlockCancelledRef.current = true;
+          markGeneratedUnlockCancelled(
+            flowInstanceRef.current,
+            user.uid,
+            generatedMode,
+          );
+          setUnlockWithPassphraseFallback(true);
+          setError(PASSKEY_UNLOCK_CANCELLED_MESSAGE);
+          return;
+        }
+        console.error("Generated vault unlock failed:", err);
+        const message = toInvestorVaultUnlockError(err);
+        setError(message);
+      } finally {
+        generatedUnlockAttemptRef.current = false;
+        releaseGeneratedUnlock(flowInstanceRef.current);
+        setIsUnlocking(false);
+      }
+    },
+    [finalizeUnlock, user.uid, vaultMode],
+  );
+
+  const handleRetryGeneratedUnlock = useCallback(() => {
+    if (isUnlocking || !isGeneratedVaultKeyMode(vaultMode)) return;
+    generatedUnlockCancelledRef.current = false;
+    clearGeneratedUnlockCancellation(user.uid, vaultMode);
+    setError(null);
+    setUnlockWithPassphraseFallback(false);
+    void handleUnlockGeneratedDefault("user");
+  }, [handleUnlockGeneratedDefault, isUnlocking, user.uid, vaultMode]);
 
   const handleRecoveryKeySubmit = async () => {
     setIsUnlocking(true);
@@ -828,8 +1149,10 @@ export function VaultFlow({
             // A refused or unavailable authenticator must not cost the vault
             // that was just created. The passphrase wrapper is already written,
             // so the only thing lost is the shortcut.
-            console.error("Quick unlock enable failed:", quickUnlockError);
-            toast.error("Couldn't turn that on. Your passphrase still works.");
+            if (!isWebAuthnCancellationError(quickUnlockError)) {
+              console.warn("Quick unlock enable failed:", quickUnlockError);
+              toast.error("Couldn't turn that on. Your passphrase still works.");
+            }
           }
         } else {
           try {
@@ -923,14 +1246,19 @@ export function VaultFlow({
   }, [webPrfDecision, vaultMode]);
 
   useEffect(() => {
+    const anotherHardGateIsActive =
+      !isHardGate &&
+      typeof document !== "undefined" &&
+      document.documentElement.hasAttribute("data-vault-unlock-hard-gate");
     if (
+      isVaultUnlocked ||
+      anotherHardGateIsActive ||
       step !== "unlock" ||
       !hasActiveGeneratedWrapper ||
       skipGeneratedUnlockForAutomation ||
       unlockWithPassphraseFallback ||
       webPrfAutoPromptBlocked
     ) {
-      autoGeneratedPromptedRef.current = false;
       return;
     }
     // Never start a second ceremony while one is already running. Without this,
@@ -939,14 +1267,27 @@ export function VaultFlow({
     if (isUnlocking) return;
     if (autoGeneratedPromptedRef.current) return;
     autoGeneratedPromptedRef.current = true;
-    void handleUnlockGeneratedDefault();
+    if (
+      isGeneratedVaultKeyMode(vaultMode) &&
+      isGeneratedUnlockCancelled(user.uid, vaultMode)
+    ) {
+      generatedUnlockCancelledRef.current = true;
+      setUnlockWithPassphraseFallback(true);
+      setError(PASSKEY_UNLOCK_CANCELLED_MESSAGE);
+      return;
+    }
+    void handleUnlockGeneratedDefault("automatic");
   }, [
     handleUnlockGeneratedDefault,
     hasActiveGeneratedWrapper,
     isUnlocking,
+    isVaultUnlocked,
+    isHardGate,
     skipGeneratedUnlockForAutomation,
     step,
+    user.uid,
     unlockWithPassphraseFallback,
+    vaultMode,
     webPrfAutoPromptBlocked,
   ]);
 
@@ -994,19 +1335,35 @@ export function VaultFlow({
               </div>
               <p className="text-muted-foreground">{error}</p>
               <Button
-                onClick={reloadWindow}
+                onClick={() => {
+                  // A clean restart of the whole check, not a page reload:
+                  // re-enter "checking" and re-run the effect from scratch
+                  // rather than dragging a stale error/step across a retry.
+                  setError(null);
+                  setIsRestoringSession(false);
+                  setCheckAttempt((attempt) => attempt + 1);
+                }}
                 variant="none"
                 className="border border-input bg-background hover:bg-accent hover:text-accent-foreground"
               >
                 Try again
               </Button>
+              {signOutEscape}
             </div>
           </div>
         </Card>
       );
     }
 
-    return <HushhLoader label={toInvestorLoading("VAULT")} />;
+    return (
+      <HushhLoader
+        label={
+          isRestoringSession
+            ? "Restoring your session…"
+            : toInvestorLoading("VAULT")
+        }
+      />
+    );
   }
 
   return (
@@ -1065,7 +1422,7 @@ export function VaultFlow({
                   <Icon icon={Key} size={18} className="shrink-0 text-foreground/50" />
                   <input
                     id="passphrase"
-                    type="password"
+                    type={showPassphrase ? "text" : "password"}
                     placeholder="Create passphrase"
                     value={passphrase}
                     onChange={(e) => setPassphrase(e.target.value)}
@@ -1073,6 +1430,15 @@ export function VaultFlow({
                     autoComplete="new-password"
                     className="min-w-0 flex-1 bg-transparent text-[16px] text-foreground caret-[color:var(--app-accent)] outline-none placeholder:text-foreground/35"
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassphrase((prev) => !prev)}
+                    className="shrink-0 p-1 text-foreground/50 transition-colors hover:text-foreground focus:outline-none"
+                    aria-label={showPassphrase ? "Hide passphrase" : "Show passphrase"}
+                    title={showPassphrase ? "Hide passphrase" : "Show passphrase"}
+                  >
+                    <Icon icon={showPassphrase ? EyeOff : Eye} size={18} />
+                  </button>
                 </div>
               </div>
               <div className="space-y-1.5">
@@ -1091,13 +1457,22 @@ export function VaultFlow({
                   <Icon icon={Key} size={18} className="shrink-0 text-foreground/50" />
                   <input
                     id="confirm"
-                    type="password"
+                    type={showConfirmPassphrase ? "text" : "password"}
                     placeholder="Confirm passphrase"
                     value={confirmPassphrase}
                     onChange={(e) => setConfirmPassphrase(e.target.value)}
                     autoComplete="new-password"
                     className="min-w-0 flex-1 bg-transparent text-[16px] text-foreground caret-[color:var(--app-accent)] outline-none placeholder:text-foreground/35"
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassphrase((prev) => !prev)}
+                    className="shrink-0 p-1 text-foreground/50 transition-colors hover:text-foreground focus:outline-none"
+                    aria-label={showConfirmPassphrase ? "Hide passphrase" : "Show passphrase"}
+                    title={showConfirmPassphrase ? "Hide passphrase" : "Show passphrase"}
+                  >
+                    <Icon icon={showConfirmPassphrase ? EyeOff : Eye} size={18} />
+                  </button>
                 </div>
                 {createPassphraseHelperText && (
                   <p className="text-xs font-medium text-destructive" role="status">
@@ -1207,7 +1582,7 @@ export function VaultFlow({
                     <Icon icon={Key} size={18} className="shrink-0 text-foreground/50" />
                     <input
                       id="unlock-passphrase"
-                      type="password"
+                      type={showPassphrase ? "text" : "password"}
                       placeholder="Enter passphrase"
                       aria-label="Vault passphrase"
                       value={passphrase}
@@ -1219,6 +1594,15 @@ export function VaultFlow({
                       autoComplete="current-password"
                       className="min-w-0 flex-1 bg-transparent text-[16px] text-foreground caret-[color:var(--app-accent)] outline-none placeholder:text-foreground/35"
                     />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassphrase((prev) => !prev)}
+                      className="shrink-0 p-1 text-foreground/50 transition-colors hover:text-foreground focus:outline-none"
+                      aria-label={showPassphrase ? "Hide passphrase" : "Show passphrase"}
+                      title={showPassphrase ? "Hide passphrase" : "Show passphrase"}
+                    >
+                      <Icon icon={showPassphrase ? EyeOff : Eye} size={18} />
+                    </button>
                   </div>
                 </div>
               )}
@@ -1268,17 +1652,17 @@ export function VaultFlow({
                   </div>
                 )}
 
-                {hasActiveGeneratedWrapper && !unlockWithPassphraseFallback && error && (
+                {hasActiveGeneratedWrapper && error && (
                   <Button
                     variant="none"
                     effect="fade"
                     size="default"
                     fullWidth
                     className="h-10 text-sm sm:h-11"
-                    onClick={() => void handleUnlockGeneratedDefault()}
+                    onClick={handleRetryGeneratedUnlock}
                     disabled={isUnlocking}
                   >
-                    Try passkey again
+                    Passkey
                   </Button>
                 )}
 
@@ -1308,9 +1692,7 @@ export function VaultFlow({
                           Passphrase
                         </Button>
                       ) : null}
-                      {!webPasskeyUnsupported &&
-                      ((hasActiveGeneratedWrapper && unlockWithPassphraseFallback) ||
-                        showPasskeyAlternative) ? (
+                      {showPasskeyFallbackAlternative ? (
                         <Button
                           variant="none"
                           effect="fade"
@@ -1318,6 +1700,14 @@ export function VaultFlow({
                           fullWidth
                           className={VAULT_ALTERNATIVE_BUTTON_CLASS}
                           onClick={() => {
+                            generatedUnlockCancelledRef.current = false;
+                            if (availableGeneratedMethod) {
+                              clearGeneratedUnlockCancellation(
+                                user.uid,
+                                availableGeneratedMethod,
+                              );
+                            }
+                            autoGeneratedPromptedRef.current = false;
                             setError(null);
                             setPassphrase("");
                             setUnlockWithPassphraseFallback(false);
@@ -1467,6 +1857,22 @@ export function VaultFlow({
                 } and still retain passphrase and recovery-key backup.`}
               />
 
+              {error ? (
+                <Alert
+                  role="alert"
+                  className="rounded-[18px] border-[color:var(--app-accent-border)] bg-[color:var(--app-accent-tint)] px-3.5 py-3 text-left"
+                >
+                  <Icon
+                    icon={AlertCircle}
+                    size="sm"
+                    className="mt-0.5 text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-deep)]"
+                  />
+                  <AlertDescription className="type-footnote leading-snug text-foreground">
+                    {error}
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+
               <div className="flex flex-col gap-3 pt-2">
                 <Button
                   variant="blue-gradient"
@@ -1495,10 +1901,16 @@ export function VaultFlow({
                           : "Biometric unlock enabled."
                       );
                     } catch (err: any) {
-                      console.error("Quick unlock enable failed:", err);
-                      toast.error(
-                        err?.message || "Couldn't enable quick unlock right now."
-                      );
+                      if (isWebAuthnCancellationError(err)) {
+                        setError(
+                          "Passkey setup was cancelled. Your passphrase still works."
+                        );
+                      } else {
+                        console.error("Quick unlock enable failed:", err);
+                        toast.error(
+                          err?.message || "Couldn't enable quick unlock right now."
+                        );
+                      }
                     } finally {
                       setIsUnlocking(false);
                     }

--- a/hushh-webapp/lib/copy/investor-language.ts
+++ b/hushh-webapp/lib/copy/investor-language.ts
@@ -49,11 +49,11 @@ export function toInvestorMessage(
     case "ONBOARDING_STATE_UNAVAILABLE":
       return "We could not load your onboarding progress. Please try again.";
     case "VAULT_STATUS_UNAVAILABLE":
-      return "We could not reach it right now. Check your connection and try again.";
+      return "We could not reach Vault right now. Check your connection and try again.";
     case "LOCAL_BACKEND_UNAVAILABLE":
       return "Local backend information is unavailable right now. Start the local backend with the proxy-aware launcher, then try again.";
     case "VAULT_UNLOCK_FAILED":
-      return "We could not unlock it. Please confirm your details and try again.";
+      return "We could not unlock your Vault. Please confirm your details and try again.";
     case "VAULT_PASSKEY_ENROLL_REQUIRED":
       return "This passkey was enrolled under an older domain. Use your passphrase once, then enable passkey again for one.hushh.ai.";
     case "MARKET_DATA_UNAVAILABLE":
@@ -81,6 +81,13 @@ export function toInvestorVaultUnlockError(value: unknown): string {
   const lowered = raw.toLowerCase();
 
   if (
+    lowered.includes("relying party id is not a registrable domain suffix") ||
+    lowered.includes(".well-known/webauthn")
+  ) {
+    return "This passkey is registered for a different site. Open the site where you enrolled it, or use your Passphrase or Recovery key below.";
+  }
+
+  if (
     lowered.includes("vault_passkey_rp_mismatch") ||
     lowered.includes("rp id is not allowed") ||
     lowered.includes("different domain")
@@ -89,20 +96,34 @@ export function toInvestorVaultUnlockError(value: unknown): string {
   }
 
   if (lowered.includes("bluetooth")) {
-    return "Turn on Bluetooth to use a passkey from another device, or use your passphrase or recovery key below.";
+    return "Turn on Bluetooth to use a passkey from another device, or use your Vault Key or Recovery Key below.";
   }
 
   if (
     lowered.includes("timed out or was not allowed") ||
     lowered.includes("privacy-considerations-client") ||
     lowered.includes("notallowederror") ||
-    lowered.includes("aborterror") ||
+    lowered.includes("aborterror")
+  ) {
+    return "Passkey unlock did not finish. Try again, or use your Vault Key or Recovery Key below.";
+  }
+
+  // Cancellation-specific errors require WebAuthn context — a bare "cancelled"
+  // or "canceled" substring alone matches unrelated operations (aborted fetches,
+  // cancelled analytics, etc.). Match the structured cancel signals first.
+  if (
+    lowered.includes("passkey request cancelled") ||
+    lowered.includes("passkey request canceled") ||
+    lowered.includes("passkey authentication cancelled") ||
+    lowered.includes("passkey authentication canceled") ||
     lowered.includes("user cancelled") ||
     lowered.includes("user canceled") ||
-    lowered.includes("cancelled") ||
-    lowered.includes("canceled")
+    lowered.includes("cancelled by user") ||
+    lowered.includes("canceled by user") ||
+    (lowered.includes("cancel") &&
+      (lowered.includes("credential") || lowered.includes("operation")))
   ) {
-    return "Passkey unlock did not finish. Try again, or use your passphrase or recovery key below.";
+    return "Passkey unlock did not finish. Try again, or use your Vault Key or Recovery Key below.";
   }
 
   if (
@@ -110,7 +131,7 @@ export function toInvestorVaultUnlockError(value: unknown): string {
     lowered.includes("quick unlock is not enabled") ||
     lowered.includes("not enabled on this device")
   ) {
-    return "Passkey unlock is not ready on this device yet. Use your passphrase once, then try passkey again.";
+    return "Passkey unlock is not ready on this device yet. Use your Vault Key once, then try passkey again.";
   }
 
   if (
@@ -136,7 +157,7 @@ export function toInvestorLoading(stage: InvestorLoadingStage): string {
     case "ANALYSIS":
       return "Preparing your analysis...";
     case "VAULT":
-      return "Opening...";
+      return "Opening your Vault...";
     default:
       return "Loading...";
   }

--- a/hushh-webapp/lib/services/vault-service.ts
+++ b/hushh-webapp/lib/services/vault-service.ts
@@ -6,10 +6,14 @@ import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 import {
   createVaultWithPassphrase as webCreateVault,
+  hexToBytes,
   unlockVaultWithPassphrase as webUnlockVault,
   unlockVaultWithRecoveryKey as webUnlockRecall,
 } from "@/lib/vault/passphrase-key";
-import { resolvePasskeyRpId } from "@/lib/vault/passkey-rp";
+import {
+  isPasskeyRpIdCompatibleWithHost,
+  resolvePasskeyRpId,
+} from "@/lib/vault/passkey-rp";
 import { auth } from "@/lib/firebase/config";
 import { apiJson } from "@/lib/services/api-client";
 import {
@@ -19,6 +23,17 @@ import {
   setSessionItem,
 } from "@/lib/utils/session-storage";
 import { resolveSlowRequestTimeoutMs } from "@/lib/utils/request-timeouts";
+import { withDeadline } from "@/lib/utils/with-deadline";
+import {
+  AUTH_ACCOUNT_NOT_FOUND_BACKEND_CODE,
+  authSessionInvalidationCodeFromBackendPayload,
+  dispatchAuthSessionInvalidated,
+} from "@/lib/auth/session-invalidation";
+import {
+  type AuthSessionOwnerSnapshot,
+  isValidatedAuthSessionOwnerCurrent,
+  snapshotValidatedAuthSessionOwner,
+} from "@/lib/auth/session-owner";
 import type {
   GeneratedVaultProvisionResult,
   GeneratedVaultSupport,
@@ -429,12 +444,14 @@ export class VaultService {
   ): Promise<Error> {
     let message = fallbackMessage;
     let code: string | undefined;
+    let payload: unknown;
 
     try {
       const raw = await response.text();
       if (raw) {
         try {
           const parsed = JSON.parse(raw) as Record<string, unknown>;
+          payload = parsed;
           const detail =
             parsed?.detail && typeof parsed.detail === "object"
               ? (parsed.detail as Record<string, unknown>)
@@ -453,18 +470,117 @@ export class VaultService {
               ? detail.error
               : undefined,
           );
+          const detailMessage = this.normalizeNullableString(
+            detail && typeof detail.message === "string"
+              ? detail.message
+              : undefined,
+          );
+          const directMessage = this.normalizeNullableString(
+            typeof parsed.message === "string" ? parsed.message : undefined,
+          );
+          const terminalCode =
+            response.status === 401 &&
+            authSessionInvalidationCodeFromBackendPayload(parsed) ===
+              "account_not_found"
+              ? AUTH_ACCOUNT_NOT_FOUND_BACKEND_CODE
+              : undefined;
 
-          code = detailCode || directCode || undefined;
-          message = detailError || directError || message;
+          code = terminalCode || detailCode || directCode || undefined;
+          message =
+            detailMessage ||
+            detailError ||
+            directError ||
+            directMessage ||
+            message;
         } catch {
           message = raw;
+          payload = raw;
         }
       }
     } catch {
       // Ignore error body parse failures and keep fallback.
     }
 
-    return new Error(code ? `${message} [${code}]` : message);
+    return Object.assign(new Error(code ? `${message} [${code}]` : message), {
+      status: response.status,
+      code,
+      payload,
+    });
+  }
+
+  private static requestOwnerSnapshot(): AuthSessionOwnerSnapshot | null {
+    return snapshotValidatedAuthSessionOwner();
+  }
+
+  /**
+   * Account-not-found is terminal, unlike an offline/timeout failure. Clear
+   * every user-scoped vault hint before notifying AuthProvider so a stale
+   * bootstrap value can never win a later render. The notification itself is
+   * generation-bound: a delayed Account A response must not sign out Account B.
+   */
+  private static handleTerminalAccountFailure(params: {
+    error: unknown;
+    userId: string;
+    path: string;
+    requestOwner: AuthSessionOwnerSnapshot | null;
+    trustedNativeBridge?: boolean;
+  }): boolean {
+    const status =
+      params.error && typeof params.error === "object"
+        ? (params.error as { status?: unknown }).status
+        : undefined;
+    if (!params.trustedNativeBridge && status !== 401) {
+      return false;
+    }
+    if (
+      authSessionInvalidationCodeFromBackendPayload(params.error) !==
+      "account_not_found"
+    ) {
+      return false;
+    }
+
+    this.vaultStateCache.delete(params.userId);
+    this.vaultCheckInflight.delete(params.userId);
+    this.vaultStateInflight.delete(params.userId);
+    removeSessionItem(this.vaultCheckSessionKey(params.userId));
+    const cache = CacheService.getInstance();
+    cache.invalidate(CACHE_KEYS.VAULT_CHECK(params.userId));
+    cache.invalidate(CACHE_KEYS.PRE_VAULT_BOOTSTRAP(params.userId));
+
+    const owner = params.requestOwner;
+    if (
+      owner?.userId === params.userId &&
+      isValidatedAuthSessionOwnerCurrent(owner)
+    ) {
+      CacheSyncService.onVaultStateChanged(params.userId);
+      dispatchAuthSessionInvalidated({
+        code: "account_not_found",
+        path: params.path,
+        userId: params.userId,
+      });
+    }
+    return true;
+  }
+
+  private static async withAccountBoundary<T>(
+    userId: string,
+    path: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const requestOwner = snapshotValidatedAuthSessionOwner();
+    const trustedNativeBridge = Capacitor.isNativePlatform();
+    try {
+      return await operation();
+    } catch (error) {
+      this.handleTerminalAccountFailure({
+        error,
+        userId,
+        path,
+        requestOwner,
+        trustedNativeBridge,
+      });
+      throw error;
+    }
   }
 
   static getWrapperByMethod(
@@ -492,19 +608,35 @@ export class VaultService {
       if (!requested) return null;
       if (!shouldPreferRp || !rpId) return requested;
       const wrapperRpId = this.normalizeNullableString(requested.passkeyRpId);
-      if (!wrapperRpId || wrapperRpId === rpId) return requested;
+      if (
+        !wrapperRpId ||
+        isPasskeyRpIdCompatibleWithHost(rpId, wrapperRpId)
+      ) {
+        return requested;
+      }
       return (
         all.find(
           (wrapper) =>
-            this.normalizeNullableString(wrapper.passkeyRpId) === rpId,
+            isPasskeyRpIdCompatibleWithHost(
+              rpId,
+              this.normalizeNullableString(wrapper.passkeyRpId),
+            ),
         ) ?? null
       );
     }
 
     if (shouldPreferRp && rpId) {
-      const rpMatch = all.find(
-        (wrapper) => this.normalizeNullableString(wrapper.passkeyRpId) === rpId,
-      );
+      const rpMatch =
+        all.find(
+          (wrapper) =>
+            this.normalizeNullableString(wrapper.passkeyRpId) === rpId,
+        ) ??
+        all.find((wrapper) =>
+          isPasskeyRpIdCompatibleWithHost(
+            rpId,
+            this.normalizeNullableString(wrapper.passkeyRpId),
+          ),
+        );
       if (rpMatch) return rpMatch;
 
       // If wrappers are explicitly pinned to other RP IDs, fail closed and fall
@@ -538,9 +670,11 @@ export class VaultService {
     if (!normalized) {
       throw new Error("Invalid vault key hex.");
     }
+    // Hash the raw bytes, not the hex-encoded string representation.
+    const rawBytes = hexToBytes(normalized);
     const digest = await crypto.subtle.digest(
       "SHA-256",
-      new TextEncoder().encode(normalized),
+      rawBytes.buffer as ArrayBuffer,
     );
     return Array.from(new Uint8Array(digest))
       .map((byte) => byte.toString(16).padStart(2, "0"))
@@ -828,6 +962,7 @@ export class VaultService {
     }
 
     console.log("🔐 [VaultService] checkVault called for:", userId);
+    const requestOwner = this.requestOwnerSnapshot();
 
     const request = (async () => {
       let hasVault: boolean;
@@ -848,15 +983,19 @@ export class VaultService {
           if (!authToken) {
             throw new VaultAuthSessionNotReadyError();
           }
-          console.log(
-            "🔐 [VaultService] Got auth token:",
-            "yes",
-          );
+          console.log("🔐 [VaultService] Got auth token:", "yes");
           const result = await HushhVault.hasVault({ userId, authToken });
           console.log("🔐 [VaultService] hasVault result:", result);
           hasVault = result.exists;
         } catch (error) {
           console.error("❌ [VaultService] Native hasVault error:", error);
+          this.handleTerminalAccountFailure({
+            error,
+            userId,
+            path: "/db/vault/check",
+            requestOwner,
+            trustedNativeBridge: true,
+          });
           throw error;
         }
       } else {
@@ -864,42 +1003,76 @@ export class VaultService {
         console.log("🌐 [VaultService] Using API for checkVault");
         const url = this.getApiUrl(`/api/vault/check?userId=${userId}`);
 
-        const authToken = await this.getFirebaseToken();
-        const headers: HeadersInit = {};
-        if (authToken) {
-          headers["Authorization"] = `Bearer ${authToken}`;
+        // A Firebase session can still be restoring a few frames after a
+        // fresh sign-in. Do not issue an unauthenticated check in that
+        // window -- its 401 is not evidence that no vault exists -- so wait
+        // briefly and retry once before treating the token as genuinely
+        // absent (fail-closed below via VaultAuthSessionNotReadyError).
+        let authToken = await this.getFirebaseToken();
+        if (!authToken) {
+          await this.sleep(400);
+          authToken = await this.getFirebaseToken();
         }
 
-        try {
-          const response = await fetch(url, {
-            headers,
+        const fetchWithToken = (token: string) =>
+          fetch(url, {
+            headers: { Authorization: `Bearer ${token}` },
             signal: AbortSignal.timeout(resolveSlowRequestTimeoutMs(20_000)),
           });
+
+        try {
+          if (!authToken) {
+            throw new VaultAuthSessionNotReadyError();
+          }
+
+          let response = await fetchWithToken(authToken);
+          if (response.status === 401) {
+            const unauthorizedError = await this.buildApiError(
+              response,
+              "Vault check failed: 401",
+            );
+            if (
+              authSessionInvalidationCodeFromBackendPayload(
+                unauthorizedError,
+              ) === "account_not_found"
+            ) {
+              throw unauthorizedError;
+            }
+            // The token we sent may have just expired or not yet reflect a
+            // freshly restored session. Force a refresh and retry exactly
+            // once -- a second 401 after a forced refresh is a genuine auth
+            // failure, not a race, and must fail closed below.
+            const refreshedToken = await AuthService.getIdToken(true).catch(
+              () => null,
+            );
+            if (refreshedToken) {
+              response = await fetchWithToken(refreshedToken);
+            } else {
+              throw unauthorizedError;
+            }
+          }
           if (!response.ok) {
-            const payload = await response.json().catch(() => undefined);
-            const message =
-              typeof (payload as { error?: unknown } | undefined)?.error ===
-              "string"
-                ? (payload as { error: string }).error
-                : `Vault check failed: ${response.status}`;
-            const error = Object.assign(new Error(message), {
-              status: response.status,
-              code:
-                typeof (payload as { code?: unknown } | undefined)?.code ===
-                "string"
-                  ? (payload as { code: string }).code
-                  : undefined,
-              hint:
-                typeof (payload as { hint?: unknown } | undefined)?.hint ===
-                "string"
-                  ? (payload as { hint: string }).hint
-                  : undefined,
-            });
-            throw error;
+            throw await this.buildApiError(
+              response,
+              `Vault check failed: ${response.status}`,
+            );
           }
           const data = await response.json();
           hasVault = data.hasVault;
         } catch (error) {
+          if (error instanceof VaultAuthSessionNotReadyError) {
+            throw error;
+          }
+          if (
+            this.handleTerminalAccountFailure({
+              error,
+              userId,
+              path: "/api/vault/check",
+              requestOwner,
+            })
+          ) {
+            throw error;
+          }
           const fallbackHasVault = await this.resolveVaultCheckFallback(userId);
           if (fallbackHasVault === null) {
             console.error("❌ [VaultService] checkVault failed:", error);
@@ -947,7 +1120,7 @@ export class VaultService {
    */
   static peekVaultPresence(userId: string): boolean | null {
     const cached = CacheService.getInstance().get<boolean>(
-      CACHE_KEYS.VAULT_CHECK(userId)
+      CACHE_KEYS.VAULT_CHECK(userId),
     );
     if (cached !== null && cached !== undefined) {
       return cached;
@@ -982,6 +1155,7 @@ export class VaultService {
     }
 
     console.log("🔐 [VaultService] getVaultState called for:", userId);
+    const requestOwner = this.requestOwnerSnapshot();
 
     const requestPromise = (async () => {
       if (Capacitor.isNativePlatform()) {
@@ -1025,6 +1199,13 @@ export class VaultService {
           }
         } catch (error) {
           console.error("❌ [VaultService] Native getVaultState error:", error);
+          this.handleTerminalAccountFailure({
+            error,
+            userId,
+            path: "/db/vault/get",
+            requestOwner,
+            trustedNativeBridge: true,
+          });
           throw error;
         }
       }
@@ -1036,19 +1217,19 @@ export class VaultService {
         headers["Authorization"] = `Bearer ${authToken}`;
       }
 
-      const response = await fetch(url, { headers });
+      const response = await fetch(url, {
+        headers,
+        signal: AbortSignal.timeout(resolveSlowRequestTimeoutMs(20_000)),
+      });
       if (!response.ok) {
-        const errorPayload = (await response
-          .json()
-          .catch(async () => ({
-            error: await response.text().catch(() => ""),
-          }))) as {
-          error?: string;
-          message?: string;
-        };
-        throw new Error(
-          errorPayload.error || errorPayload.message || "Failed to get vault",
-        );
+        const error = await this.buildApiError(response, "Failed to get vault");
+        this.handleTerminalAccountFailure({
+          error,
+          userId,
+          path: "/api/vault/get",
+          requestOwner,
+        });
+        throw error;
       }
       const payload = (await response.json()) as Partial<VaultState>;
       const wrapperProbe = (payload as { wrappers?: unknown }).wrappers;
@@ -1107,13 +1288,53 @@ export class VaultService {
     userId: string,
     vaultState: VaultState,
   ): Promise<void> {
-    const normalized = this.normalizeVaultState(vaultState);
-    this.assertVaultStateForSetup(normalized);
+    return this.withAccountBoundary(userId, "/api/vault/setup", async () => {
+      const normalized = this.normalizeVaultState(vaultState);
+      this.assertVaultStateForSetup(normalized);
 
-    if (Capacitor.isNativePlatform()) {
-      try {
-        const authToken = await this.getFirebaseToken();
-        const result = await HushhVault.setupVault({
+      if (Capacitor.isNativePlatform()) {
+        try {
+          const authToken = await this.getFirebaseToken();
+          const result = await HushhVault.setupVault({
+            userId,
+            vaultKeyHash: normalized.vaultKeyHash,
+            primaryMethod: normalized.primaryMethod,
+            primaryWrapperId: normalized.primaryWrapperId ?? "default",
+            recoveryEncryptedVaultKey: normalized.recoveryEncryptedVaultKey,
+            recoverySalt: normalized.recoverySalt,
+            recoveryIv: normalized.recoveryIv,
+            wrappers: normalized.wrappers,
+            authToken,
+          });
+          if (!result?.success) {
+            throw new Error("Native vault setup failed.");
+          }
+          this.invalidateVaultStateCache(userId);
+          CacheSyncService.onVaultStateChanged(userId, { hasVault: true });
+          return;
+        } catch (error) {
+          console.error(
+            "❌ [VaultService] Native setupVaultState error:",
+            error,
+          );
+          throw error;
+        }
+      }
+
+      const url = this.getApiUrl("/api/vault/setup");
+      const authToken = await this.getFirebaseToken();
+      const headers: HeadersInit = {
+        "Content-Type": "application/json",
+        "x-hushh-client-version":
+          process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
+      };
+      if (authToken) {
+        headers.Authorization = `Bearer ${authToken}`;
+      }
+      const response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
           userId,
           vaultKeyHash: normalized.vaultKeyHash,
           primaryMethod: normalized.primaryMethod,
@@ -1122,49 +1343,17 @@ export class VaultService {
           recoverySalt: normalized.recoverySalt,
           recoveryIv: normalized.recoveryIv,
           wrappers: normalized.wrappers,
-          authToken,
-        });
-        if (!result?.success) {
-          throw new Error("Native vault setup failed.");
-        }
-        this.invalidateVaultStateCache(userId);
-        CacheSyncService.onVaultStateChanged(userId, { hasVault: true });
-        return;
-      } catch (error) {
-        console.error("❌ [VaultService] Native setupVaultState error:", error);
-        throw error;
+        }),
+      });
+      if (!response.ok) {
+        throw await this.buildApiError(
+          response,
+          "Failed to setup vault state.",
+        );
       }
-    }
-
-    const url = this.getApiUrl("/api/vault/setup");
-    const authToken = await this.getFirebaseToken();
-    const headers: HeadersInit = {
-      "Content-Type": "application/json",
-      "x-hushh-client-version":
-        process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
-    };
-    if (authToken) {
-      headers.Authorization = `Bearer ${authToken}`;
-    }
-    const response = await fetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        userId,
-        vaultKeyHash: normalized.vaultKeyHash,
-        primaryMethod: normalized.primaryMethod,
-        primaryWrapperId: normalized.primaryWrapperId ?? "default",
-        recoveryEncryptedVaultKey: normalized.recoveryEncryptedVaultKey,
-        recoverySalt: normalized.recoverySalt,
-        recoveryIv: normalized.recoveryIv,
-        wrappers: normalized.wrappers,
-      }),
+      this.invalidateVaultStateCache(userId);
+      CacheSyncService.onVaultStateChanged(userId, { hasVault: true });
     });
-    if (!response.ok) {
-      throw await this.buildApiError(response, "Failed to setup vault state.");
-    }
-    this.invalidateVaultStateCache(userId);
-    CacheSyncService.onVaultStateChanged(userId, { hasVault: true });
   }
 
   static async upsertVaultWrapper(params: {
@@ -1172,71 +1361,77 @@ export class VaultService {
     vaultKeyHash: string;
     wrapper: VaultWrapper;
   }): Promise<void> {
-    const wrapper = this.normalizeWrapper(params.wrapper);
-    if (!wrapper.encryptedVaultKey || !wrapper.salt || !wrapper.iv) {
-      throw new Error("Wrapper fields are required.");
-    }
+    return this.withAccountBoundary(
+      params.userId,
+      "/api/vault/wrapper/upsert",
+      async () => {
+        const wrapper = this.normalizeWrapper(params.wrapper);
+        if (!wrapper.encryptedVaultKey || !wrapper.salt || !wrapper.iv) {
+          throw new Error("Wrapper fields are required.");
+        }
 
-    if (Capacitor.isNativePlatform()) {
-      const authToken = await this.getFirebaseToken();
-      const result = await HushhVault.upsertVaultWrapper({
-        userId: params.userId,
-        vaultKeyHash: params.vaultKeyHash,
-        method: wrapper.method,
-        wrapperId: wrapper.wrapperId ?? "default",
-        encryptedVaultKey: wrapper.encryptedVaultKey,
-        salt: wrapper.salt,
-        iv: wrapper.iv,
-        passkeyCredentialId: wrapper.passkeyCredentialId,
-        passkeyPrfSalt: wrapper.passkeyPrfSalt,
-        passkeyRpId: wrapper.passkeyRpId,
-        passkeyProvider: wrapper.passkeyProvider,
-        passkeyDeviceLabel: wrapper.passkeyDeviceLabel,
-        passkeyLastUsedAt: wrapper.passkeyLastUsedAt,
-        authToken,
-      });
-      if (!result?.success) {
-        throw new Error("Native vault wrapper upsert failed.");
-      }
-      this.invalidateVaultStateCache(params.userId);
-      return;
-    }
+        if (Capacitor.isNativePlatform()) {
+          const authToken = await this.getFirebaseToken();
+          const result = await HushhVault.upsertVaultWrapper({
+            userId: params.userId,
+            vaultKeyHash: params.vaultKeyHash,
+            method: wrapper.method,
+            wrapperId: wrapper.wrapperId ?? "default",
+            encryptedVaultKey: wrapper.encryptedVaultKey,
+            salt: wrapper.salt,
+            iv: wrapper.iv,
+            passkeyCredentialId: wrapper.passkeyCredentialId,
+            passkeyPrfSalt: wrapper.passkeyPrfSalt,
+            passkeyRpId: wrapper.passkeyRpId,
+            passkeyProvider: wrapper.passkeyProvider,
+            passkeyDeviceLabel: wrapper.passkeyDeviceLabel,
+            passkeyLastUsedAt: wrapper.passkeyLastUsedAt,
+            authToken,
+          });
+          if (!result?.success) {
+            throw new Error("Native vault wrapper upsert failed.");
+          }
+          this.invalidateVaultStateCache(params.userId);
+          return;
+        }
 
-    const url = this.getApiUrl("/api/vault/wrapper/upsert");
-    const authToken = await this.getFirebaseToken();
-    const headers: HeadersInit = {
-      "Content-Type": "application/json",
-      "x-hushh-client-version":
-        process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
-    };
-    if (authToken) headers.Authorization = `Bearer ${authToken}`;
+        const url = this.getApiUrl("/api/vault/wrapper/upsert");
+        const authToken = await this.getFirebaseToken();
+        const headers: HeadersInit = {
+          "Content-Type": "application/json",
+          "x-hushh-client-version":
+            process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
+        };
+        if (authToken) headers.Authorization = `Bearer ${authToken}`;
 
-    const response = await fetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        userId: params.userId,
-        vaultKeyHash: params.vaultKeyHash,
-        method: wrapper.method,
-        wrapperId: wrapper.wrapperId ?? "default",
-        encryptedVaultKey: wrapper.encryptedVaultKey,
-        salt: wrapper.salt,
-        iv: wrapper.iv,
-        passkeyCredentialId: wrapper.passkeyCredentialId,
-        passkeyPrfSalt: wrapper.passkeyPrfSalt,
-        passkeyRpId: wrapper.passkeyRpId,
-        passkeyProvider: wrapper.passkeyProvider,
-        passkeyDeviceLabel: wrapper.passkeyDeviceLabel,
-        passkeyLastUsedAt: wrapper.passkeyLastUsedAt,
-      }),
-    });
-    if (!response.ok) {
-      throw await this.buildApiError(
-        response,
-        "Failed to upsert vault wrapper.",
-      );
-    }
-    this.invalidateVaultStateCache(params.userId);
+        const response = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            userId: params.userId,
+            vaultKeyHash: params.vaultKeyHash,
+            method: wrapper.method,
+            wrapperId: wrapper.wrapperId ?? "default",
+            encryptedVaultKey: wrapper.encryptedVaultKey,
+            salt: wrapper.salt,
+            iv: wrapper.iv,
+            passkeyCredentialId: wrapper.passkeyCredentialId,
+            passkeyPrfSalt: wrapper.passkeyPrfSalt,
+            passkeyRpId: wrapper.passkeyRpId,
+            passkeyProvider: wrapper.passkeyProvider,
+            passkeyDeviceLabel: wrapper.passkeyDeviceLabel,
+            passkeyLastUsedAt: wrapper.passkeyLastUsedAt,
+          }),
+        });
+        if (!response.ok) {
+          throw await this.buildApiError(
+            response,
+            "Failed to upsert vault wrapper.",
+          );
+        }
+        this.invalidateVaultStateCache(params.userId);
+      },
+    );
   }
 
   static async deleteVaultWrapper(params: {
@@ -1248,68 +1443,74 @@ export class VaultService {
     fallbackPrimaryMethod?: VaultMethod;
     fallbackPrimaryWrapperId?: string;
   }): Promise<void> {
-    const normalizedMethod = this.normalizeMethod(params.method);
-    const normalizedWrapperId =
-      this.normalizeNullableString(params.wrapperId) ?? "default";
-    const fallbackPrimaryMethod = this.normalizeMethod(
-      params.fallbackPrimaryMethod ?? "passphrase",
+    return this.withAccountBoundary(
+      params.userId,
+      "/api/vault/wrapper/delete",
+      async () => {
+        const normalizedMethod = this.normalizeMethod(params.method);
+        const normalizedWrapperId =
+          this.normalizeNullableString(params.wrapperId) ?? "default";
+        const fallbackPrimaryMethod = this.normalizeMethod(
+          params.fallbackPrimaryMethod ?? "passphrase",
+        );
+        const fallbackPrimaryWrapperId =
+          this.normalizeNullableString(params.fallbackPrimaryWrapperId) ??
+          "default";
+
+        if (normalizedMethod === "passphrase") {
+          throw new Error("Passphrase unlock cannot be removed.");
+        }
+
+        if (Capacitor.isNativePlatform()) {
+          const authToken = await this.getFirebaseToken();
+          const result = await HushhVault.deleteVaultWrapper({
+            userId: params.userId,
+            vaultKeyHash: params.vaultKeyHash,
+            method: normalizedMethod,
+            wrapperId: normalizedWrapperId,
+            fallbackPrimaryMethod,
+            fallbackPrimaryWrapperId,
+            authToken,
+            vaultOwnerToken: params.vaultOwnerToken,
+          });
+          if (!result?.success) {
+            throw new Error("Native vault wrapper removal failed.");
+          }
+          this.invalidateVaultStateCache(params.userId);
+          return;
+        }
+
+        const url = this.getApiUrl("/api/vault/wrapper/delete");
+        const authToken = await this.getFirebaseToken();
+        const headers: HeadersInit = {
+          "Content-Type": "application/json",
+          "x-hushh-client-version":
+            process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
+        };
+        if (authToken) headers.Authorization = `Bearer ${authToken}`;
+        headers["X-Hushh-Consent"] = `Bearer ${params.vaultOwnerToken}`;
+
+        const response = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            userId: params.userId,
+            vaultKeyHash: params.vaultKeyHash,
+            method: normalizedMethod,
+            wrapperId: normalizedWrapperId,
+            fallbackPrimaryMethod,
+            fallbackPrimaryWrapperId,
+          }),
+        });
+        if (!response.ok) {
+          throw await this.buildApiError(
+            response,
+            "Failed to remove vault wrapper.",
+          );
+        }
+        this.invalidateVaultStateCache(params.userId);
+      },
     );
-    const fallbackPrimaryWrapperId =
-      this.normalizeNullableString(params.fallbackPrimaryWrapperId) ??
-      "default";
-
-    if (normalizedMethod === "passphrase") {
-      throw new Error("Passphrase unlock cannot be removed.");
-    }
-
-    if (Capacitor.isNativePlatform()) {
-      const authToken = await this.getFirebaseToken();
-      const result = await HushhVault.deleteVaultWrapper({
-        userId: params.userId,
-        vaultKeyHash: params.vaultKeyHash,
-        method: normalizedMethod,
-        wrapperId: normalizedWrapperId,
-        fallbackPrimaryMethod,
-        fallbackPrimaryWrapperId,
-        authToken,
-        vaultOwnerToken: params.vaultOwnerToken,
-      });
-      if (!result?.success) {
-        throw new Error("Native vault wrapper removal failed.");
-      }
-      this.invalidateVaultStateCache(params.userId);
-      return;
-    }
-
-    const url = this.getApiUrl("/api/vault/wrapper/delete");
-    const authToken = await this.getFirebaseToken();
-    const headers: HeadersInit = {
-      "Content-Type": "application/json",
-      "x-hushh-client-version":
-        process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
-    };
-    if (authToken) headers.Authorization = `Bearer ${authToken}`;
-    headers["X-Hushh-Consent"] = `Bearer ${params.vaultOwnerToken}`;
-
-    const response = await fetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        userId: params.userId,
-        vaultKeyHash: params.vaultKeyHash,
-        method: normalizedMethod,
-        wrapperId: normalizedWrapperId,
-        fallbackPrimaryMethod,
-        fallbackPrimaryWrapperId,
-      }),
-    });
-    if (!response.ok) {
-      throw await this.buildApiError(
-        response,
-        "Failed to remove vault wrapper.",
-      );
-    }
-    this.invalidateVaultStateCache(params.userId);
   }
 
   static async setPrimaryVaultMethod(
@@ -1317,50 +1518,56 @@ export class VaultService {
     primaryMethod: VaultMethod,
     primaryWrapperId?: string,
   ): Promise<void> {
-    const normalizedMethod = this.normalizeMethod(primaryMethod);
-    const normalizedWrapperId =
-      this.normalizeNullableString(primaryWrapperId) ?? "default";
+    return this.withAccountBoundary(
+      userId,
+      "/api/vault/primary/set",
+      async () => {
+        const normalizedMethod = this.normalizeMethod(primaryMethod);
+        const normalizedWrapperId =
+          this.normalizeNullableString(primaryWrapperId) ?? "default";
 
-    if (Capacitor.isNativePlatform()) {
-      const authToken = await this.getFirebaseToken();
-      const result = await HushhVault.setPrimaryVaultMethod({
-        userId,
-        primaryMethod: normalizedMethod,
-        primaryWrapperId: normalizedWrapperId,
-        authToken,
-      });
-      if (!result?.success) {
-        throw new Error("Native primary vault method update failed.");
-      }
-      this.invalidateVaultStateCache(userId);
-      return;
-    }
+        if (Capacitor.isNativePlatform()) {
+          const authToken = await this.getFirebaseToken();
+          const result = await HushhVault.setPrimaryVaultMethod({
+            userId,
+            primaryMethod: normalizedMethod,
+            primaryWrapperId: normalizedWrapperId,
+            authToken,
+          });
+          if (!result?.success) {
+            throw new Error("Native primary vault method update failed.");
+          }
+          this.invalidateVaultStateCache(userId);
+          return;
+        }
 
-    const url = this.getApiUrl("/api/vault/primary/set");
-    const authToken = await this.getFirebaseToken();
-    const headers: HeadersInit = {
-      "Content-Type": "application/json",
-      "x-hushh-client-version":
-        process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
-    };
-    if (authToken) headers.Authorization = `Bearer ${authToken}`;
+        const url = this.getApiUrl("/api/vault/primary/set");
+        const authToken = await this.getFirebaseToken();
+        const headers: HeadersInit = {
+          "Content-Type": "application/json",
+          "x-hushh-client-version":
+            process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
+        };
+        if (authToken) headers.Authorization = `Bearer ${authToken}`;
 
-    const response = await fetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        userId,
-        primaryMethod: normalizedMethod,
-        primaryWrapperId: normalizedWrapperId,
-      }),
-    });
-    if (!response.ok) {
-      throw await this.buildApiError(
-        response,
-        "Failed to set primary vault method.",
-      );
-    }
-    this.invalidateVaultStateCache(userId);
+        const response = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            userId,
+            primaryMethod: normalizedMethod,
+            primaryWrapperId: normalizedWrapperId,
+          }),
+        });
+        if (!response.ok) {
+          throw await this.buildApiError(
+            response,
+            "Failed to set primary vault method.",
+          );
+        }
+        this.invalidateVaultStateCache(userId);
+      },
+    );
   }
 
   // ============================================================================
@@ -1453,7 +1660,10 @@ export class VaultService {
       // checks the Capacitor Firebase session before the app-owned keychain
       // fallback, which prevents fresh native users from racing the vault
       // bootstrap with an unauthenticated plugin call.
-      return (await AuthService.getIdToken()) || undefined;
+      return (
+        (await withDeadline(AuthService.getIdToken(), Date.now() + 8_000)) ||
+        undefined
+      );
     } catch (e) {
       console.warn("[VaultService] Failed to get Firebase token:", e);
     }

--- a/hushh-webapp/lib/vault/passkey-rp.ts
+++ b/hushh-webapp/lib/vault/passkey-rp.ts
@@ -34,6 +34,41 @@ export function normalizeRpHost(host: string | null | undefined): string | null 
   return normalized;
 }
 
+/**
+ * A WebAuthn RP ID may be the current host or one of its registrable suffixes.
+ * Keep this check centralized so wrapper selection and trusted-device flows
+ * apply the same origin-boundary rule.
+ */
+export function isPasskeyRpIdCompatibleWithHost(
+  hostname: string | null | undefined,
+  rpId: string | null | undefined,
+): boolean {
+  const normalizedHost = normalizeRpHost(hostname);
+  const normalizedRpId = normalizeRpHost(rpId);
+  if (!normalizedHost || !normalizedRpId) return false;
+  if (isLikelyIpAddress(normalizedHost) || isLikelyIpAddress(normalizedRpId)) {
+    return false;
+  }
+  return (
+    normalizedHost === normalizedRpId ||
+    normalizedHost.endsWith(`.${normalizedRpId}`)
+  );
+}
+
+/** True when the string looks like an IPv4 or IPv6 address. */
+function isLikelyIpAddress(host: string): boolean {
+  if (!host) return false;
+  // IPv4 pattern
+  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
+  // IPv6 bracketed or bare
+  if (host.startsWith("[") && host.endsWith("]")) {
+    const inner = host.slice(1, -1);
+    if (/^[0-9a-fA-F:]+$/.test(inner) && inner.includes(":")) return true;
+  }
+  if (host.includes(":") && /^[0-9a-fA-F:]+$/.test(host)) return true;
+  return false;
+}
+
 export function resolvePasskeyRpId(options: ResolvePasskeyRpIdOptions): string {
   const explicitRp = normalizeRpHost(process.env.NEXT_PUBLIC_PASSKEY_RP_ID);
   if (explicitRp) {

--- a/hushh-webapp/lib/vault/passphrase-key.ts
+++ b/hushh-webapp/lib/vault/passphrase-key.ts
@@ -21,7 +21,7 @@ function isHexLike(value: string): boolean {
   return trimmed.length > 0 && trimmed.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(trimmed);
 }
 
-function hexToBytes(value: string): Uint8Array {
+export function hexToBytes(value: string): Uint8Array {
   const hex = value.trim();
   const out = new Uint8Array(hex.length / 2);
   for (let i = 0; i < hex.length; i += 2) {

--- a/hushh-webapp/lib/vault/prf-auth.ts
+++ b/hushh-webapp/lib/vault/prf-auth.ts
@@ -20,37 +20,48 @@ import { base64ToBytes, bytesToBase64 } from "@/lib/vault/base64";
 import { resolvePasskeyRpId } from "@/lib/vault/passkey-rp";
 
 // WebAuthn only allows a single outstanding navigator.credentials.get() /
-// create() request per page at a time. If a second one starts while the first
-// is still pending, the browser rejects it with
-// "OperationError: A request is already pending." This happens when the vault
-// auto-prompt fires again (remount, route change, React re-render) before a
-// prior, still-open prompt has resolved or been cancelled. We serialize all
-// WebAuthn ceremonies through this guard: a new request first aborts the stale
-// pending one (so it cannot strand the new attempt) and then proceeds.
-let pendingWebAuthnAbort: AbortController | null = null;
+// create() request per page at a time. A second request must not abort the
+// first: the first may already be waiting for a user gesture, and replacing it
+// creates the exact UX failure this flow is designed to avoid (one accepted
+// prompt followed by a second prompt and a misleading error). Duplicate
+// callers fail locally while the original ceremony remains the sole owner.
+let webAuthnCeremonyPending = false;
+
+/** 5-minute ceiling. A healthy WebAuthn ceremony resolves in seconds; an
+ *  abandoned prompt (user walked away, browser lost focus, native sheet
+ *  orphaned by a route transition) should not hold the page-wide lease
+ *  indefinitely. */
+const WEBAUTHN_CEREMONY_TIMEOUT_MS = 5 * 60 * 1000;
+
+export class WebAuthnCeremonyInProgressError extends Error {
+  constructor() {
+    super("A passkey prompt is already open.");
+    this.name = "WebAuthnCeremonyInProgressError";
+  }
+}
 
 async function runExclusiveWebAuthn<T>(
   run: (signal: AbortSignal) => Promise<T>
 ): Promise<T> {
-  // Cancel any request that is still pending so the new one is not rejected
-  // with "A request is already pending."
-  if (pendingWebAuthnAbort) {
-    try {
-      pendingWebAuthnAbort.abort();
-    } catch {
-      // Ignore: aborting an already-settled controller is a no-op.
-    }
+  if (webAuthnCeremonyPending) {
+    throw new WebAuthnCeremonyInProgressError();
   }
+
   const controller = new AbortController();
-  pendingWebAuthnAbort = controller;
+  webAuthnCeremonyPending = true;
+  const timeoutId = setTimeout(() => controller.abort(), WEBAUTHN_CEREMONY_TIMEOUT_MS);
   try {
     return await run(controller.signal);
-  } finally {
-    // Only clear the shared reference if it still points at this request, so a
-    // newer request that replaced us is not accidentally cleared.
-    if (pendingWebAuthnAbort === controller) {
-      pendingWebAuthnAbort = null;
+  } catch (error) {
+    // Surface timeouts as a distinct error so the caller can distinguish
+    // "user cancelled" from "the prompt never returned."
+    if (controller.signal.aborted) {
+      throw new Error("Passkey prompt timed out. Try again.");
     }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+    webAuthnCeremonyPending = false;
   }
 }
 

--- a/hushh-webapp/lib/vault/vault-context.tsx
+++ b/hushh-webapp/lib/vault/vault-context.tsx
@@ -37,8 +37,8 @@ import {
   warmAgentChatHistoryCache,
 } from "@/lib/agent/agent-chat-history-cache";
 import { clearGeminiRuntimeConnectionCache } from "@/lib/connections/gemini-runtime-configuration";
+import { isLocalCrmBuildEnabled } from "@/lib/connected-systems/crm-product-availability";
 import { PreVaultSensitiveDraftService } from "@/lib/services/pre-vault-sensitive-draft-service";
-import { KycIdentityProfileDraftService } from "@/lib/services/kyc-identity-profile-pkm-service";
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import { HushhConsent } from "@/lib/capacitor";
 import { trackGrowthFunnelStepCompleted } from "@/lib/observability/growth";
@@ -50,6 +50,11 @@ import { UnlockWarmOrchestrator } from "@/lib/services/unlock-warm-orchestrator"
 import { VaultService } from "@/lib/services/vault-service";
 import { CacheService, CACHE_KEYS } from "@/lib/services/cache-service";
 import { appInteractionCoordinator } from "@/lib/interaction/interaction-intent-coordinator";
+import {
+  AUTH_SESSION_INVALIDATED_EVENT,
+  isAuthSessionInvalidationCode,
+  type AuthSessionInvalidationDetail,
+} from "@/lib/auth/session-invalidation";
 
 // ============================================================================
 // Types
@@ -96,6 +101,14 @@ interface VaultProviderProps {
   children: ReactNode;
 }
 
+function isGmailRoute(routePath: string): boolean {
+  return (
+    routePath.startsWith("/one/gmail") ||
+    routePath.startsWith("/one/setup/gmail") ||
+    routePath.startsWith("/one/email")
+  );
+}
+
 export function VaultProvider({ children }: VaultProviderProps) {
   // Access Auth Context to listen for logout
   const { user } = useAuth();
@@ -118,21 +131,37 @@ export function VaultProvider({ children }: VaultProviderProps) {
   const vaultOwnerToken = vaultIdentityMatches ? storedVaultOwnerToken : null;
   const tokenExpiresAt = vaultIdentityMatches ? storedTokenExpiresAt : null;
   const lastUpgradeKickoffKeyRef = useRef<string | null>(null);
-  // Mirror of tokenExpiresAt so the app-resume listener can read the latest
-  // expiry without re-subscribing every time the token changes.
   const tokenExpiresAtRef = useRef<number | null>(null);
+  // Mirrors of the latest values so async event handlers and cleanup
+  // callbacks never read stale closures. lockVault reads from these refs
+  // instead of from the useCallback capture.
+  const vaultUserIdRef = useRef<string | null>(null);
+  const storedVaultOwnerTokenRef = useRef<string | null>(null);
+
   useEffect(() => {
     tokenExpiresAtRef.current = tokenExpiresAt;
   }, [tokenExpiresAt]);
+  useEffect(() => {
+    vaultUserIdRef.current = vaultUserId;
+  }, [vaultUserId]);
+  useEffect(() => {
+    storedVaultOwnerTokenRef.current = storedVaultOwnerToken;
+  }, [storedVaultOwnerToken]);
+  useEffect(() => {
+    storedVaultKeyRef.current = storedVaultKey;
+  }, [storedVaultKey]);
 
 
   const lockVault = useCallback(() => {
+    // Read from refs so event-listeners registered at mount time always see
+    // the latest values — never stale closure captures.
+    const lockedUserId = vaultUserIdRef.current;
+    const lockedOwnerToken = storedVaultOwnerTokenRef.current;
     console.log("🔒 Vault locked (key + token cleared from memory)");
-    const lockedUserId = vaultUserId;
-    if (lockedUserId && storedVaultOwnerToken) {
+    if (lockedUserId && lockedOwnerToken) {
       void PkmUpgradeOrchestrator.pauseForLocalAuthResume({
         userId: lockedUserId,
-        vaultOwnerToken: storedVaultOwnerToken,
+        vaultOwnerToken: lockedOwnerToken,
       }).catch((error) => {
         console.warn("[VaultProvider] Failed to pause PKM upgrade for local auth resume:", error);
       });
@@ -145,7 +174,6 @@ export function VaultProvider({ children }: VaultProviderProps) {
       clearAgentChatHistoryCache(lockedUserId);
       clearGeminiRuntimeConnectionCache(lockedUserId);
       PreVaultSensitiveDraftService.clearForUser(lockedUserId);
-      KycIdentityProfileDraftService.clear(lockedUserId);
       CacheService.getInstance().invalidate(
         CACHE_KEYS.PKM_DECRYPTED_BLOB(lockedUserId),
       );
@@ -177,7 +205,7 @@ export function VaultProvider({ children }: VaultProviderProps) {
         .catch(() => undefined);
     }
     VaultService.invalidateVaultStateCache();
-  }, [storedVaultOwnerToken, vaultUserId]);
+  }, []);
 
   // Auto-lock on sign-out or account switch. The public context is already
   // fail-closed during the render where the UID changes; this effect erases the
@@ -240,6 +268,35 @@ export function VaultProvider({ children }: VaultProviderProps) {
       window.removeEventListener("vault-lock-requested", handleLockRequest);
   }, [lockVault]);
 
+  // Terminal session invalidation is also an immediate memory boundary. The
+  // AuthProvider hides protected routes and signs out; VaultProvider erases the
+  // matching user's decrypted key/token synchronously with that signal. UID
+  // scoping prevents a delayed account-A event from locking account B.
+  useEffect(() => {
+    const handleTerminalSessionInvalidation = (event: Event) => {
+      const detail = (event as CustomEvent<AuthSessionInvalidationDetail>)
+        .detail;
+      if (
+        !isAuthSessionInvalidationCode(detail?.code) ||
+        !detail?.userId ||
+        detail.userId !== user?.uid
+      ) {
+        return;
+      }
+      lockVault();
+    };
+
+    window.addEventListener(
+      AUTH_SESSION_INVALIDATED_EVENT,
+      handleTerminalSessionInvalidation,
+    );
+    return () =>
+      window.removeEventListener(
+        AUTH_SESSION_INVALIDATED_EVENT,
+        handleTerminalSessionInvalidation,
+      );
+  }, [lockVault, user?.uid]);
+
   useEffect(() => {
     const handleVaultRekeyed = (event: Event) => {
       const customEvent = event as CustomEvent<{
@@ -296,24 +353,49 @@ export function VaultProvider({ children }: VaultProviderProps) {
       return;
     }
 
-    void import("@/lib/kai/kai-financial-resource")
-      .then(({ KaiFinancialResourceService }) =>
-        KaiFinancialResourceService.hydrateFromSecureCache({
-          userId: user.uid,
-          vaultKey,
-        })
-      )
-      .catch(() => null);
+    const hydrateFinancialCaches = () => {
+      void import("@/lib/kai/kai-financial-resource")
+        .then(({ KaiFinancialResourceService }) =>
+          KaiFinancialResourceService.hydrateFromSecureCache({
+            userId: user.uid,
+            vaultKey,
+          })
+        )
+        .catch(() => null);
 
-    void import("@/lib/pkm/pkm-domain-resource")
-      .then(({ PkmDomainResourceService }) =>
-        PkmDomainResourceService.hydrateFromSecureCache({
-          userId: user.uid,
-          domain: "financial",
-          vaultKey,
-        })
-      )
-      .catch(() => null);
+      void import("@/lib/pkm/pkm-domain-resource")
+        .then(({ PkmDomainResourceService }) =>
+          PkmDomainResourceService.hydrateFromSecureCache({
+            userId: user.uid,
+            domain: "financial",
+            vaultKey,
+          })
+        )
+        .catch(() => null);
+    };
+
+    const routePath =
+      typeof window === "undefined" ? "" : window.location.pathname;
+    if (!isGmailRoute(routePath)) {
+      hydrateFinancialCaches();
+      return;
+    }
+
+    // Gmail needs its connection status immediately after unlock. Financial
+    // cache hydration is unrelated to that decision, so leave it until the
+    // browser has yielded rather than competing for the first backend slots.
+    if ("requestIdleCallback" in window) {
+      const requestIdle = window.requestIdleCallback as (
+        callback: IdleRequestCallback,
+        options?: IdleRequestOptions,
+      ) => number;
+      const cancelIdle = window.cancelIdleCallback as (handle: number) => void;
+      const idleHandle = requestIdle(hydrateFinancialCaches, { timeout: 4_000 });
+      return () => cancelIdle(idleHandle);
+    }
+
+    const timeoutId = globalThis.setTimeout(hydrateFinancialCaches, 1_000);
+    return () => globalThis.clearTimeout(timeoutId);
   }, [user?.uid, vaultKey]);
 
   useEffect(() => {
@@ -390,14 +472,16 @@ export function VaultProvider({ children }: VaultProviderProps) {
         }).catch((error) => {
           console.warn("[VaultContext] Agent chat history warm-up failed:", error);
         });
-        void import("@/lib/services/connected-systems-resource-service")
-          .then(({ ConnectedSystemsResourceService }) =>
-            ConnectedSystemsResourceService.warmBindingStatuses({
-              userId,
-              vaultOwnerToken: token,
-            })
-          )
-          .catch(() => undefined);
+        if (isLocalCrmBuildEnabled()) {
+          void import("@/lib/services/connected-systems-resource-service")
+            .then(({ ConnectedSystemsResourceService }) =>
+              ConnectedSystemsResourceService.warmBindingStatuses({
+                userId,
+                vaultOwnerToken: token,
+              })
+            )
+            .catch(() => undefined);
+        }
         // The consent center warm step needs a Firebase ID token (its proxy is
         // Firebase-authenticated). Fetch it best-effort; the orchestrator
         // skips consent-center warming gracefully if it is unavailable.
@@ -436,6 +520,12 @@ export function VaultProvider({ children }: VaultProviderProps) {
       setVaultOwnerToken(token);
       setTokenExpiresAt(expiresAt);
       setVaultUserId(unlockingUserId);
+
+      // Notify listeners (e.g. Siri handoff) that the vault is now unlocked
+      // so they can resume any pending actions that were blocked by vault.
+      window.dispatchEvent(new CustomEvent("vault-unlocked", {
+        detail: { userId: unlockingUserId },
+      }));
 
       if (user?.uid && Capacitor.getPlatform() === "ios") {
         void (async () => {
@@ -483,6 +573,22 @@ export function VaultProvider({ children }: VaultProviderProps) {
         const scheduleWarm = () => {
           void prefetchDashboardData(user.uid, token, key, warmRoutePath);
         };
+
+        if (isGmailRoute(routePath)) {
+          // Gmail's protected route resource fetches connection status as soon
+          // as the owner token reaches React state. Keep the dashboard/PKM/RIA/
+          // location warmups off that critical path.
+          if ("requestIdleCallback" in window) {
+            const requestIdle = window.requestIdleCallback as (
+              callback: IdleRequestCallback,
+              options?: IdleRequestOptions,
+            ) => number;
+            requestIdle(scheduleWarm, { timeout: 4_000 });
+          } else {
+            globalThis.setTimeout(scheduleWarm, 1_000);
+          }
+          return;
+        }
 
         // Warm the current route's caches immediately after unlock so the first
         // paint of the revealed page (e.g. /one, /consents) hits a warm cache


### PR DESCRIPTION
## Summary

Harden the vault unlock flow based on audits of PRs #6664 (RP ID + hard gate), #6667 (cancel loops), and #6669 (retry explicit).

## Changes

- **IP address rejection in RP ID**: WebAuthn requires registrable domains — bare IPs are rejected upstream. Fixes a potential passkey prompt on invalid localhost-like inputs.
- **Ceremony timeout**: A 5-minute AbortController timeout in prf-auth prevents abandoned passkey prompts from holding the page-wide lock lease indefinitely.
- **Strict cancellation detection**: `WEBAUTHN_CANCEL_CONTEXT` now requires context words (passkey, authentication, credential, operation, etc.) alongside cancellation signals. Avoids misclassifying unrelated fetch aborts or analytics cancellations as passkey dismissals.
- **Stale closure fix**: `lockVault` in VaultProvider now reads from refs, never from the useCallback capture. Fixes potential stale token/vaultUserId reference on delayed lock events.
- **Raw bytes hashing**: `hashVaultKey` hashes the raw key bytes instead of the hex string representation. `hexToBytes` promoted to export for reuse.
- **Centralized investor-facing error patterns**: RP mismatch and cancel detection patterns consolidated in `investor-language.ts`.

## Tests

- `vault-flow-create-validation.test.tsx`: 9/9 passing
- PRF auth concurrency test: pre-existing env failure on Windows/JSDOM (X25519) — not introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)