### PR TITLE
fix(ios): restore TestFlight signing certificate setup

### DIFF
--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -185,6 +185,36 @@ jobs:
         shell: bash
         run: bash scripts/ci/materialize-ios-testflight-release-config.sh
 
+      - name: Create signing keychain
+        shell: bash
+        run: |
+          set -euo pipefail
+          KEYCHAIN="${RUNNER_TEMP}/app-signing.keychain-db"
+          KC_PW="$(openssl rand -base64 24)"
+          security create-keychain -p "$KC_PW" "$KEYCHAIN"
+          security set-keychain-settings -lt 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KC_PW" "$KEYCHAIN"
+          # Keep the keychain runner-local; Apple-managed signing can use the
+          # existing distribution certificate without creating another one.
+          security list-keychains -d user -s "$KEYCHAIN" "login.keychain-db"
+          security default-keychain -s "$KEYCHAIN"
+
+          DIST_CERT_B64="$(gcloud secrets versions access latest \
+            --secret=APPSTORE_DISTRIBUTION_CERT_P12_B64 \
+            --project="${GCP_PROJECT_ID}" 2>/dev/null || true)"
+          if [ -z "$DIST_CERT_B64" ]; then
+            echo "Missing APPSTORE_DISTRIBUTION_CERT_P12_B64 in ${GCP_PROJECT_ID}." >&2
+            exit 1
+          fi
+          umask 077
+          echo "$DIST_CERT_B64" | openssl base64 -d -A > "${RUNNER_TEMP}/dist_cert.p12"
+          security import "${RUNNER_TEMP}/dist_cert.p12" -k "$KEYCHAIN" -P "" -A
+          rm -f "${RUNNER_TEMP}/dist_cert.p12"
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: -s -k "$KC_PW" "$KEYCHAIN" \
+            >/dev/null 2>&1 || true
+          echo "Distribution certificate imported into signing keychain."
+
       - name: Verify matching UAT backend revision
         shell: bash
         env:


### PR DESCRIPTION
## Problem

The TestFlight archive failed on the hosted macOS runner because automatic signing could not find a provisioning profile and attempted to create another certificate after the Apple account reached its certificate limit.

## Change

Restore the runner-local signing keychain setup used by the App Store release path. The workflow now imports the approved `APPSTORE_DISTRIBUTION_CERT_P12_B64` from `hushh-pda-uat` Secret Manager before archive/export, so Apple-managed signing can reuse the existing certificate.

## Validation

- `git diff --check`
- YAML parse passed with PyYAML
- Existing workflow gates remain unchanged

This change is limited to `.github/workflows/ship-ios-testflight.yml` and does not alter app source or release policy.
