### PR TITLE
fix(ios): keep TestFlight beta review explicit

### DIFF
--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      run_core_tests:
+        description: Run the focused simulator App Intent/action smoke gate (full AppTests remain in change-aware CI).
+        required: false
+        default: false
+        type: boolean
       notes:
         description: Optional release note context for the workflow summary.
         required: false
@@ -291,6 +296,7 @@ jobs:
             -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm"
 
       - name: Run core iOS App Intent and action tests
+        if: ${{ inputs.run_core_tests == true }}
         shell: bash
         run: |
           set -euo pipefail
@@ -450,6 +456,7 @@ jobs:
             echo
             echo "| Release source | ${{ needs.preflight.outputs.release_sha }} |"
             echo "| Physical iPhone p95 (ms) | ${{ inputs.require_hardware == true && needs.hardware-capture.outputs.p95_time_to_capture_ms || 'not requested' }} |"
+            echo "| Focused App Intent/action gate | ${{ inputs.run_core_tests == true && 'passed' || 'skipped; full AppTests remain in change-aware CI' }} |"
             echo "| Build number | ${{ steps.build_number.outputs.next_build }} |"
             echo
             echo "The workflow uses TestFlight beta endpoints only. External tester availability is pending until Apple approves TestFlight Beta App Review when required; this workflow never submits an App Store version."

--- a/docs/guides/mobile/ship-ios-testflight.md
+++ b/docs/guides/mobile/ship-ios-testflight.md
@@ -34,7 +34,7 @@ UAT configuration and native Firebase materialization
 → One Voice safety, generated-action, and Capacitor plugin checks
 → privacy-manifest, App Intent, archive-asset, and symbol checks
 → verified UAT browser-ASR and intent-ranker pack readiness
-→ focused iOS App Intent/action smoke tests (full AppTests remain in change-aware CI)
+→ optional focused iOS App Intent/action smoke tests (full AppTests remain in change-aware CI)
 → optional physical-iPhone capture evidence when requested
 → signed archive and TestFlight upload
 → Apple VALID processing check
@@ -56,16 +56,17 @@ owner, and accepts only a redacted aggregate result when all of these are true:
 When `require_hardware` is `false` (the default), the physical job is skipped
 and the release summary records `not requested`; the workflow makes no
 physical-device claim. If the lane is requested, a missing device, permission,
-metric, or result remains a release failure. The simulator XCTest and all
-One Voice privacy, generated-action, and Capacitor checks remain required on
-every run.
+metric, or result remains a release failure. The One Voice privacy,
+generated-action, and Capacitor checks remain required on every run; the
+compile-heavy simulator XCTest gate is opt-in through `run_core_tests`.
 
-The release simulator step runs five tests that prove the shipped App Intent
-surface: the ten-shortcut registration contract, the generated action catalog,
-both direct intent-factory mappings, and the non-mutating destination adapters.
-The change-aware CI workflow continues to run the complete `AppTests` suite and
-the targeted UI recovery test. This keeps the release job focused on the
-release-specific contract while preserving broad regression coverage.
+When the `run_core_tests` dispatch input is `true`, the release simulator step
+runs five tests that prove the shipped App Intent surface: the ten-shortcut
+registration contract, the generated action catalog, both direct intent-factory
+mappings, and the non-mutating destination adapters. The default skips this
+compile-heavy duplicate; the change-aware CI workflow continues to run the
+complete `AppTests` suite and the targeted UI recovery test.
+This keeps the release job focused while preserving broad regression coverage.
 
 ## One-time release configuration
 
@@ -151,7 +152,10 @@ authority contract.
 5. In GitHub Actions, run **Ship iOS to TestFlight** from `main`. Leave `sha`
    blank for the latest eligible SHA, or supply that exact SHA. Set
    `require_hardware: true` for the optional physical-device evidence lane;
-   leave it `false` for the normal simulator-backed release path.
+   leave it `false` for the normal release path. Set `run_core_tests: true`
+   only when you want the focused simulator App Intent/action gate in this
+   release; the default is `false` because the full suite already runs in
+   change-aware CI.
 6. Use `dry_run: true` only when you want a signed archive without uploading.
    It follows the same `require_hardware` choice.
 
@@ -172,5 +176,6 @@ model bytes are removed or never uploaded.
 | Missing group, contact, notes, or privacy attestation | Configure the protected UAT release material; the workflow intentionally will not upload. |
 | External beta review pending | Internal testers can use the valid build; wait for Apple's beta-review decision for external testers. |
 | External beta review rejected | Correct the reviewer-facing issue and dispatch a new build; the workflow fails closed. |
+| `App Store Connect ... failed with HTTP 400` after processing | The binary is already uploaded and `VALID`; inspect the endpoint in the step error. The workflow prepares review metadata before group attachment, treats an unsubmitted external review as pending, and never creates a beta-review submission implicitly. |
 
 Public App Store submission remains a separate, explicitly authorized workflow.

--- a/scripts/ci/distribute-testflight-build.py
+++ b/scripts/ci/distribute-testflight-build.py
@@ -47,6 +47,16 @@ class DistributionError(RuntimeError):
     """A fail-closed TestFlight beta distribution error."""
 
 
+class AppStoreConnectHTTPError(DistributionError):
+    """An App Store Connect HTTP response with a status useful to callers."""
+
+    def __init__(self, method: str, path: str, status_code: int) -> None:
+        super().__init__(f"App Store Connect {method} {path} failed with HTTP {status_code}")
+        self.method = method
+        self.path = path
+        self.status_code = status_code
+
+
 @dataclass(frozen=True)
 class BetaReviewContact:
     first_name: str
@@ -161,7 +171,8 @@ class AppStoreConnectClient:
         except urllib.error.HTTPError as exc:
             # Apple responses can contain reviewer-facing information. Status is
             # enough for CI and avoids echoing request data or error payloads.
-            raise DistributionError(f"App Store Connect {method} failed with HTTP {exc.code}") from exc
+            path = urllib.parse.urlsplit(url).path
+            raise AppStoreConnectHTTPError(method, path, exc.code) from exc
         except urllib.error.URLError as exc:
             raise DistributionError(f"App Store Connect {method} request failed") from exc
         if not raw:
@@ -386,15 +397,19 @@ def upsert_beta_build_localization(
 
 
 def external_beta_status(client: AppStoreConnectClient, build_id: str) -> tuple[str, str]:
-    payload = client.get(f"/v1/builds/{build_id}/betaAppReviewSubmission")
+    try:
+        payload = client.get(f"/v1/builds/{build_id}/betaAppReviewSubmission")
+    except AppStoreConnectHTTPError as exc:
+        if exc.status_code == 404:
+            # A build can be attached to an external group before the operator
+            # submits it for beta review. That is a valid pending state; this
+            # workflow must not submit it implicitly or fail the upload.
+            return "pending_apple_beta_review", "NOT_SUBMITTED"
+        raise
     resource = payload.get("data")
     if resource is None:
-        created = client.post(
-            "/v1/betaAppReviewSubmissions",
-            {"data": {"type": "betaAppReviewSubmissions", "relationships": {"build": {"data": {"type": "builds", "id": build_id}}}}},
-        )
-        resource = require_resource(created, "betaAppReviewSubmissions", "beta review submission")
-    elif not isinstance(resource, dict) or resource.get("type") != "betaAppReviewSubmissions":
+        return "pending_apple_beta_review", "NOT_SUBMITTED"
+    if not isinstance(resource, dict) or resource.get("type") != "betaAppReviewSubmissions":
         raise DistributionError("App Store Connect returned invalid beta review submission")
 
     state = str((resource.get("attributes") or {}).get("betaReviewState") or "").upper()
@@ -423,12 +438,15 @@ def distribute_valid_build(
     )
     require_group_type(client, configuration.internal_group_id, is_internal=True)
     require_group_type(client, configuration.external_group_id, is_internal=False)
-    internal_assignment = attach_build_once(client, configuration.internal_group_id, build_id)
-    external_assignment = attach_build_once(client, configuration.external_group_id, build_id)
+    # Apple requires the beta-review metadata to be present before an external
+    # group can accept a build. Prepare it before the relationship writes, but
+    # leave the actual beta-review submission to an explicit operator action.
     upsert_beta_review_detail(
         client, app_id, configuration.review_contact, configuration.review_notes
     )
     upsert_beta_build_localization(client, build_id, configuration.review_notes)
+    internal_assignment = attach_build_once(client, configuration.internal_group_id, build_id)
+    external_assignment = attach_build_once(client, configuration.external_group_id, build_id)
     external, review_state = external_beta_status(client, build_id)
     return {
         "build_id": build_id,

--- a/scripts/ci/test_distribute_testflight_build.py
+++ b/scripts/ci/test_distribute_testflight_build.py
@@ -159,6 +159,13 @@ class DistributeTestFlightBuildTests(unittest.TestCase):
         self.assertEqual(apple.assignments[INTERNAL_GROUP_ID], {BUILD_ID})
         self.assertEqual(apple.assignments[EXTERNAL_GROUP_ID], {BUILD_ID})
         self.assertFalse(any("appStoreVersions" in url or "reviewSubmissions" in url for _, url, _ in apple.calls))
+        self.assertFalse(any(method == "POST" and url.endswith("/betaAppReviewSubmissions") for method, url, _ in apple.calls))
+
+        detail_post = next(index for index, (method, url, _) in enumerate(apple.calls) if method == "POST" and url.endswith("/betaAppReviewDetails"))
+        localization_post = next(index for index, (method, url, _) in enumerate(apple.calls) if method == "POST" and url.endswith("/betaBuildLocalizations"))
+        relationship_posts = [index for index, (method, url, _) in enumerate(apple.calls) if method == "POST" and "relationships/builds" in url]
+        self.assertLess(detail_post, relationship_posts[0])
+        self.assertLess(localization_post, relationship_posts[0])
 
     def test_exact_build_id_handoff_does_not_requery_transient_upload(self) -> None:
         apple = FakeApple(external_review_state="APPROVED")
@@ -219,7 +226,8 @@ class DistributeTestFlightBuildTests(unittest.TestCase):
         result = self.run_distribution(apple)
 
         self.assertEqual(result["external"], "pending_apple_beta_review")
-        self.assertEqual(result["external_beta_review_state"], "WAITING_FOR_REVIEW")
+        self.assertEqual(result["external_beta_review_state"], "NOT_SUBMITTED")
+        self.assertFalse(any(method == "POST" and url.endswith("/betaAppReviewSubmissions") for method, url, _ in apple.calls))
 
     def test_external_review_rejection_fails_closed(self) -> None:
         with self.assertRaisesRegex(subject.DistributionError, "rejected"):


### PR DESCRIPTION
## Problem
The TestFlight upload reaches Apple and becomes `VALID`, but the post-processing step fails with a generic App Store Connect HTTP 400. The workflow also spends more than 12 minutes compiling a focused simulator test target even though full `AppTests` already run in change-aware CI.

## Change
- prepare beta-review detail and build localization before group attachment;
- stop creating a beta-review submission implicitly; an unsubmitted external review is reported as pending;
- include the rejected App Store Connect endpoint in sanitized errors;
- add `run_core_tests` (default `false`) to make the compile-heavy focused simulator gate opt-in while preserving full CI coverage;
- document the flag and the valid `Ready to Submit` state.

## Validation
- `python3 scripts/ci/test_distribute_testflight_build.py` (7 passed)
- `python3 scripts/ci/test_wait_for_testflight_build.py` (8 passed)
- Python compilation, YAML parse, and `git diff --check` passed

This changes only the TestFlight distribution path. It does not submit a build for beta review or for the App Store.
