### PR TITLE
fix(vault): harden passkey unlock recovery

### DIFF
--- a/hushh-webapp/__tests__/services/passkey-rp.test.ts
+++ b/hushh-webapp/__tests__/services/passkey-rp.test.ts
@@ -74,6 +74,15 @@ describe("passkey RP resolution", () => {
     ).toBe(true);
   });
 
+  it("rejects IP-address RP IDs even when localhost normalization is available", () => {
+    expect(
+      isPasskeyRpIdCompatibleWithHost("127.0.0.1", "127.0.0.1"),
+    ).toBe(false);
+    expect(
+      isPasskeyRpIdCompatibleWithHost("[::1]", "[::1]"),
+    ).toBe(false);
+  });
+
   it("does not accept a child RP from the canonical origin", () => {
     expect(
       isPasskeyRpIdCompatibleWithHost("one.hushh.ai", "uat.one.hushh.ai"),

--- a/hushh-webapp/__tests__/vault/prf-auth-concurrency.test.ts
+++ b/hushh-webapp/__tests__/vault/prf-auth-concurrency.test.ts
@@ -48,4 +48,38 @@ describe("PRF passkey ceremony coordination", () => {
       credentialId: "AQ==",
     });
   });
+
+  it("releases an abandoned prompt after the timeout so an explicit retry can run", async () => {
+    vi.useFakeTimers();
+    const get = vi.fn((options: CredentialRequestOptions) =>
+      new Promise<never>((_resolve, reject) => {
+        options.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      }),
+    );
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: { get },
+    });
+
+    const firstAttempt = authenticateWithPrf("user-1", "c2FsdA==");
+    const firstRejection = expect(firstAttempt).rejects.toThrow(
+      "Passkey prompt timed out",
+    );
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await firstRejection;
+
+    const credential = {
+      rawId: new Uint8Array([1]).buffer,
+      getClientExtensionResults: () => ({
+        prf: { results: { first: new Uint8Array(32).buffer } },
+      }),
+    } as unknown as PublicKeyCredential;
+    get.mockResolvedValueOnce(credential);
+
+    await expect(authenticateWithPrf("user-1", "c2FsdA==")).resolves.toMatchObject({
+      credentialId: "AQ==",
+    });
+  });
 });

--- a/hushh-webapp/lib/copy/investor-language.ts
+++ b/hushh-webapp/lib/copy/investor-language.ts
@@ -101,13 +101,28 @@ export function toInvestorVaultUnlockError(value: unknown): string {
 
   if (
     lowered.includes("timed out or was not allowed") ||
+    lowered.includes("passkey prompt timed out") ||
     lowered.includes("privacy-considerations-client") ||
     lowered.includes("notallowederror") ||
-    lowered.includes("aborterror") ||
+    lowered.includes("aborterror")
+  ) {
+    return "Passkey unlock did not finish. Try again, or use your Vault Key or Recovery Key below.";
+  }
+
+  // Cancellation-specific errors require WebAuthn context — a bare "cancelled"
+  // or "canceled" substring alone matches unrelated operations (aborted fetches,
+  // cancelled analytics, etc.). Match the structured cancel signals first.
+  if (
+    lowered.includes("passkey request cancelled") ||
+    lowered.includes("passkey request canceled") ||
+    lowered.includes("passkey authentication cancelled") ||
+    lowered.includes("passkey authentication canceled") ||
     lowered.includes("user cancelled") ||
     lowered.includes("user canceled") ||
-    lowered.includes("cancelled") ||
-    lowered.includes("canceled")
+    lowered.includes("cancelled by user") ||
+    lowered.includes("canceled by user") ||
+    (lowered.includes("cancel") &&
+      (lowered.includes("credential") || lowered.includes("operation")))
   ) {
     return "Passkey unlock did not finish. Try again, or use your Vault Key or Recovery Key below.";
   }

--- a/hushh-webapp/lib/vault/passkey-rp.ts
+++ b/hushh-webapp/lib/vault/passkey-rp.ts
@@ -43,6 +43,7 @@ export function isPasskeyRpIdCompatibleWithHost(
   hostname: string | null | undefined,
   rpId: string | null | undefined,
 ): boolean {
+  if (isLikelyIpAddress(hostname) || isLikelyIpAddress(rpId)) return false;
   const normalizedHost = normalizeRpHost(hostname);
   const normalizedRpId = normalizeRpHost(rpId);
   if (!normalizedHost || !normalizedRpId) return false;
@@ -52,6 +53,21 @@ export function isPasskeyRpIdCompatibleWithHost(
   );
 }
 
+/** WebAuthn RPs are registrable domains; bare IP addresses are never valid. */
+function isLikelyIpAddress(value: string | null | undefined): boolean {
+  const raw = value?.trim() ?? "";
+  if (!raw) return false;
+  const host = raw.startsWith("[") ? raw : extractHost(raw) || raw;
+  const unbracketed = host.replace(/^\[|\]$/g, "");
+  const ipv4Parts = unbracketed.split(".");
+  if (
+    ipv4Parts.length === 4 &&
+    ipv4Parts.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255)
+  ) {
+    return true;
+  }
+  return unbracketed.includes(":") && /^[0-9a-fA-F:]+$/.test(unbracketed);
+}
 export function resolvePasskeyRpId(options: ResolvePasskeyRpIdOptions): string {
   const explicitRp = normalizeRpHost(process.env.NEXT_PUBLIC_PASSKEY_RP_ID);
   if (explicitRp) {

--- a/hushh-webapp/lib/vault/prf-auth.ts
+++ b/hushh-webapp/lib/vault/prf-auth.ts
@@ -27,6 +27,12 @@ import { resolvePasskeyRpId } from "@/lib/vault/passkey-rp";
 // callers fail locally while the original ceremony remains the sole owner.
 let webAuthnCeremonyPending = false;
 
+/** 5-minute ceiling. A healthy WebAuthn ceremony resolves in seconds; an
+ *  abandoned prompt (user walked away, browser lost focus, native sheet
+ *  orphaned by a route transition) should not hold the page-wide lease
+ *  indefinitely. */
+const WEBAUTHN_CEREMONY_TIMEOUT_MS = 5 * 60 * 1000;
+
 export class WebAuthnCeremonyInProgressError extends Error {
   constructor() {
     super("A passkey prompt is already open.");
@@ -43,9 +49,20 @@ async function runExclusiveWebAuthn<T>(
 
   const controller = new AbortController();
   webAuthnCeremonyPending = true;
+  let timedOut = false;
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, WEBAUTHN_CEREMONY_TIMEOUT_MS);
   try {
     return await run(controller.signal);
+  } catch (error) {
+    if (timedOut) {
+      throw new Error("Passkey prompt timed out. Try again.");
+    }
+    throw error;
   } finally {
+    clearTimeout(timeoutId);
     webAuthnCeremonyPending = false;
   }
 }

--- a/hushh-webapp/lib/vault/vault-context.tsx
+++ b/hushh-webapp/lib/vault/vault-context.tsx
@@ -131,21 +131,32 @@ export function VaultProvider({ children }: VaultProviderProps) {
   const vaultOwnerToken = vaultIdentityMatches ? storedVaultOwnerToken : null;
   const tokenExpiresAt = vaultIdentityMatches ? storedTokenExpiresAt : null;
   const lastUpgradeKickoffKeyRef = useRef<string | null>(null);
-  // Mirror of tokenExpiresAt so the app-resume listener can read the latest
-  // expiry without re-subscribing every time the token changes.
   const tokenExpiresAtRef = useRef<number | null>(null);
+  // Mirrors of the latest values so async event handlers and cleanup
+  // callbacks never read stale closures. lockVault reads from these refs
+  // instead of from the useCallback capture.
+  const vaultUserIdRef = useRef<string | null>(vaultUserId);
+  const storedVaultOwnerTokenRef = useRef<string | null>(storedVaultOwnerToken);
+
   useEffect(() => {
     tokenExpiresAtRef.current = tokenExpiresAt;
   }, [tokenExpiresAt]);
-
-
+  useEffect(() => {
+    vaultUserIdRef.current = vaultUserId;
+  }, [vaultUserId]);
+  useEffect(() => {
+    storedVaultOwnerTokenRef.current = storedVaultOwnerToken;
+  }, [storedVaultOwnerToken]);
   const lockVault = useCallback(() => {
+    // Read from refs so event-listeners registered at mount time always see
+    // the latest values — never stale closure captures.
+    const lockedUserId = vaultUserIdRef.current;
+    const lockedOwnerToken = storedVaultOwnerTokenRef.current;
     console.log("🔒 Vault locked (key + token cleared from memory)");
-    const lockedUserId = vaultUserId;
-    if (lockedUserId && storedVaultOwnerToken) {
+    if (lockedUserId && lockedOwnerToken) {
       void PkmUpgradeOrchestrator.pauseForLocalAuthResume({
         userId: lockedUserId,
-        vaultOwnerToken: storedVaultOwnerToken,
+        vaultOwnerToken: lockedOwnerToken,
       }).catch((error) => {
         console.warn("[VaultProvider] Failed to pause PKM upgrade for local auth resume:", error);
       });
@@ -189,7 +200,7 @@ export function VaultProvider({ children }: VaultProviderProps) {
         .catch(() => undefined);
     }
     VaultService.invalidateVaultStateCache();
-  }, [storedVaultOwnerToken, vaultUserId]);
+  }, []);
 
   // Auto-lock on sign-out or account switch. The public context is already
   // fail-closed during the render where the UID changes; this effect erases the


### PR DESCRIPTION
## Summary

Corrects the base-branch error in #6671: its vault fixes were merged into `feat/voice-v2`, not `main`.

This PR replays the compatible hardening on current `main`:
- reject IP-address WebAuthn RP IDs;
- time out abandoned passkey ceremonies so the explicit Passkey retry remains available;
- keep cancellation copy specific to WebAuthn context; and
- make vault locking read the current owner/token values rather than a stale callback closure.

Excluded from #6671: the proposed raw-byte `vaultKeyHash` change. That hash is persisted and compared by wrapper APIs, so changing it without a versioned migration would make existing vaults fail integrity and wrapper checks.

## Verification

- `npm.cmd test -- __tests__/services/passkey-rp.test.ts __tests__/vault/prf-auth-concurrency.test.ts __tests__/lib/vault/vault-context-resume.test.tsx` (19 passed)
- `npm.cmd run typecheck`
- focused ESLint on changed source and tests
- `git diff --check`