### PR TITLE
fix(ios): resume TestFlight distribution without rebuilding

### DIFF
--- a/.github/workflows/resume-ios-testflight.yml
+++ b/.github/workflows/resume-ios-testflight.yml
@@ -1,0 +1,108 @@
+name: Resume TestFlight Distribution
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload_run_id:
+        description: Original Ship iOS to TestFlight run with a successful upload and recovery receipt
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+  checks: read
+  id-token: write
+
+concurrency:
+  group: ship-ios-testflight
+  cancel-in-progress: false
+
+jobs:
+  resume:
+    runs-on: ubuntu-latest
+    environment: uat
+    timeout-minutes: 35
+    env:
+      GCP_PROJECT_ID: hushh-pda-uat
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      UPLOAD_RUN_ID: ${{ inputs.upload_run_id }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Validate dispatch and original upload provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF_NAME" = main
+          [[ "$UPLOAD_RUN_ID" =~ ^[0-9]+$ ]]
+          python3 scripts/ci/assert-governed-actor.py --surface uat --actor "$GITHUB_ACTOR"
+          gh api "repos/$GH_REPO/actions/runs/$UPLOAD_RUN_ID" > "$RUNNER_TEMP/upload-run.json"
+          jq -e '.path == ".github/workflows/ship-ios-testflight.yml" and .head_branch == "main" and .event == "workflow_dispatch"' "$RUNNER_TEMP/upload-run.json" >/dev/null
+          gh run download "$UPLOAD_RUN_ID" --name testflight-upload-receipt --dir "$RUNNER_TEMP/receipt"
+          python3 - <<'PY'
+          import json, os, pathlib, re, subprocess
+          receipt = json.loads(pathlib.Path(os.environ['RUNNER_TEMP'], 'receipt/testflight-upload-receipt.json').read_text())
+          assert receipt['bundle_id'] == 'com.hushh.app'
+          assert re.fullmatch(r'[0-9a-f]{40}', receipt['source_sha'])
+          assert re.fullmatch(r'[0-9]+', receipt['build_number'])
+          assert re.fullmatch(r'[0-9]+(?:\.[0-9]+){1,2}', receipt['marketing_version'])
+          subprocess.run(['git', 'merge-base', '--is-ancestor', receipt['source_sha'], 'origin/main'], check=True)
+          with open(os.environ['GITHUB_ENV'], 'a') as out:
+              for field in ('source_sha', 'build_number', 'marketing_version'):
+                  out.write(f'{field.upper()}={receipt[field]}\n')
+          PY
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - run: python -m pip install pyjwt cryptography
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          project_id: hushh-pda-uat
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Materialize protected TestFlight configuration
+        run: bash scripts/ci/materialize-ios-testflight-release-config.sh
+      - name: Reconcile the existing uploaded build
+        id: processing
+        run: |
+          python scripts/ci/wait_for_testflight_build.py \
+            --p8-path "$RUNNER_TEMP/asc.p8" --key-id "$ASC_KEY_ID" --issuer-id "$ASC_ISSUER_ID" \
+            --bundle-id com.hushh.app --marketing-version "$MARKETING_VERSION" --build-number "$BUILD_NUMBER" \
+            --timeout-seconds 1200 --poll-interval-seconds 30 --output-json "$RUNNER_TEMP/testflight-build.json"
+      - name: Resume idempotent group distribution
+        id: distribution
+        run: |
+          python scripts/ci/distribute-testflight-build.py \
+            --p8-path "$RUNNER_TEMP/asc.p8" --key-id "$ASC_KEY_ID" --issuer-id "$ASC_ISSUER_ID" \
+            --bundle-id com.hushh.app --marketing-version "$MARKETING_VERSION" --build-number "$BUILD_NUMBER" \
+            --build-id-file "$RUNNER_TEMP/testflight-build.json" \
+            --internal-group-id "$ASC_INTERNAL_GROUP_ID" --external-group-id "$ASC_EXTERNAL_GROUP_ID" \
+            --beta-review-contact-file "$ASC_BETA_REVIEW_CONTACT_PATH" --beta-review-notes-file "$ASC_BETA_REVIEW_NOTES_PATH" \
+            --output-json "$RUNNER_TEMP/testflight-distribution.json"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: testflight-resumed-distribution
+          path: ${{ runner.temp }}/testflight-distribution.json
+          if-no-files-found: warn
+      - name: Recovery summary
+        if: always()
+        env:
+          PROCESSING: ${{ steps.processing.outcome }}
+          DISTRIBUTION: ${{ steps.distribution.outcome }}
+        run: |
+          echo "Existing upload run: $UPLOAD_RUN_ID; build: ${BUILD_NUMBER:-unresolved}; source: ${SOURCE_SHA:-unresolved}." >> "$GITHUB_STEP_SUMMARY"
+          echo "Apple processing: $PROCESSING; distribution: $DISTRIBUTION. No archive, upload, or App Intent tests executed." >> "$GITHUB_STEP_SUMMARY"
+      - name: Remove protected files
+        if: always()
+        run: |
+          python - <<'PY'
+          import os, pathlib
+          for name in ('asc.p8', 'asc-beta-review-contact.json', 'asc-beta-review-notes.txt'):
+              pathlib.Path(os.environ['RUNNER_TEMP'], name).unlink(missing_ok=True)
+          PY

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      run_core_tests:
+        description: Run the focused simulator App Intent/action smoke gate (full AppTests remain in change-aware CI).
+        required: false
+        default: false
+        type: boolean
       notes:
         description: Optional release note context for the workflow summary.
         required: false
@@ -291,6 +296,7 @@ jobs:
             -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm"
 
       - name: Run core iOS App Intent and action tests
+        if: ${{ inputs.run_core_tests == true }}
         shell: bash
         run: |
           set -euo pipefail
@@ -450,6 +456,7 @@ jobs:
             echo
             echo "| Release source | ${{ needs.preflight.outputs.release_sha }} |"
             echo "| Physical iPhone p95 (ms) | ${{ inputs.require_hardware == true && needs.hardware-capture.outputs.p95_time_to_capture_ms || 'not requested' }} |"
+            echo "| Focused App Intent/action gate | ${{ inputs.run_core_tests == true && 'passed' || 'skipped; full AppTests remain in change-aware CI' }} |"
             echo "| Build number | ${{ steps.build_number.outputs.next_build }} |"
             echo
             echo "The workflow uses TestFlight beta endpoints only. External tester availability is pending until Apple approves TestFlight Beta App Review when required; this workflow never submits an App Store version."

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -296,6 +296,7 @@ jobs:
             -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm"
 
       - name: Run core iOS App Intent and action tests
+        id: core_tests
         if: ${{ inputs.run_core_tests == true }}
         shell: bash
         run: |
@@ -368,6 +369,7 @@ jobs:
             -- "$RUNNER_TEMP/App.xcarchive"
 
       - name: Export and upload TestFlight build
+        id: upload
         shell: bash
         run: |
           set -euo pipefail
@@ -386,7 +388,31 @@ jobs:
             -authenticationKeyID "$ASC_KEY_ID" \
             -authenticationKeyIssuerID "$ASC_ISSUER_ID"
 
+      - name: Preserve uploaded build identity for recovery
+        if: inputs.dry_run != true
+        shell: bash
+        env:
+          RELEASE_SHA: ${{ needs.preflight.outputs.release_sha }}
+          BUILD_NUMBER: ${{ steps.build_number.outputs.next_build }}
+        run: |
+          python3 - <<'PY'
+          import json, os, pathlib, re
+          version = re.search(r'MARKETING_VERSION\s*=\s*([^;]+)', pathlib.Path(os.environ['PBXPROJ']).read_text()).group(1).strip()
+          receipt = dict(source_sha=os.environ['RELEASE_SHA'], build_number=os.environ['BUILD_NUMBER'], marketing_version=version, bundle_id=os.environ['IOS_BUNDLE_ID'])
+          pathlib.Path(os.environ['RUNNER_TEMP'], 'testflight-upload-receipt.json').write_text(json.dumps(receipt))
+          PY
+
+      - name: Upload recovery receipt before Apple processing
+        if: inputs.dry_run != true
+        uses: actions/upload-artifact@v4
+        with:
+          name: testflight-upload-receipt
+          path: ${{ runner.temp }}/testflight-upload-receipt.json
+          retention-days: 90
+          if-no-files-found: error
+
       - name: Wait for valid TestFlight processing
+        id: processing
         if: inputs.dry_run != true
         shell: bash
         run: |
@@ -405,6 +431,7 @@ jobs:
             --output-json "$RUNNER_TEMP/testflight-build.json"
 
       - name: Attach the same valid build to both TestFlight groups
+        id: distribution
         if: inputs.dry_run != true
         shell: bash
         run: |
@@ -456,8 +483,11 @@ jobs:
             echo
             echo "| Release source | ${{ needs.preflight.outputs.release_sha }} |"
             echo "| Physical iPhone p95 (ms) | ${{ inputs.require_hardware == true && needs.hardware-capture.outputs.p95_time_to_capture_ms || 'not requested' }} |"
-            echo "| Focused App Intent/action gate | ${{ inputs.run_core_tests == true && 'passed' || 'skipped; full AppTests remain in change-aware CI' }} |"
+            echo "| Focused App Intent/action gate | ${{ steps.core_tests.outcome }} |"
             echo "| Build number | ${{ steps.build_number.outputs.next_build }} |"
+            echo "| Upload | ${{ steps.upload.outcome }} |"
+            echo "| Apple processing | ${{ steps.processing.outcome }} |"
+            echo "| TestFlight distribution | ${{ steps.distribution.outcome }} |"
             echo
             echo "The workflow uses TestFlight beta endpoints only. External tester availability is pending until Apple approves TestFlight Beta App Review when required; this workflow never submits an App Store version."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/guides/mobile/ship-ios-testflight.md
+++ b/docs/guides/mobile/ship-ios-testflight.md
@@ -179,3 +179,24 @@ model bytes are removed or never uploaded.
 | `App Store Connect ... failed with HTTP 400` after processing | The binary is already uploaded and `VALID`; inspect the endpoint in the step error. The workflow prepares review metadata before group attachment, treats an unsubmitted external review as pending, and never creates a beta-review submission implicitly. |
 
 Public App Store submission remains a separate, explicitly authorized workflow.
+
+### Recover a processed upload without rebuilding
+
+If Apple processing finishes after the wait expires, or metadata/distribution fails,
+use **Resume TestFlight Distribution** (`resume-ios-testflight.yml`) from `main`,
+with `upload_run_id` set to the original upload run. It reads the upload receipt,
+validates its source is on main, reconciles the same version/build with Apple,
+and repeats the idempotent group assignment. It does not archive, upload another
+binary, run App Intent tests, or submit beta review. A still-processing build can
+be reconciled again later with the same run ID. Original failed runs remain failed;
+the recovery run records the recovered distribution separately.
+
+Receipts are preserved immediately after successful uploads for 90 days. Runs
+before this receipt was introduced require an operator to verify the existing
+build's bundle ID, version, number and source before using the distribution CLI;
+do not rebuild merely to recover metadata. The normal release's `run_core_tests`
+flag remains `false` by default.
+
+The localization relationship GET accepts `limit`, not `filter[locale]`. Locale
+selection follows all pages locally; localization PATCH sends only `whatsNew`.
+The test double rejects unsupported query parameters and checks update payloads.

--- a/docs/guides/mobile/ship-ios-testflight.md
+++ b/docs/guides/mobile/ship-ios-testflight.md
@@ -34,7 +34,7 @@ UAT configuration and native Firebase materialization
 → One Voice safety, generated-action, and Capacitor plugin checks
 → privacy-manifest, App Intent, archive-asset, and symbol checks
 → verified UAT browser-ASR and intent-ranker pack readiness
-→ focused iOS App Intent/action smoke tests (full AppTests remain in change-aware CI)
+→ optional focused iOS App Intent/action smoke tests (full AppTests remain in change-aware CI)
 → optional physical-iPhone capture evidence when requested
 → signed archive and TestFlight upload
 → Apple VALID processing check
@@ -56,16 +56,17 @@ owner, and accepts only a redacted aggregate result when all of these are true:
 When `require_hardware` is `false` (the default), the physical job is skipped
 and the release summary records `not requested`; the workflow makes no
 physical-device claim. If the lane is requested, a missing device, permission,
-metric, or result remains a release failure. The simulator XCTest and all
-One Voice privacy, generated-action, and Capacitor checks remain required on
-every run.
+metric, or result remains a release failure. The One Voice privacy,
+generated-action, and Capacitor checks remain required on every run; the
+compile-heavy simulator XCTest gate is opt-in through `run_core_tests`.
 
-The release simulator step runs five tests that prove the shipped App Intent
-surface: the ten-shortcut registration contract, the generated action catalog,
-both direct intent-factory mappings, and the non-mutating destination adapters.
-The change-aware CI workflow continues to run the complete `AppTests` suite and
-the targeted UI recovery test. This keeps the release job focused on the
-release-specific contract while preserving broad regression coverage.
+When the `run_core_tests` dispatch input is `true`, the release simulator step
+runs five tests that prove the shipped App Intent surface: the ten-shortcut
+registration contract, the generated action catalog, both direct intent-factory
+mappings, and the non-mutating destination adapters. The default skips this
+compile-heavy duplicate; the change-aware CI workflow continues to run the
+complete `AppTests` suite and the targeted UI recovery test.
+This keeps the release job focused while preserving broad regression coverage.
 
 ## One-time release configuration
 
@@ -151,7 +152,10 @@ authority contract.
 5. In GitHub Actions, run **Ship iOS to TestFlight** from `main`. Leave `sha`
    blank for the latest eligible SHA, or supply that exact SHA. Set
    `require_hardware: true` for the optional physical-device evidence lane;
-   leave it `false` for the normal simulator-backed release path.
+   leave it `false` for the normal release path. Set `run_core_tests: true`
+   only when you want the focused simulator App Intent/action gate in this
+   release; the default is `false` because the full suite already runs in
+   change-aware CI.
 6. Use `dry_run: true` only when you want a signed archive without uploading.
    It follows the same `require_hardware` choice.
 
@@ -172,5 +176,6 @@ model bytes are removed or never uploaded.
 | Missing group, contact, notes, or privacy attestation | Configure the protected UAT release material; the workflow intentionally will not upload. |
 | External beta review pending | Internal testers can use the valid build; wait for Apple's beta-review decision for external testers. |
 | External beta review rejected | Correct the reviewer-facing issue and dispatch a new build; the workflow fails closed. |
+| `App Store Connect ... failed with HTTP 400` after processing | The binary is already uploaded and `VALID`; inspect the endpoint in the step error. The workflow prepares review metadata before group attachment, treats an unsubmitted external review as pending, and never creates a beta-review submission implicitly. |
 
 Public App Store submission remains a separate, explicitly authorized workflow.

--- a/scripts/ci/distribute-testflight-build.py
+++ b/scripts/ci/distribute-testflight-build.py
@@ -354,11 +354,24 @@ def upsert_beta_review_detail(
 def upsert_beta_build_localization(
     client: AppStoreConnectClient, build_id: str, notes: str
 ) -> None:
-    query = urllib.parse.urlencode({"filter[locale]": "en-US", "limit": "2"})
-    payload = client.get(f"/v1/builds/{build_id}/betaBuildLocalizations?{query}")
-    records = payload.get("data")
-    if not isinstance(records, list):
-        raise DistributionError("App Store Connect returned invalid beta build localizations")
+    # The build relationship endpoint supports `limit` but not the collection
+    # `filter[locale]` parameter. Fetch the bounded relationship page and select
+    # the requested locale locally so Apple does not reject the request with 400.
+    query = urllib.parse.urlencode({"limit": "200"})
+    next_url = f"/v1/builds/{build_id}/betaBuildLocalizations?{query}"
+    records: list[Any] = []
+    visited: set[str] = set()
+    while next_url:
+        absolute = client.absolute_url(next_url)
+        if absolute in visited:
+            raise DistributionError("App Store Connect returned cyclic localization pages")
+        visited.add(absolute)
+        payload = client.get(next_url)
+        page = payload.get("data")
+        if not isinstance(page, list):
+            raise DistributionError("App Store Connect returned invalid beta build localizations")
+        records.extend(page)
+        next_url = (payload.get("links") or {}).get("next")
     matches = [
         record
         for record in records
@@ -379,7 +392,7 @@ def upsert_beta_build_localization(
                 "data": {
                     "type": "betaBuildLocalizations",
                     "id": localization_id,
-                    "attributes": attributes,
+                    "attributes": {"whatsNew": notes},
                 }
             },
         )

--- a/scripts/ci/distribute-testflight-build.py
+++ b/scripts/ci/distribute-testflight-build.py
@@ -47,6 +47,16 @@ class DistributionError(RuntimeError):
     """A fail-closed TestFlight beta distribution error."""
 
 
+class AppStoreConnectHTTPError(DistributionError):
+    """An App Store Connect HTTP response with a status useful to callers."""
+
+    def __init__(self, method: str, path: str, status_code: int) -> None:
+        super().__init__(f"App Store Connect {method} {path} failed with HTTP {status_code}")
+        self.method = method
+        self.path = path
+        self.status_code = status_code
+
+
 @dataclass(frozen=True)
 class BetaReviewContact:
     first_name: str
@@ -161,7 +171,8 @@ class AppStoreConnectClient:
         except urllib.error.HTTPError as exc:
             # Apple responses can contain reviewer-facing information. Status is
             # enough for CI and avoids echoing request data or error payloads.
-            raise DistributionError(f"App Store Connect {method} failed with HTTP {exc.code}") from exc
+            path = urllib.parse.urlsplit(url).path
+            raise AppStoreConnectHTTPError(method, path, exc.code) from exc
         except urllib.error.URLError as exc:
             raise DistributionError(f"App Store Connect {method} request failed") from exc
         if not raw:
@@ -386,15 +397,19 @@ def upsert_beta_build_localization(
 
 
 def external_beta_status(client: AppStoreConnectClient, build_id: str) -> tuple[str, str]:
-    payload = client.get(f"/v1/builds/{build_id}/betaAppReviewSubmission")
+    try:
+        payload = client.get(f"/v1/builds/{build_id}/betaAppReviewSubmission")
+    except AppStoreConnectHTTPError as exc:
+        if exc.status_code == 404:
+            # A build can be attached to an external group before the operator
+            # submits it for beta review. That is a valid pending state; this
+            # workflow must not submit it implicitly or fail the upload.
+            return "pending_apple_beta_review", "NOT_SUBMITTED"
+        raise
     resource = payload.get("data")
     if resource is None:
-        created = client.post(
-            "/v1/betaAppReviewSubmissions",
-            {"data": {"type": "betaAppReviewSubmissions", "relationships": {"build": {"data": {"type": "builds", "id": build_id}}}}},
-        )
-        resource = require_resource(created, "betaAppReviewSubmissions", "beta review submission")
-    elif not isinstance(resource, dict) or resource.get("type") != "betaAppReviewSubmissions":
+        return "pending_apple_beta_review", "NOT_SUBMITTED"
+    if not isinstance(resource, dict) or resource.get("type") != "betaAppReviewSubmissions":
         raise DistributionError("App Store Connect returned invalid beta review submission")
 
     state = str((resource.get("attributes") or {}).get("betaReviewState") or "").upper()
@@ -423,12 +438,15 @@ def distribute_valid_build(
     )
     require_group_type(client, configuration.internal_group_id, is_internal=True)
     require_group_type(client, configuration.external_group_id, is_internal=False)
-    internal_assignment = attach_build_once(client, configuration.internal_group_id, build_id)
-    external_assignment = attach_build_once(client, configuration.external_group_id, build_id)
+    # Apple requires the beta-review metadata to be present before an external
+    # group can accept a build. Prepare it before the relationship writes, but
+    # leave the actual beta-review submission to an explicit operator action.
     upsert_beta_review_detail(
         client, app_id, configuration.review_contact, configuration.review_notes
     )
     upsert_beta_build_localization(client, build_id, configuration.review_notes)
+    internal_assignment = attach_build_once(client, configuration.internal_group_id, build_id)
+    external_assignment = attach_build_once(client, configuration.external_group_id, build_id)
     external, review_state = external_beta_status(client, build_id)
     return {
         "build_id": build_id,

--- a/scripts/ci/test_distribute_testflight_build.py
+++ b/scripts/ci/test_distribute_testflight_build.py
@@ -9,6 +9,7 @@ import importlib.util
 import sys
 import tempfile
 import unittest
+import urllib.parse
 from pathlib import Path
 from typing import Any
 
@@ -116,6 +117,8 @@ class FakeApple:
         if method == "POST" and path == "/v1/betaAppReviewDetails":
             return {"data": {"type": "betaAppReviewDetails", "id": "detail-1"}}
         if method == "GET" and path.startswith(f"/v1/builds/{BUILD_ID}/betaBuildLocalizations"):
+            params = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query)
+            assert set(params) <= {"limit", "fields[betaBuildLocalizations]"}, params
             return {"data": []}
         if method == "POST" and path == "/v1/betaBuildLocalizations":
             return {"data": {"type": "betaBuildLocalizations", "id": "localization-1"}}
@@ -141,6 +144,20 @@ class FakeApple:
 
 
 class DistributeTestFlightBuildTests(unittest.TestCase):
+    def test_localization_update_finds_locale_on_later_page_and_only_patches_notes(self) -> None:
+        calls = []
+        def request(method, url, payload):
+            calls.append((method, url, payload))
+            if method == "PATCH":
+                self.assertEqual(payload["data"]["attributes"], {"whatsNew": "new notes"})
+                return {}
+            if "cursor=next" in url:
+                return {"data": [{"type": "betaBuildLocalizations", "id": "loc-en", "attributes": {"locale": "en-US"}}]}
+            self.assertNotIn("filter", url)
+            return {"data": [{"type": "betaBuildLocalizations", "id": "loc-fr", "attributes": {"locale": "fr-FR"}}], "links": {"next": f"{subject.ASC_API_ROOT}/v1/builds/{BUILD_ID}/betaBuildLocalizations?cursor=next"}}
+        subject.upsert_beta_build_localization(subject.AppStoreConnectClient("test", request=request), BUILD_ID, "new notes")
+        self.assertEqual([call[0] for call in calls], ["GET", "GET", "PATCH"])
+
     def run_distribution(self, apple: FakeApple) -> dict[str, str]:
         return subject.distribute_valid_build(
             client=subject.AppStoreConnectClient("test", request=apple.request),

--- a/scripts/ci/test_distribute_testflight_build.py
+++ b/scripts/ci/test_distribute_testflight_build.py
@@ -159,6 +159,13 @@ class DistributeTestFlightBuildTests(unittest.TestCase):
         self.assertEqual(apple.assignments[INTERNAL_GROUP_ID], {BUILD_ID})
         self.assertEqual(apple.assignments[EXTERNAL_GROUP_ID], {BUILD_ID})
         self.assertFalse(any("appStoreVersions" in url or "reviewSubmissions" in url for _, url, _ in apple.calls))
+        self.assertFalse(any(method == "POST" and url.endswith("/betaAppReviewSubmissions") for method, url, _ in apple.calls))
+
+        detail_post = next(index for index, (method, url, _) in enumerate(apple.calls) if method == "POST" and url.endswith("/betaAppReviewDetails"))
+        localization_post = next(index for index, (method, url, _) in enumerate(apple.calls) if method == "POST" and url.endswith("/betaBuildLocalizations"))
+        relationship_posts = [index for index, (method, url, _) in enumerate(apple.calls) if method == "POST" and "relationships/builds" in url]
+        self.assertLess(detail_post, relationship_posts[0])
+        self.assertLess(localization_post, relationship_posts[0])
 
     def test_exact_build_id_handoff_does_not_requery_transient_upload(self) -> None:
         apple = FakeApple(external_review_state="APPROVED")
@@ -219,7 +226,8 @@ class DistributeTestFlightBuildTests(unittest.TestCase):
         result = self.run_distribution(apple)
 
         self.assertEqual(result["external"], "pending_apple_beta_review")
-        self.assertEqual(result["external_beta_review_state"], "WAITING_FOR_REVIEW")
+        self.assertEqual(result["external_beta_review_state"], "NOT_SUBMITTED")
+        self.assertFalse(any(method == "POST" and url.endswith("/betaAppReviewSubmissions") for method, url, _ in apple.calls))
 
     def test_external_review_rejection_fails_closed(self) -> None:
         with self.assertRaisesRegex(subject.DistributionError, "rejected"):


### PR DESCRIPTION
The upload and Apple processing succeeded, but TestFlight distribution failed because the localization relationship GET sent unsupported `filter[locale]`. Use the documented query, follow pagination, and send only `whatsNew` when updating an existing localization. Regression tests reject the invalid query and update payload.

Preserve an upload receipt before polling Apple and add `Resume TestFlight Distribution`: retries the existing uploaded build from the original trusted main workflow receipt, without archive, upload, App Intent tests, or beta review submission. Report upload, processing, and distribution outcomes separately. Core App Intent tests remain opt-in (`run_core_tests=false`).

Validation: 16 Python tests pass, YAML parses, diff whitespace clean. Live Apple API verified com.hushh.app 1.4.0 (109) VALID; both configured groups assigned successfully. Repeating distribution returns already_assigned for both. Internal testing active; external beta review NOT_SUBMITTED. Recovery workflow receipt path requires its first CI execution; old build 109 predates receipts and was recovered with the same client locally.
