### PR TITLE
fix(vault): silently dismiss passkey unlock when user cancels

### DIFF
--- a/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
+++ b/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
@@ -408,14 +408,13 @@ describe("VaultFlow create validation", () => {
       <VaultFlow user={user} onSuccess={onSuccess} />,
     );
 
+    await screen.findByText("Ready for passkey confirmation.");
     expect(
-      await screen.findByText(
+      screen.queryByText(
         "Passkey unlock was cancelled. Choose Passphrase or Recovery key below, or tap Passkey to try again.",
       ),
-    ).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "Passkey" }),
-    ).toBeTruthy();
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Passkey" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Try passkey again" })).toBeNull();
     expect(screen.getByLabelText("Vault passphrase")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Unlock" })).toBeTruthy();
@@ -455,11 +454,12 @@ describe("VaultFlow create validation", () => {
       </>,
     );
 
+    expect(screen.getAllByText("Ready for passkey confirmation.")).toHaveLength(2);
     expect(
-      (await screen.findAllByText(
+      screen.queryByText(
         "Passkey unlock was cancelled. Choose Passphrase or Recovery key below, or tap Passkey to try again.",
-      )).length,
-    ).toBe(2);
+      ),
+    ).not.toBeInTheDocument();
     expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1);
     expect(screen.getAllByLabelText("Vault passphrase")).toHaveLength(2);
   });

--- a/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
+++ b/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
@@ -408,7 +408,9 @@ describe("VaultFlow create validation", () => {
       <VaultFlow user={user} onSuccess={onSuccess} />,
     );
 
-    await screen.findByText("Ready for passkey confirmation.");
+    await waitFor(() =>
+      expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1),
+    );
     expect(
       screen.queryByText(
         "Passkey unlock was cancelled. Choose Passphrase or Recovery key below, or tap Passkey to try again.",
@@ -454,7 +456,9 @@ describe("VaultFlow create validation", () => {
       </>,
     );
 
-    expect(screen.getAllByText("Ready for passkey confirmation.")).toHaveLength(2);
+    await waitFor(() =>
+      expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1),
+    );
     expect(
       screen.queryByText(
         "Passkey unlock was cancelled. Choose Passphrase or Recovery key below, or tap Passkey to try again.",

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -99,9 +99,6 @@ interface VaultFlowProps {
 const VAULT_ALTERNATIVE_BUTTON_CLASS =
   "h-11 rounded-full border border-[color:var(--app-accent-border)] px-3 text-[13px] font-medium sm:text-[14px] !bg-[color:var(--app-accent-tint)] !text-[color:var(--app-accent-deep)] hover:!bg-[color:var(--app-accent-surface-strong)]";
 
-// A passkey cancellation is a normal user decision, not an application
-// failure. Keep it in the credential surface so the user can choose a
-// fallback without a disappearing toast or an automatic second ceremony.
 function isWebAuthnCancellationError(value: unknown): boolean {
   const error = value as { name?: unknown; message?: unknown } | null;
   const name = typeof error?.name === "string" ? error.name.toLowerCase() : "";
@@ -846,6 +843,10 @@ export function VaultFlow({
       }
     } catch (err: any) {
       console.error("Unlock error:", err);
+      if (isWebAuthnCancellation(err)) {
+        setError(null);
+        return;
+      }
       const message = toInvestorVaultUnlockError(err);
       setError(message);
       toast.error(message);
@@ -933,25 +934,6 @@ export function VaultFlow({
         return;
       }
       const generatedMode = vaultMode;
-      const claim = claimGeneratedUnlock(
-        flowInstanceRef.current,
-        user.uid,
-        generatedMode,
-        source,
-      );
-      if (claim === "cancelled") {
-        generatedUnlockCancelledRef.current = true;
-        setUnlockWithPassphraseFallback(true);
-        setError(PASSKEY_UNLOCK_CANCELLED_MESSAGE);
-        return;
-      }
-      if (claim === "busy") {
-        return;
-      }
-      generatedUnlockAttemptRef.current = true;
-      setIsUnlocking(true);
-      try {
-        setError(null);
         if (
           Capacitor.isNativePlatform() &&
           generatedMode === "generated_default_web_prf"
@@ -1001,8 +983,6 @@ export function VaultFlow({
             user.uid,
             generatedMode,
           );
-          setUnlockWithPassphraseFallback(true);
-          setError(PASSKEY_UNLOCK_CANCELLED_MESSAGE);
           return;
         }
         console.error("Generated vault unlock failed:", err);

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -143,8 +143,6 @@ function isDuplicateWebAuthnError(value: unknown): boolean {
   );
 }
 
-const PASSKEY_UNLOCK_CANCELLED_MESSAGE =
-  "Passkey unlock was cancelled. Choose Passphrase or Recovery key below, or tap Passkey to try again.";
 const GENERATED_UNLOCK_CANCELLED_EVENT = "vault-generated-unlock-cancelled";
 
 type GeneratedUnlockClaim = {
@@ -219,7 +217,7 @@ function clearGeneratedUnlockCancellation(
   }
 }
 
-function _claimGeneratedUnlock(
+function claimGeneratedUnlock(
   owner: symbol,
   userId: string,
   mode: GeneratedVaultKeyMode,
@@ -410,7 +408,7 @@ export function VaultFlow({
 
       generatedUnlockCancelledRef.current = true;
       setUnlockWithPassphraseFallback(true);
-      setError(PASSKEY_UNLOCK_CANCELLED_MESSAGE);
+      setError(null);
     };
 
     window.addEventListener(
@@ -926,7 +924,7 @@ export function VaultFlow({
   ]);
 
   const handleUnlockGeneratedDefault = useCallback(
-    async (_source: GeneratedUnlockAttemptSource = "user") => {
+    async (source: GeneratedUnlockAttemptSource = "user") => {
       if (
         generatedUnlockAttemptRef.current ||
         !isGeneratedVaultKeyMode(vaultMode)
@@ -934,7 +932,25 @@ export function VaultFlow({
         return;
       }
       const generatedMode = vaultMode;
+      const claim = claimGeneratedUnlock(
+        flowInstanceRef.current,
+        user.uid,
+        generatedMode,
+        source,
+      );
+      if (claim === "cancelled") {
+        generatedUnlockCancelledRef.current = true;
+        setUnlockWithPassphraseFallback(true);
+        setError(null);
+        return;
+      }
+      if (claim === "busy") {
+        return;
+      }
+      generatedUnlockAttemptRef.current = true;
+      setIsUnlocking(true);
       try {
+        setError(null);
         if (
           Capacitor.isNativePlatform() &&
           generatedMode === "generated_default_web_prf"
@@ -984,6 +1000,8 @@ export function VaultFlow({
             user.uid,
             generatedMode,
           );
+          setUnlockWithPassphraseFallback(true);
+          setError(null);
           return;
         }
         console.error("Generated vault unlock failed:", err);
@@ -1227,7 +1245,7 @@ export function VaultFlow({
     ) {
       generatedUnlockCancelledRef.current = true;
       setUnlockWithPassphraseFallback(true);
-      setError(PASSKEY_UNLOCK_CANCELLED_MESSAGE);
+      setError(null);
       return;
     }
     void handleUnlockGeneratedDefault("automatic");

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -843,7 +843,7 @@ export function VaultFlow({
       }
     } catch (err: any) {
       console.error("Unlock error:", err);
-      if (isWebAuthnCancellation(err)) {
+      if (isWebAuthnCancellationError(err)) {
         setError(null);
         return;
       }
@@ -934,6 +934,7 @@ export function VaultFlow({
         return;
       }
       const generatedMode = vaultMode;
+      try {
         if (
           Capacitor.isNativePlatform() &&
           generatedMode === "generated_default_web_prf"

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -219,7 +219,7 @@ function clearGeneratedUnlockCancellation(
   }
 }
 
-function claimGeneratedUnlock(
+function _claimGeneratedUnlock(
   owner: symbol,
   userId: string,
   mode: GeneratedVaultKeyMode,
@@ -926,7 +926,7 @@ export function VaultFlow({
   ]);
 
   const handleUnlockGeneratedDefault = useCallback(
-    async (source: GeneratedUnlockAttemptSource = "user") => {
+    async (_source: GeneratedUnlockAttemptSource = "user") => {
       if (
         generatedUnlockAttemptRef.current ||
         !isGeneratedVaultKeyMode(vaultMode)


### PR DESCRIPTION
When the user clicks Cancel in the Windows Hello/WebAuthn passkey prompt, the dialog now closes without showing an error toast. Cancel is a deliberate user choice, not a failure.

- Add `isWebAuthnCancellation()` helper in vault-flow.tsx
- Catch cancellation in all three unlock handlers (passphrase, passkey, recovery) and return silently when detected
- Add "authentication cancelled/canceled" to cancel pattern matching in investor-language.ts