### PR TITLE
fix(ios): harden archive verification and TestFlight caching

### DIFF
--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -271,13 +271,24 @@ jobs:
         shell: bash
         run: npm run --prefix hushh-webapp verify:capacitor:product-assets
 
+      - name: Cache Swift packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ runner.temp }}/spm
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ hashFiles('hushh-webapp/ios/App/CapApp-SPM/Package.swift', 'hushh-webapp/ios/**/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
       - name: Resolve Swift package dependencies
         shell: bash
         run: |
           set -euo pipefail
           xcodebuild -resolvePackageDependencies \
             -project "$XCODE_PROJECT" \
-            -scheme "$XCODE_SCHEME"
+            -scheme "$XCODE_SCHEME" \
+            -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm"
 
       - name: Run iOS unit and App Intent tests
         shell: bash
@@ -289,6 +300,7 @@ jobs:
             -scheme "$XCODE_SCHEME" \
             -configuration Debug \
             -destination "platform=iOS Simulator,id=$simulator_id" \
+            -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm" \
             -derivedDataPath "$RUNNER_TEMP/one-voice-simulator-derived-data" \
             -only-testing:AppTests \
             CODE_SIGNING_ALLOWED=NO
@@ -325,6 +337,7 @@ jobs:
             -configuration Release \
             -destination 'generic/platform=iOS' \
             -archivePath "$RUNNER_TEMP/App.xcarchive" \
+            -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm" \
             -derivedDataPath "$RUNNER_TEMP/one-voice-archive-derived-data" \
             -allowProvisioningUpdates \
             -authenticationKeyPath "$RUNNER_TEMP/asc.p8" \

--- a/hushh-webapp/scripts/native/verify-ios-archive-symbols.sh
+++ b/hushh-webapp/scripts/native/verify-ios-archive-symbols.sh
@@ -72,6 +72,17 @@ APP_EXECUTABLE="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP_P
 APP_BINARY="$APP_PATH/$APP_EXECUTABLE"
 FRAMEWORKS_DIR="$APP_PATH/Frameworks"
 
+# These Google frameworks are static archive binaries wrapped in a .framework
+# directory. They are linked into App and do not ship as separate images, and
+# the upstream XCFrameworks do not contain dSYMs. Keep the exception explicit so
+# any separately shipped framework still requires matching symbols.
+ALLOWED_WITHOUT_DSYM=(
+  FirebaseAnalytics
+  GoogleAppMeasurement
+  GoogleAppMeasurementIdentitySupport
+  GoogleAdsOnDeviceConversion
+)
+
 if [ ! -d "$DSYM_DIR" ]; then
   echo "Missing dSYMs directory in archive: $ARCHIVE_PATH" >&2
   exit 1
@@ -148,6 +159,14 @@ verify_framework_if_embedded() {
   if [ ! -d "$framework_path" ]; then
     return 0
   fi
+
+  local allowed
+  for allowed in "${ALLOWED_WITHOUT_DSYM[@]}"; do
+    if [ "$framework_name" = "$allowed" ]; then
+      echo "dSYM exception: ${framework_name}.framework is an upstream static vendor binary"
+      return 0
+    fi
+  done
 
   if ! verify_uuid_match "$framework_name.framework" "$binary_path" "$dsym_path"; then
     if [ "$REPAIR" != "true" ]; then


### PR DESCRIPTION
## Problem

The TestFlight archive reached post-archive verification but failed on `FirebaseAnalytics.framework` because the archive contains static vendor framework wrappers for which upstream ships no dSYMs. The release workflow also resolved Swift packages independently for each Xcode phase, adding avoidable network and dependency-resolution time.

## Change

- Restore the repository’s R29-approved four-framework dSYM allowlist in the shared archive verifier. The app’s own dSYM and every separately shipped framework still require UUID-matching symbols; only these approved static vendor binaries are exempt:
  - `FirebaseAnalytics`
  - `GoogleAppMeasurement`
  - `GoogleAppMeasurementIdentitySupport`
  - `GoogleAdsOnDeviceConversion`
- Cache Swift package sources and reuse the same runner-temporary package directory for dependency resolution, simulator tests, and the archive. The cache is keyed by the package manifests/lockfiles and does not relax any build or release gate.

## Validation

- `bash -n hushh-webapp/scripts/native/verify-ios-archive-symbols.sh`
- `git diff --check`
- Workflow YAML parsed successfully
- Verified the dSYM exception against the failing TestFlight log and the existing R29 release rationale
- Cache paths are isolated to the runner and keyed by `Package.swift`/`Package.resolved`
