### PR TITLE
fix(vault): require explicit passkey retry across remounts and access failures

### DIFF
--- a/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
+++ b/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { VaultFlow } from "@/components/vault/vault-flow";
@@ -15,6 +15,7 @@ const setupVaultStateMock = vi.fn();
 const assertVaultKeyMatchesStateMock = vi.fn();
 const setVaultCheckCacheMock = vi.fn();
 const checkPrfSupportMock = vi.fn();
+const getOrIssueVaultOwnerTokenMock = vi.fn();
 let isNativePlatformMock = false;
 
 vi.mock("@capacitor/core", () => ({
@@ -26,6 +27,7 @@ vi.mock("@capacitor/core", () => ({
 vi.mock("@/lib/services/vault-service", () => ({
   VaultAuthSessionNotReadyError: class extends Error {},
   VaultService: {
+    getOrIssueVaultOwnerToken: (...args: unknown[]) => getOrIssueVaultOwnerTokenMock(...args),
     checkVault: (...args: unknown[]) => checkVaultMock(...args),
     getVaultState: (...args: unknown[]) => getVaultStateMock(...args),
     getPrimaryWrapper: (...args: unknown[]) => getPrimaryWrapperMock(...args),
@@ -537,6 +539,81 @@ describe("VaultFlow create validation", () => {
       expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(2),
     );
   });
+
+  it("does not reopen passkey after owner-token issuance fails and the flow remounts", async () => {
+    const tokenUser = { uid: "owner-token-failure-remount" } as Parameters<typeof VaultFlow>[0]["user"];
+    checkVaultMock.mockResolvedValue(true);
+    getVaultStateMock.mockResolvedValue(
+      vaultState("generated_default_web_prf", [passphraseWrapper, passkeyWrapper]),
+    );
+    unlockGeneratedDefaultVaultMock.mockResolvedValue("test-only-vault-key");
+    getOrIssueVaultOwnerTokenMock.mockRejectedValue(new Error("Service unavailable"));
+    const onSuccess = vi.fn();
+    const first = render(<VaultFlow user={tokenUser} onSuccess={onSuccess} />);
+    await waitFor(() => expect(getOrIssueVaultOwnerTokenMock).toHaveBeenCalledTimes(1));
+    first.unmount();
+    render(<VaultFlow user={tokenUser} onSuccess={onSuccess} />);
+    await screen.findByLabelText("Vault passphrase");
+    expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(unlockVaultMock).not.toHaveBeenCalled();
+    getOrIssueVaultOwnerTokenMock.mockResolvedValue({ token: "test-only-token", expiresAt: 123 });
+    fireEvent.click(screen.getByRole("button", { name: "Passkey" }));
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(2);
+    expect(unlockVaultMock).toHaveBeenCalledWith("test-only-vault-key", "test-only-token", 123);
+  });
+
+  it("honors explicit Passkey retry when a hard gate suppresses automatic prompts", async () => {
+    const gateUser = { uid: "explicit-retry-overlapping-hard-gate" } as Parameters<typeof VaultFlow>[0]["user"];
+    checkVaultMock.mockResolvedValue(true);
+    getVaultStateMock.mockResolvedValue(
+      vaultState("generated_default_web_prf", [passphraseWrapper, passkeyWrapper]),
+    );
+    unlockGeneratedDefaultVaultMock.mockRejectedValueOnce(
+      Object.assign(new Error("Cancelled"), { name: "NotAllowedError" }),
+    );
+    render(<VaultFlow user={gateUser} onSuccess={vi.fn()} />);
+    await screen.findByRole("button", { name: "Passkey" });
+    document.documentElement.setAttribute("data-vault-unlock-hard-gate", "true");
+    try {
+      fireEvent.click(screen.getByRole("button", { name: "Passkey" }));
+      await waitFor(() => expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(2));
+    } finally {
+      document.documentElement.removeAttribute("data-vault-unlock-hard-gate");
+    }
+  });
+
+  it.each(["NotAllowedError", "AbortError", "UnknownError"])(
+    "keeps a pending web ceremony exclusive across remounts and blocks retry after %s",
+    async (name) => {
+      const pendingUser = { uid: `pending-remount-${name}` } as Parameters<typeof VaultFlow>[0]["user"];
+      checkVaultMock.mockResolvedValue(true);
+      getVaultStateMock.mockResolvedValue(
+        vaultState("generated_default_web_prf", [passphraseWrapper, passkeyWrapper]),
+      );
+      let rejectAttempt!: (reason: Error) => void;
+      unlockGeneratedDefaultVaultMock.mockImplementationOnce(
+        () => new Promise((_, reject) => { rejectAttempt = reject; }),
+      );
+      const first = render(<VaultFlow user={pendingUser} onSuccess={vi.fn()} />);
+      await waitFor(() => expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1));
+      first.unmount();
+      const second = render(<VaultFlow user={pendingUser} onSuccess={vi.fn()} />);
+      await screen.findByText(/Ready for .* confirmation/);
+      expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        rejectAttempt(Object.assign(new Error("Provider did not complete"), { name }));
+      });
+      await screen.findByRole("button", { name: "Passkey" });
+      second.unmount();
+      render(<VaultFlow user={pendingUser} onSuccess={vi.fn()} />);
+      await screen.findByRole("button", { name: "Passkey" });
+      expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1);
+      fireEvent.click(screen.getByRole("button", { name: "Passkey" }));
+      await waitFor(() => expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(2));
+    },
+  );
 
   it("explains a localhost RP ID mismatch without reopening the passkey prompt", async () => {
     isNativePlatformMock = true;

--- a/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
+++ b/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
@@ -14,6 +14,7 @@ const hashVaultKeyMock = vi.fn();
 const setupVaultStateMock = vi.fn();
 const assertVaultKeyMatchesStateMock = vi.fn();
 const setVaultCheckCacheMock = vi.fn();
+const checkPrfSupportMock = vi.fn();
 let isNativePlatformMock = false;
 
 vi.mock("@capacitor/core", () => ({
@@ -52,6 +53,10 @@ vi.mock("@/lib/services/vault-method-service", () => ({
 
 vi.mock("@/lib/services/vault-method-prompt-local-service", () => ({
   VaultMethodPromptLocalService: {},
+}));
+
+vi.mock("@/lib/vault/prf-auth", () => ({
+  checkPrfSupport: (...args: unknown[]) => checkPrfSupportMock(...args),
 }));
 
 vi.mock("@/lib/utils/native-download", () => ({
@@ -154,6 +159,7 @@ describe("VaultFlow create validation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     isNativePlatformMock = false;
+    checkPrfSupportMock.mockResolvedValue(true);
     checkVaultMock.mockResolvedValue(false);
     getVaultStateMock.mockResolvedValue(
       vaultState("passphrase", [passphraseWrapper, passkeyWrapper]),
@@ -438,6 +444,9 @@ describe("VaultFlow create validation", () => {
 
   it("shares cancellation across overlapping native unlock surfaces", async () => {
     isNativePlatformMock = true;
+    const overlappingUser = {
+      uid: "user-overlapping-native-unlock-surfaces",
+    } as Parameters<typeof VaultFlow>[0]["user"];
     checkVaultMock.mockResolvedValue(true);
     getVaultStateMock.mockResolvedValue(
       vaultState("generated_default_native_passkey_prf", [
@@ -451,8 +460,8 @@ describe("VaultFlow create validation", () => {
 
     render(
       <>
-        <VaultFlow user={user} onSuccess={vi.fn()} />
-        <VaultFlow user={user} onSuccess={vi.fn()} />
+        <VaultFlow user={overlappingUser} onSuccess={vi.fn()} />
+        <VaultFlow user={overlappingUser} onSuccess={vi.fn()} />
       </>,
     );
 
@@ -466,6 +475,67 @@ describe("VaultFlow create validation", () => {
     ).not.toBeInTheDocument();
     expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1);
     expect(screen.getAllByLabelText("Vault passphrase")).toHaveLength(2);
+  });
+
+  it("does not re-open a web passkey prompt after cancellation and a vault-flow remount", async () => {
+    const webUser = {
+      uid: "user-web-passkey-cancel-remount",
+    } as Parameters<typeof VaultFlow>[0]["user"];
+    checkVaultMock.mockResolvedValue(true);
+    getVaultStateMock.mockResolvedValue(
+      vaultState("generated_default_web_prf", [passphraseWrapper, passkeyWrapper]),
+    );
+    unlockGeneratedDefaultVaultMock.mockRejectedValueOnce(
+      Object.assign(new Error("The operation was not allowed."), {
+        name: "NotAllowedError",
+      }),
+    );
+
+    const firstFlow = render(<VaultFlow user={webUser} onSuccess={vi.fn()} />);
+    await waitFor(() =>
+      expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1),
+    );
+
+    firstFlow.unmount();
+    render(<VaultFlow user={webUser} onSuccess={vi.fn()} />);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Passkey" }));
+    await waitFor(() =>
+      expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it("requires an explicit retry after a Google Password Manager failure and remount", async () => {
+    const webUser = {
+      uid: "user-google-password-manager-failure-remount",
+    } as Parameters<typeof VaultFlow>[0]["user"];
+    checkVaultMock.mockResolvedValue(true);
+    getVaultStateMock.mockResolvedValue(
+      vaultState("generated_default_web_prf", [passphraseWrapper, passkeyWrapper]),
+    );
+    unlockGeneratedDefaultVaultMock.mockRejectedValueOnce(
+      new Error("Can't reach Google Password Manager"),
+    );
+
+    const firstFlow = render(<VaultFlow user={webUser} onSuccess={vi.fn()} />);
+    expect(
+      await screen.findByRole("button", { name: "Passkey" }),
+    ).toBeTruthy();
+    expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1);
+
+    firstFlow.unmount();
+    render(<VaultFlow user={webUser} onSuccess={vi.fn()} />);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Passkey" }));
+    await waitFor(() =>
+      expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(2),
+    );
   });
 
   it("explains a localhost RP ID mismatch without reopening the passkey prompt", async () => {
@@ -494,7 +564,8 @@ describe("VaultFlow create validation", () => {
       ),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Passkey" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Passphrase" })).toBeTruthy();
+    expect(screen.getByLabelText("Vault passphrase")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Unlock" })).toBeTruthy();
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(unlockGeneratedDefaultVaultMock).toHaveBeenCalledTimes(1);
   });

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -981,7 +981,9 @@ export function VaultFlow({
         }
 
         await VaultService.assertVaultKeyMatchesState(vaultData, decryptedKey);
-        await finalizeUnlock(decryptedKey);
+        if (!(await finalizeUnlock(decryptedKey))) {
+          throw new Error("We could not complete Vault access. Please try again.");
+        }
       } catch (err: any) {
         // A duplicate caller is rejected before it can reach the browser. The
         // original ceremony remains active and owns the visible prompt.
@@ -1679,6 +1681,10 @@ export function VaultFlow({
                           fullWidth
                           className={VAULT_ALTERNATIVE_BUTTON_CLASS}
                           onClick={() => {
+                            if (hasActiveGeneratedWrapper) {
+                              handleRetryGeneratedUnlock();
+                              return;
+                            }
                             generatedUnlockCancelledRef.current = false;
                             if (availableGeneratedMethod) {
                               clearGeneratedUnlockCancellation(

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -194,38 +194,12 @@ function isGeneratedVaultKeyMode(
 
 // A locked session can briefly have more than one mounted VaultFlow while a
 // route gate takes ownership. The browser and the native Credential Manager
-// must see one page-wide ceremony, and a user cancellation must follow that
-// session across the handoff instead of being treated as permission to prompt
-// again from the newly mounted flow.
+// must see one page-wide ceremony. A settled attempt must also outlive a UI
+// handoff: browser focus can briefly unmount the flow for session verification,
+// but that must not turn a cancellation or provider failure into permission to
+// show another passkey prompt.
 let activeGeneratedUnlockClaim: GeneratedUnlockClaim | null = null;
 let cancelledGeneratedUnlock: Omit<GeneratedUnlockClaim, "owner"> | null = null;
-const activeGeneratedUnlockSurfaces = new Map<string, number>();
-
-function registerGeneratedUnlockSurface(userId: string): () => void {
-  activeGeneratedUnlockSurfaces.set(
-    userId,
-    (activeGeneratedUnlockSurfaces.get(userId) ?? 0) + 1,
-  );
-
-  let released = false;
-  return () => {
-    if (released) return;
-    released = true;
-
-    const count = activeGeneratedUnlockSurfaces.get(userId) ?? 0;
-    if (count <= 1) {
-      activeGeneratedUnlockSurfaces.delete(userId);
-    } else {
-      activeGeneratedUnlockSurfaces.set(userId, count - 1);
-    }
-
-    // Once the last unlock surface is gone and no native/browser ceremony is
-    // still settling, the next deliberate unlock is a fresh session.
-    if (activeGeneratedUnlockClaim === null && activeGeneratedUnlockSurfaces.size === 0) {
-      cancelledGeneratedUnlock = null;
-    }
-  };
-}
 
 function isGeneratedUnlockCancelled(
   userId: string,
@@ -287,9 +261,6 @@ function markGeneratedUnlockCancelled(
 function releaseGeneratedUnlock(owner: symbol): void {
   if (activeGeneratedUnlockClaim?.owner !== owner) return;
   activeGeneratedUnlockClaim = null;
-  if (activeGeneratedUnlockSurfaces.size === 0) {
-    cancelledGeneratedUnlock = null;
-  }
 }
 
 function VaultFlowHeader({
@@ -421,11 +392,6 @@ export function VaultFlow({
   });
 
   const { isVaultUnlocked, unlockVault } = useVault();
-
-  useEffect(
-    () => registerGeneratedUnlockSurface(user.uid),
-    [user.uid],
-  );
 
   useEffect(() => {
     const handleGeneratedUnlockCancelled = (event: Event) => {
@@ -1034,6 +1000,18 @@ export function VaultFlow({
           return;
         }
         console.error("Generated vault unlock failed:", err);
+        // Google Password Manager and the platform authenticator can fail
+        // after opening their UI. Keep that outcome session-scoped too: a
+        // focus-driven remount must not immediately reopen the same ceremony.
+        // The visible Passkey action explicitly clears this block and is the
+        // only way to begin another attempt.
+        generatedUnlockCancelledRef.current = true;
+        markGeneratedUnlockCancelled(
+          flowInstanceRef.current,
+          user.uid,
+          generatedMode,
+        );
+        setUnlockWithPassphraseFallback(true);
         const message = toInvestorVaultUnlockError(err);
         setError(message);
       } finally {


### PR DESCRIPTION
## Description

Google Password Manager cancellation or provider failure could reopen the vault passkey prompt when browser focus caused session validation to unmount and remount VaultFlow. Cancellation state was cleared when the last flow unmounted; ordinary provider failures only lived in component state. A separate path ignored failed vault-owner token issuance after successful passkey authentication, allowing another automatic attempt after remount.

Keep the existing in-memory cancellation marker across component remounts, apply it to provider and access-finalization failures, and make the existing Passkey retry control invoke retry explicitly when the generated wrapper is active. Pending ceremonies retain exclusive ownership. Failures leave the vault locked with fallback methods; deliberate Passkey interaction permits another attempt.

## Impact map

- Reachable surface: `/one` and other protected routes through VaultLockGuard / VaultUnlockDialog / VaultFlow.
- Trust boundary: vault unlock and auth completion. Key validation and owner-token issuance remain required; no key, token, or decrypted information is persisted by this change.
- API/schema/types/cache keys/runtime DB/world-model effects: none.
- Docs/config/generated/dependencies: none.
- Caller pairing: existing VaultService and VaultBootstrapService contracts unchanged.
- Mobile parity: shared VaultFlow affects web and Capacitor clients. Native plugin and API changes are N/A; native cancellation coverage passes, but real iOS/Android device verification remains pending.
- Related open PRs checked: no duplicate retry-latch change found; vault-method visibility work is separate.
- Rollback: revert the two commits together. No migration or stored vault format changes. Reverting restores the previous retry behavior.

## Verification

- Passed: `cd hushh-webapp && npm run typecheck`.
- Passed: `cd hushh-webapp && npx vitest run __tests__/components/vault-flow-create-validation.test.tsx __tests__/components/vault-lock-guard.test.tsx __tests__/components/vault-unlock-dialog.test.tsx __tests__/vault/prf-auth-concurrency.test.ts __tests__/services/vault-bootstrap-service-unlock.test.ts` — 41 tests.
- Passed: `git diff --check` and DCO signoff for both commits.
- Attempted: `./bin/hushh codex pre-pr`; DCO passes, then the Windows Python subprocess launcher fails with WinError 193 when invoking `./bin/hushh ci`. The full local CI mirror and production build are not claimed as passed. Hosted CI remains required.
- Tests import production VaultFlow with mocked service/provider boundaries. They cover failure then remount, remount while a ceremony remains pending, cancellation/abort/provider errors, failed token issuance, overlapping-gate explicit retry, and a successful manual retry reaching unlocked context.
- The token-issuance regression was observed failing before its corrective change.
- A separate read-only code review found the token-finalization and overlapping-gate retry gaps; both are addressed here. This is not independent real-provider validation.

## UAT acceptance still required

On Chrome/Windows with Google Password Manager at `/one`: cancel the prompt, exercise a provider failure, and change browser focus. Verify no additional app-triggered prompt occurs after each settled failure. Click Passkey and confirm one new attempt can unlock. Check passphrase/recovery availability. Real Google Password Manager, Windows Security, and mobile device UI have not been exercised for this version; no screenshot or browser proof is claimed.

The marker is in page memory: it survives component remounts, not a full page reload. This change controls VaultFlow requests, not the provider's internal UI sequence.

## Review contract

- [x] Title, diff, and tests describe the same reachable unlock behavior.
- [x] Commits are signed off; first-party changes remain Apache-2.0 compatible.
- [x] No new access to user information or consent scope is introduced.
- [ ] Hosted CI passes on the submitted head.
- [ ] Real-provider UAT acceptance passes.

Same-repository branch; no fork maintainer-edit restriction. User will merge and perform UAT acceptance.
