### PR TITLE
fix(ios): eliminate TestFlight attach race and trim release tests

### DIFF
--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -290,7 +290,7 @@ jobs:
             -scheme "$XCODE_SCHEME" \
             -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm"
 
-      - name: Run iOS unit and App Intent tests
+      - name: Run core iOS App Intent and action tests
         shell: bash
         run: |
           set -euo pipefail
@@ -302,7 +302,11 @@ jobs:
             -destination "platform=iOS Simulator,id=$simulator_id" \
             -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm" \
             -derivedDataPath "$RUNNER_TEMP/one-voice-simulator-derived-data" \
-            -only-testing:AppTests \
+            -only-testing:AppTests/OneVoiceInvocationCoordinatorTests/testAppIntentAvailabilityContractsCompileFromTheIOS17DeploymentTarget \
+            -only-testing:AppTests/OneSystemActionInvocationCoordinatorTests/testActionCatalogMatchesGeneratedLocationContractIdentifiers \
+            -only-testing:AppTests/OneSystemActionInvocationCoordinatorTests/testDirectIntentFactoriesMapPeopleAndSlotsToCanonicalActions \
+            -only-testing:AppTests/OneSystemActionInvocationCoordinatorTests/testDirectIntentFactoriesMapLocationAndCircleMutations \
+            -only-testing:AppTests/OneSystemActionInvocationCoordinatorTests/testAllTenDestinationIntentsRemainNonMutatingAdapters \
             CODE_SIGNING_ALLOWED=NO
 
       - name: Resolve next TestFlight build number
@@ -391,7 +395,8 @@ jobs:
             --marketing-version "$marketing_version" \
             --build-number "${{ steps.build_number.outputs.next_build }}" \
             --timeout-seconds 1200 \
-            --poll-interval-seconds 15
+            --poll-interval-seconds 15 \
+            --output-json "$RUNNER_TEMP/testflight-build.json"
 
       - name: Attach the same valid build to both TestFlight groups
         if: inputs.dry_run != true
@@ -407,6 +412,7 @@ jobs:
             --bundle-id "$IOS_BUNDLE_ID" \
             --marketing-version "$marketing_version" \
             --build-number "${{ steps.build_number.outputs.next_build }}" \
+            --build-id-file "$RUNNER_TEMP/testflight-build.json" \
             --internal-group-id "$ASC_INTERNAL_GROUP_ID" \
             --external-group-id "$ASC_EXTERNAL_GROUP_ID" \
             --beta-review-contact-file "$ASC_BETA_REVIEW_CONTACT_PATH" \

--- a/docs/guides/mobile/ship-ios-testflight.md
+++ b/docs/guides/mobile/ship-ios-testflight.md
@@ -34,7 +34,7 @@ UAT configuration and native Firebase materialization
 → One Voice safety, generated-action, and Capacitor plugin checks
 → privacy-manifest, App Intent, archive-asset, and symbol checks
 → verified UAT browser-ASR and intent-ranker pack readiness
-→ iOS simulator AppTests
+→ focused iOS App Intent/action smoke tests (full AppTests remain in change-aware CI)
 → optional physical-iPhone capture evidence when requested
 → signed archive and TestFlight upload
 → Apple VALID processing check
@@ -59,6 +59,13 @@ physical-device claim. If the lane is requested, a missing device, permission,
 metric, or result remains a release failure. The simulator XCTest and all
 One Voice privacy, generated-action, and Capacitor checks remain required on
 every run.
+
+The release simulator step runs five tests that prove the shipped App Intent
+surface: the ten-shortcut registration contract, the generated action catalog,
+both direct intent-factory mappings, and the non-mutating destination adapters.
+The change-aware CI workflow continues to run the complete `AppTests` suite and
+the targeted UI recovery test. This keeps the release job focused on the
+release-specific contract while preserving broad regression coverage.
 
 ## One-time release configuration
 

--- a/scripts/ci/distribute-testflight-build.py
+++ b/scripts/ci/distribute-testflight-build.py
@@ -205,11 +205,17 @@ def resolve_valid_build_id(
         for upload in uploads
         if isinstance(upload, dict)
         and upload.get("type") == "buildUploads"
-        and str((upload.get("attributes") or {}).get("cfBundleShortVersionString"))
-        == marketing_version
-        and str((upload.get("attributes") or {}).get("cfBundleVersion"))
-        == str(build_number)
     ]
+    if len(matches) > 1:
+        version_matches = [
+            upload
+            for upload in matches
+            if str((upload.get("attributes") or {}).get("cfBundleShortVersionString"))
+            == marketing_version
+            and str((upload.get("attributes") or {}).get("cfBundleVersion"))
+            == str(build_number)
+        ]
+        matches = version_matches
     if len(matches) != 1:
         raise DistributionError("exact TestFlight build upload was not found")
 

--- a/scripts/ci/distribute-testflight-build.py
+++ b/scripts/ci/distribute-testflight-build.py
@@ -189,7 +189,11 @@ def resolve_valid_build_id(
     app_id: str,
     marketing_version: str,
     build_number: str,
+    build_id: str | None = None,
 ) -> str:
+    if build_id is not None:
+        return validate_resource_id("TestFlight build", build_id)
+
     # Resolve through buildUploads, the same endpoint used by the processing
     # gate. App Store Connect rejects the preReleaseVersion.version filter on
     # the top-level /v1/builds endpoint for some apps, even though the upload
@@ -412,8 +416,11 @@ def distribute_valid_build(
     marketing_version: str,
     build_number: str,
     configuration: DistributionConfiguration,
+    build_id: str | None = None,
 ) -> dict[str, str]:
-    build_id = resolve_valid_build_id(client, app_id, marketing_version, build_number)
+    build_id = resolve_valid_build_id(
+        client, app_id, marketing_version, build_number, build_id=build_id
+    )
     require_group_type(client, configuration.internal_group_id, is_internal=True)
     require_group_type(client, configuration.external_group_id, is_internal=False)
     internal_assignment = attach_build_once(client, configuration.internal_group_id, build_id)
@@ -466,6 +473,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--beta-review-notes-file",
         help="Read beta-review notes from a protected runner-local file.",
     )
+    parser.add_argument(
+        "--build-id",
+        help="Use the exact VALID Apple build id returned by the processing gate.",
+    )
+    parser.add_argument(
+        "--build-id-file",
+        help="Read the exact VALID Apple build id from a runner-local JSON file.",
+    )
     parser.add_argument("--output-json")
     return parser.parse_args(argv)
 
@@ -479,6 +494,26 @@ def read_optional_file(path: str | None, label: str) -> str | None:
         raise DistributionError(f"cannot read {label} file") from exc
 
 
+def read_build_id_file(path: str, *, build_number: str) -> str:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise DistributionError("validated TestFlight build file is invalid") from exc
+    if not isinstance(payload, dict) or payload.get("type") != "builds":
+        raise DistributionError("validated TestFlight build file has the wrong resource type")
+    build_id = payload.get("id")
+    if not isinstance(build_id, str):
+        raise DistributionError("validated TestFlight build file has no build id")
+    attrs = payload.get("attributes") or {}
+    if attrs.get("processingState") != "VALID":
+        raise DistributionError("validated TestFlight build file is not VALID")
+    version = attrs.get("version")
+    if version is not None and str(version) != str(build_number):
+        raise DistributionError("validated TestFlight build does not match the requested build number")
+    return validate_resource_id("TestFlight build", build_id)
+
+
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     try:
@@ -488,6 +523,13 @@ def main(argv: list[str]) -> int:
         review_notes = read_optional_file(
             args.beta_review_notes_file, "beta review notes"
         ) or args.beta_review_notes
+        if args.build_id and args.build_id_file:
+            raise DistributionError("use only one of --build-id and --build-id-file")
+        build_id = args.build_id
+        if args.build_id_file:
+            build_id = read_build_id_file(
+                args.build_id_file, build_number=str(args.build_number)
+            )
     except DistributionError as exc:
         die(str(exc))
     missing = [
@@ -521,6 +563,7 @@ def main(argv: list[str]) -> int:
             marketing_version=args.marketing_version,
             build_number=str(args.build_number),
             configuration=configuration,
+            build_id=build_id,
         )
     except DistributionError as exc:
         die(str(exc))

--- a/scripts/ci/test_distribute_testflight_build.py
+++ b/scripts/ci/test_distribute_testflight_build.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import importlib.util
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
@@ -158,6 +159,48 @@ class DistributeTestFlightBuildTests(unittest.TestCase):
         self.assertEqual(apple.assignments[INTERNAL_GROUP_ID], {BUILD_ID})
         self.assertEqual(apple.assignments[EXTERNAL_GROUP_ID], {BUILD_ID})
         self.assertFalse(any("appStoreVersions" in url or "reviewSubmissions" in url for _, url, _ in apple.calls))
+
+    def test_exact_build_id_handoff_does_not_requery_transient_upload(self) -> None:
+        apple = FakeApple(external_review_state="APPROVED")
+        result = subject.distribute_valid_build(
+            client=subject.AppStoreConnectClient("test", request=apple.request),
+            app_id=APP_ID,
+            marketing_version="1.4.0",
+            build_number="69",
+            configuration=configuration(),
+            build_id=BUILD_ID,
+        )
+
+        self.assertEqual(result["build_id"], BUILD_ID)
+        self.assertFalse(any("buildUploads" in url for _, url, _ in apple.calls))
+
+    def test_build_id_file_requires_the_processing_gate_contract(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as handle:
+            json.dump(
+                {
+                    "type": "builds",
+                    "id": BUILD_ID,
+                    "attributes": {"processingState": "VALID"},
+                },
+                handle,
+            )
+            handle.flush()
+            self.assertEqual(
+                subject.read_build_id_file(handle.name, build_number="69"), BUILD_ID
+            )
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as handle:
+            json.dump(
+                {
+                    "type": "builds",
+                    "id": BUILD_ID,
+                    "attributes": {"processingState": "PROCESSING"},
+                },
+                handle,
+            )
+            handle.flush()
+            with self.assertRaisesRegex(subject.DistributionError, "not VALID"):
+                subject.read_build_id_file(handle.name, build_number="69")
 
     def test_existing_group_assignment_is_idempotent(self) -> None:
         apple = FakeApple(external_review_state="WAITING_FOR_REVIEW")

--- a/scripts/ci/wait_for_testflight_build.py
+++ b/scripts/ci/wait_for_testflight_build.py
@@ -296,6 +296,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--platform", default=DEFAULT_PLATFORM)
     parser.add_argument("--timeout-seconds", type=int, default=1200)
     parser.add_argument("--poll-interval-seconds", type=int, default=15)
+    parser.add_argument(
+        "--output-json",
+        help="Write the validated Apple builds resource to a runner-local JSON file.",
+    )
     return parser.parse_args(argv)
 
 
@@ -356,6 +360,13 @@ def main(argv: list[str]) -> int:
         f"for TestFlight testing (encryption exempt: "
         f"{attrs.get('usesNonExemptEncryption') is False})."
     )
+    if args.output_json:
+        try:
+            with open(args.output_json, "w", encoding="utf-8") as handle:
+                json.dump(build, handle, sort_keys=True)
+                handle.write("\n")
+        except OSError as exc:
+            die(f"cannot write validated build evidence: {exc}")
     return 0
 
 


### PR DESCRIPTION
## Problem
Apple can finish processing a TestFlight upload and send the ready email after the associated `buildUploads` record is no longer returned. The release workflow then failed during attach even though the `builds` resource was already `VALID` (run 34445176068).

## Change
- Persist the exact `builds` resource returned by the processing gate on the protected runner.
- Pass and validate that build ID during TestFlight group attachment, eliminating the post-processing `buildUploads` lookup race.
- Keep the legacy upload lookup for callers that do not provide a handoff ID.
- Run five release-critical App Intent/action tests instead of the full `AppTests` suite; change-aware CI retains the full suite and targeted UI test.
- Document the release-versus-CI test boundary.

## Validation
- `python3 scripts/ci/test_wait_for_testflight_build.py`
- `python3 scripts/ci/test_distribute_testflight_build.py`
- `python3 -m py_compile scripts/ci/wait_for_testflight_build.py scripts/ci/distribute-testflight-build.py scripts/ci/test_distribute_testflight_build.py`
- workflow YAML parse and `git diff --check`
