### PR TITLE
fix(vault): restore unlock compatibility for persisted key hashes

### DIFF
--- a/hushh-webapp/__tests__/services/vault-method-service.test.ts
+++ b/hushh-webapp/__tests__/services/vault-method-service.test.ts
@@ -89,6 +89,11 @@ describe("VaultMethodService.changePassphrase", () => {
       }),
     );
     expect(setPrimaryMock).not.toHaveBeenCalled();
+    expect(hashVaultKeyMock).toHaveBeenCalledWith(
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "vault-hash",
+    );
+    expect(upsertWrapperMock).toHaveBeenCalledWith(expect.objectContaining({ vaultKeyHash: "vault-hash" }));
     expect(result).toEqual({
       primaryMethod: "generated_default_native_passkey_prf",
       passphraseUpdated: true,

--- a/hushh-webapp/__tests__/vault/hermes-vault-vector.test.ts
+++ b/hushh-webapp/__tests__/vault/hermes-vault-vector.test.ts
@@ -1,13 +1,39 @@
 import vector from "../fixtures/hermes-vault-vector.json";
 import creationVector from "../fixtures/hermes-vault-creation-vector.json";
 
-import { VaultService } from "@/lib/services/vault-service";
+import { createHash } from "node:crypto";
+import { VaultService, type VaultState } from "@/lib/services/vault-service";
 import {
   unlockVaultWithPassphrase,
   unlockVaultWithRecoveryKey,
 } from "@/lib/vault/passphrase-key";
 
 describe("Hermes vault crypto vector", () => {
+  const key = "01".repeat(32);
+  const historicalHash = "58badd9b455145b487ad24c7f259cc437cc4ffd0784716845249321fb5961cfc";
+  const rawHash = "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793";
+  const stateWithHash = (vaultKeyHash: string): VaultState => ({
+    vaultKeyHash,
+    primaryMethod: "passphrase",
+    recoveryEncryptedVaultKey: "",
+    recoverySalt: "",
+    recoveryIv: "",
+    wrappers: [],
+  });
+
+  it.each([historicalHash, rawHash])("accepts a deployed hash encoding: %s", async (hash) => {
+    await expect(VaultService.assertVaultKeyMatchesState(stateWithHash(hash), key)).resolves.toBeUndefined();
+    expect(await VaultService.hashVaultKey(key, hash)).toBe(hash);
+  });
+
+  it("keeps new hashes canonical and rejects wrong keys for both stored encodings", async () => {
+    expect(await VaultService.hashVaultKey(key)).toBe(historicalHash);
+    for (const hash of [historicalHash, rawHash]) {
+      await expect(VaultService.assertVaultKeyMatchesState(stateWithHash(hash), "02".repeat(32))).rejects.toThrow("integrity check failed");
+    }
+    await expect(VaultService.assertVaultKeyMatchesState(stateWithHash("invalid-hash"), key)).rejects.toThrow("integrity check failed");
+  });
+
   it("unwraps and hashes identically to the native bridge", async () => {
     const vaultKey = await unlockVaultWithPassphrase(
       vector.passphrase,
@@ -36,6 +62,10 @@ describe("Hermes vault crypto vector", () => {
 
     expect(fromPassphrase).toBe(creationVector.vault_key_hex);
     expect(fromRecovery).toBe(creationVector.vault_key_hex);
+    // Reproduce the pre-change persisted format independently of the service.
+    const legacyState = stateWithHash(createHash("sha256").update(creationVector.vault_key_hex).digest("hex"));
+    await expect(VaultService.assertVaultKeyMatchesState(legacyState, fromPassphrase)).resolves.toBeUndefined();
+    await expect(VaultService.assertVaultKeyMatchesState(legacyState, fromRecovery)).resolves.toBeUndefined();
     expect(await VaultService.hashVaultKey(fromPassphrase)).toBe(
       creationVector.vault_key_hash,
     );

--- a/hushh-webapp/lib/services/vault-method-service.ts
+++ b/hushh-webapp/lib/services/vault-method-service.ts
@@ -125,7 +125,7 @@ export class VaultMethodService {
     try {
       const canonicalVaultKey = ensureVaultKeyHex(params.currentVaultKey);
       const state = await VaultService.getVaultState(params.userId);
-      const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey);
+      const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey, state.vaultKeyHash);
 
       if (state.vaultKeyHash && state.vaultKeyHash !== vaultKeyHash) {
         throw new Error("Key mismatch detected. Unlock again.");
@@ -238,7 +238,7 @@ export class VaultMethodService {
     try {
       const canonicalVaultKey = ensureVaultKeyHex(params.currentVaultKey);
       const state = await VaultService.getVaultState(params.userId);
-      const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey);
+      const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey, state.vaultKeyHash);
 
       if (state.vaultKeyHash && state.vaultKeyHash !== vaultKeyHash) {
         throw new Error("Key mismatch detected. Unlock again.");
@@ -303,7 +303,7 @@ export class VaultMethodService {
 
       const canonicalVaultKey = ensureVaultKeyHex(params.currentVaultKey);
       const state = await VaultService.getVaultState(params.userId);
-      const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey);
+      const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey, state.vaultKeyHash);
 
       if (state.vaultKeyHash && state.vaultKeyHash !== vaultKeyHash) {
         throw new Error("Key mismatch detected. Unlock again.");

--- a/hushh-webapp/lib/services/vault-service.ts
+++ b/hushh-webapp/lib/services/vault-service.ts
@@ -665,20 +665,40 @@ export class VaultService {
     return wrapper;
   }
 
-  static async hashVaultKey(vaultKeyHex: string): Promise<string> {
+  static async hashVaultKey(
+    vaultKeyHex: string,
+    existingVaultKeyHash?: string,
+  ): Promise<string> {
     const normalized = this.normalizeVaultKeyHex(vaultKeyHex);
     if (!normalized) {
       throw new Error("Invalid vault key hex.");
     }
-    // Hash the raw bytes, not the hex-encoded string representation.
+    // A deployed release briefly wrote raw-byte hashes. Retain compatibility
+    // with those records while preserving the original hex-text write format.
     const rawBytes = hexToBytes(normalized);
     const digest = await crypto.subtle.digest(
       "SHA-256",
       rawBytes.buffer as ArrayBuffer,
     );
-    return Array.from(new Uint8Array(digest))
+    const rawHash = Array.from(new Uint8Array(digest))
       .map((byte) => byte.toString(16).padStart(2, "0"))
       .join("");
+    if (existingVaultKeyHash === rawHash) return rawHash;
+
+    // Vaults created before the raw-byte hash change stored SHA-256 of the
+    // normalized hex text. Verify that exact historical encoding as well.
+    // Preserve a matching stored hash for wrapper mutations: the backend
+    // compares it verbatim, and changing it requires a coordinated migration.
+    const legacyDigest = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(normalized),
+    );
+    const legacyHash = Array.from(new Uint8Array(legacyDigest))
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("");
+    return !existingVaultKeyHash || legacyHash === existingVaultKeyHash
+      ? legacyHash
+      : rawHash;
   }
 
   static async unlockWithMethod(params: {
@@ -711,7 +731,7 @@ export class VaultService {
     }
     if (!state.vaultKeyHash) return;
 
-    const hashed = await this.hashVaultKey(normalizedKey);
+    const hashed = await this.hashVaultKey(normalizedKey, state.vaultKeyHash);
     if (hashed !== state.vaultKeyHash) {
       throw new Error("Vault key integrity check failed.");
     }


### PR DESCRIPTION
## Problem and behavior

Commit 31eb1982a changed vaultKeyHash from SHA-256 of normalized hex text to SHA-256 of raw key bytes without read compatibility. Existing encrypted wrappers still decrypt, but both passphrase and passkey then fail assertVaultKeyMatchesState with `Vault key integrity check failed`. The user's UAT console shows this for both paths. Existing Hermes crypto fixture tests independently fail under that raw-byte-only implementation.

Restore the established hex-text format for new hashes. For existing vaults, accept only a matching hash of the decrypted key under either known encoding. Preserve the matching persisted hash when changing a passphrase, switching unlock methods, or removing a method because backend mutation guards compare that value verbatim. Genuine key/hash mismatches still fail closed.

## Impact map and trust boundary

- Reachable surface: VaultFlow on `/one`, recovery unlock, trusted-device handoff integrity verification, and vault method settings.
- Auth/vault boundary: integrity verification remains mandatory. No key or token persistence, no DB edits, migrations, consent changes, schema/API changes, or encrypted payload changes.
- Web/iOS/Android: shared TypeScript service used by all three; no native plugin changes. Actual provider/device acceptance is pending.
- Cache keys, dependencies, generated artifacts, world-model effects: none.
- Backend pairing: vault_keys_service.py retains exact stored-hash comparison for wrapper mutations; callers now preserve a verified existing hash.
- Rollback: revert this PR restores the affected implementation and reintroduces legacy-vault lockout. Existing stored records are not mutated by this fix.
- Related PR: follows merged #6681 (prompt retry lifecycle); this addresses the independent persistent hash compatibility defect.

## Verification

Passed `cd hushh-webapp && npx vitest run __tests__/vault/hermes-vault-vector.test.ts __tests__/services/vault-method-service.test.ts __tests__/services/vault-service-check.test.ts __tests__/components/vault-flow-create-validation.test.tsx` (51 tests), `npm run typecheck`, and `git diff --check`.

Production crypto fixtures exercise real passphrase and recovery decryption. Added fixed independent hash vectors verify both persisted encodings, default write compatibility, wrong-key rejection, and invalid-hash rejection. Method-service test verifies the stored hash is supplied and retained in wrapper updates. Existing crypto fixtures were observed failing with the raw-byte write default before restoration.

The account's decrypted key/hash were not accessed. The code regression is reproduced; real-account UAT unlock remains the final acceptance step. No new browser proof is claimed. Full hosted CI is required; local full CI launcher is known to fail under Windows with WinError 193.

- [x] Commits signed off; first-party changes remain Apache-2.0 compatible.
- [x] Production code and reachable callers tested; no integrity check bypass.
- [ ] Hosted CI passes on current head.
- [ ] User verifies passkey and passphrase on UAT after deployment.
