### PR TITLE
fix: refine location header and breadcrumb layout

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1863,6 +1863,9 @@ describe("OneLocationAgentPage", () => {
     expect(headerActions.className).toContain("justify-center");
     expect(headerActions.className).toContain("w-[104px]");
     expect(headerActions.className).toContain("max-w-[45vw]");
+    expect(headerActions.className).toContain("min-[400px]:w-auto");
+    expect(headerActions.className).toContain("min-[400px]:flex-row-reverse");
+    expect(headerActions.className).toContain("sm:ml-0");
     // The actions column owns the switch and its compact visible status.
     const status = screen.getByTestId("one-location-header-status");
     expect(headerActions.contains(status)).toBe(true);
@@ -1873,13 +1876,14 @@ describe("OneLocationAgentPage", () => {
     );
     expect(status).toHaveClass(
       "mt-1",
+      "block",
       "max-w-full",
-      "whitespace-normal",
+      "whitespace-nowrap",
       "text-center",
       "text-[12px]",
       "leading-4",
       "font-normal",
-      "[overflow-wrap:anywhere]",
+      "min-[400px]:mt-0",
     );
     expect(status.textContent).toBe("Location off");
     // Still the switch's description wherever it renders.
@@ -1898,6 +1902,12 @@ describe("OneLocationAgentPage", () => {
     expect(headerRow).toHaveClass("flex", "justify-between");
     expect(screen.getByTestId("page-header").className).toContain(
       "[&_[data-slot=page-header-row]]:!items-center",
+    );
+    expect(screen.getByTestId("page-header").className).toContain(
+      "sm:[&_[data-slot=page-header-row]]:!justify-start",
+    );
+    expect(screen.getByTestId("page-header").className).toContain(
+      "sm:[&_[data-slot=page-header-actions]]:!ml-5",
     );
     expect(heading).toHaveClass("ui-text-agent-title");
     expect(screen.getByTestId("one-location-header-icon")).toBeTruthy();

--- a/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
+++ b/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
@@ -309,6 +309,9 @@ describe("Top app bar responsive contract", () => {
     const breadcrumbs = read("lib/navigation/top-shell-breadcrumbs.ts");
 
     expect(source).toContain("breadcrumb: topShellBreadcrumb");
+    expect(source).toContain(
+      "visibleTopShellBreadcrumbItems(topShellBreadcrumb?.items ?? [])",
+    );
     expect(source).toContain("navigateTopShellBack({");
     expect(back).toContain("navigate: (action: TopShellBackAction) => void;");
     expect(back).toContain("params.navigate(action);");

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -1,8 +1,35 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveTopShellBreadcrumb } from "@/lib/navigation/top-shell-breadcrumbs";
+import {
+  resolveTopShellBreadcrumb,
+  visibleTopShellBreadcrumbItems,
+} from "@/lib/navigation/top-shell-breadcrumbs";
 
 describe("top shell breadcrumbs", () => {
+  it("shows only the immediate parent and current page in deep trails", () => {
+    expect(
+      visibleTopShellBreadcrumbItems([
+        { label: "Profile", href: "/one/profile" },
+        { label: "Security", href: "/one/profile/security" },
+        { label: "Vault methods" },
+      ]),
+    ).toEqual([
+      { label: "Security", href: "/one/profile/security" },
+      { label: "Vault methods" },
+    ]);
+
+    expect(
+      visibleTopShellBreadcrumbItems([
+        { label: "One", href: "/one" },
+        { label: "Location", href: "/one/location" },
+        { label: "Settings" },
+      ]),
+    ).toEqual([
+      { label: "Location", href: "/one/location" },
+      { label: "Settings" },
+    ]);
+  });
+
   it("returns a query-selected saved analysis to its Analysis workspace", () => {
     expect(
       resolveTopShellBreadcrumb(

--- a/hushh-webapp/components/app-ui/page-sections.tsx
+++ b/hushh-webapp/components/app-ui/page-sections.tsx
@@ -255,7 +255,10 @@ export function PageHeader({
             )}
             data-slot="page-header-row"
           >
-            <div className="min-w-0 flex-1 space-y-[var(--page-header-copy-gap)]">
+            <div
+              className="min-w-0 flex-1 space-y-[var(--page-header-copy-gap)]"
+              data-slot="page-header-copy"
+            >
               {eyebrow ? (
                 <SectionLabel
                   as="p"

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -99,6 +99,7 @@ import {
   resolveTopShellBreadcrumb,
   type TopShellBreadcrumbConfig,
   type TopShellBreadcrumbItem,
+  visibleTopShellBreadcrumbItems,
 } from "@/lib/navigation/top-shell-breadcrumbs";
 import {
   getConnectedSystemPresentationLabel,
@@ -368,12 +369,11 @@ function isPrimaryHeaderOutOfView(header: HTMLElement | null): boolean {
 
 /* ── TopShellBreadcrumbTrail ───────────────────────────────────────── */
 /**
- * Renders the resolved breadcrumb items as a compact, tappable trail beside the
- * back arrow once the user is inside an inner/subagent route (e.g.
- * `Kai › Analysis › AAPL run`). Ancestor crumbs navigate back to their level;
- * the last crumb is the current, non-interactive location. The back arrow still
- * owns single-step back; this trail is the multi-level "go back and forth"
- * affordance. Uses currentColor so it tracks the ambient top-surface tone.
+ * Renders immediate context beside the back arrow: at most the parent and the
+ * current, non-interactive page. The parent remains tappable while the back
+ * arrow still owns single-step history navigation. Keeping older ancestors out
+ * of this compact row prevents a deep route from becoming a trail of truncated
+ * fragments. Uses currentColor so it tracks the ambient top-surface tone.
  */
 function TopShellBreadcrumbTrail({
   items,
@@ -817,21 +817,7 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
     [normalizedPathname, primaryHeaderOutOfView],
   );
   const breadcrumbTrailItems = useMemo(() => {
-    const raw = topShellBreadcrumb?.items ?? [];
-    // Defensively drop any crumb whose label is empty/whitespace before the
-    // trail renders. A resolver that spreads a conditional segment
-    // (`...(x ? [{label}] : [])`) can only ever yield real labels today, but
-    // guarding here means a future empty/undefined segment can never surface as
-    // a stray separator pair (the "Finance > , > > preview" artifact) in the
-    // shared chevron trail.
-    const cleaned = raw.filter(
-      (item) => typeof item.label === "string" && item.label.trim().length > 0,
-    );
-    // Inner/"subagent" routes read as "Kai > Analysis", not
-    // "One > Kai > Analysis": drop the app-root crumb from the visible trail.
-    return cleaned.length > 0 && cleaned[0]?.label === "One"
-      ? cleaned.slice(1)
-      : cleaned;
+    return visibleTopShellBreadcrumbItems(topShellBreadcrumb?.items ?? []);
   }, [topShellBreadcrumb]);
   const hasBreadcrumbTrail = !centerTitle && breadcrumbTrailItems.length > 0;
   const canShowPersonaSwitcher = useMemo(

--- a/hushh-webapp/components/one-location/redesign/location-cta-layout.ts
+++ b/hushh-webapp/components/one-location/redesign/location-cta-layout.ts
@@ -5,9 +5,8 @@
  * measures the exact classes rendered by the product.
  */
 
-/** Keeps the two public-link duration choices and its CTA as one centred unit. */
-export const PUBLIC_LINK_CONTROLS_CLASSNAME =
-  "mx-auto w-full max-w-[280px] space-y-3";
+/** Keeps the public-link controls together and aligned to the card's content edge. */
+export const PUBLIC_LINK_CONTROLS_CLASSNAME = "w-full max-w-[280px] space-y-3";
 
 export const PUBLIC_LINK_PRIMARY_CTA_CLASSNAME =
   "h-11 min-h-11 w-full rounded-[13px] bg-[color:var(--app-accent)] text-[16px] font-semibold leading-[21px] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90";

--- a/hushh-webapp/components/one-location/redesign/location-header-layout.ts
+++ b/hushh-webapp/components/one-location/redesign/location-header-layout.ts
@@ -4,8 +4,19 @@
  * classes instead of a copied approximation.
  */
 
+/**
+ * Keep the switch legible without letting it become a detached desktop island.
+ *
+ * Very narrow phones stack the caption under the switch to preserve the title.
+ * From 400px onward the caption sits beside the switch, and the desktop header
+ * keeps the whole control next to the title instead of at the far edge of the
+ * 880px agent shell.
+ */
 export const LOCATION_HEADER_ACTIONS_CLASSNAME =
-  "ml-auto flex min-h-[64px] w-[104px] max-w-[45vw] shrink-0 flex-col items-center justify-center overflow-visible px-1";
+  "ml-auto flex min-h-[64px] w-[104px] max-w-[45vw] shrink-0 flex-col items-center justify-center min-[400px]:min-h-11 min-[400px]:w-auto min-[400px]:max-w-none min-[400px]:flex-row-reverse min-[400px]:gap-2 sm:ml-0";
 
 export const LOCATION_HEADER_STATUS_CLASSNAME =
-  "mt-1 block max-w-full whitespace-normal text-center font-[family-name:var(--font-app-body)] text-[12px] font-normal leading-4 tracking-[-0.01em] text-[color:var(--app-secondary-label)] [overflow-wrap:anywhere]";
+  "mt-1 block max-w-full whitespace-nowrap text-center font-[family-name:var(--font-app-body)] text-[12px] font-normal leading-4 tracking-[-0.01em] text-[color:var(--app-secondary-label)] min-[400px]:mt-0";
+
+export const LOCATION_HUB_PAGE_HEADER_CLASSNAME =
+  "[&>div:first-child]:!gap-3 sm:[&>div:first-child]:!gap-3.5 [&_[data-slot=page-header-actions]]:!self-center [&_[data-slot=page-header-row]]:!items-center [&_[data-slot=page-header-row]]:!gap-2 min-[400px]:[&_[data-slot=page-header-row]]:!gap-3 sm:[&_[data-slot=page-header-row]]:!justify-start sm:[&_[data-slot=page-header-row]]:!gap-0 sm:[&_[data-slot=page-header-copy]]:!flex-none sm:[&_[data-slot=page-header-actions]]:!ml-5 sm:[&_[data-slot=page-header-actions]]:!justify-start";

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -167,6 +167,7 @@ import {
 } from "./location-cta-layout";
 import {
   LOCATION_HEADER_ACTIONS_CLASSNAME,
+  LOCATION_HUB_PAGE_HEADER_CLASSNAME,
   LOCATION_HEADER_STATUS_CLASSNAME,
 } from "./location-header-layout";
 import {
@@ -1752,7 +1753,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
         titleRole="agent"
         actionsInlineMobile
         actions={<LocationHeaderActions vm={vm} />}
-        className="[&>div:first-child]:!gap-3.5 [&_[data-slot=page-header-actions]]:!self-center [&_[data-slot=page-header-row]]:!items-center"
+        className={LOCATION_HUB_PAGE_HEADER_CLASSNAME}
       />
 
       {/*

--- a/hushh-webapp/e2e/location-cta-layout.spec.ts
+++ b/hushh-webapp/e2e/location-cta-layout.spec.ts
@@ -24,6 +24,7 @@ import {
 } from "../components/one-location/redesign/location-cta-layout";
 import {
   LOCATION_HEADER_ACTIONS_CLASSNAME,
+  LOCATION_HUB_PAGE_HEADER_CLASSNAME,
   LOCATION_HEADER_STATUS_CLASSNAME,
 } from "../components/one-location/redesign/location-header-layout";
 import { cn } from "../lib/utils";
@@ -92,6 +93,7 @@ async function buildFixture(): Promise<string> {
     COMPACT_CELL_ON_CLASSNAME,
     COMPACT_CELL_OFF_CLASSNAME,
     LOCATION_HEADER_ACTIONS_CLASSNAME,
+    LOCATION_HUB_PAGE_HEADER_CLASSNAME,
     LOCATION_HEADER_STATUS_CLASSNAME,
     harnessClasses,
   ]
@@ -106,12 +108,22 @@ async function buildFixture(): Promise<string> {
     )
     .join("");
   const headers = STATUS_LABELS.map(
-    (label) => `<header data-header class="flex items-center gap-3">
-      <span class="h-11 w-11 shrink-0 rounded-[10px]"></span>
-      <h1 data-header-title class="min-w-0 flex-1 whitespace-nowrap text-[28px] font-semibold">Location</h1>
-      <div data-header-actions class="${LOCATION_HEADER_ACTIONS_CLASSNAME}">
-        <button data-header-switch class="h-8 w-[51px] shrink-0 rounded-full"></button>
-        <span data-header-status class="${LOCATION_HEADER_STATUS_CLASSNAME}">${label}</span>
+    (label) => `<header data-header class="${LOCATION_HUB_PAGE_HEADER_CLASSNAME}">
+      <div class="flex items-stretch gap-3 sm:gap-4">
+        <span class="h-11 w-11 shrink-0 self-center rounded-[10px]"></span>
+        <div class="min-w-0 flex-1">
+          <div data-slot="page-header-row" class="flex items-start justify-between gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div data-slot="page-header-copy" class="min-w-0 flex-1">
+              <h1 data-header-title class="whitespace-nowrap text-[28px] font-semibold">Location</h1>
+            </div>
+            <div data-slot="page-header-actions" class="flex w-auto shrink-0 flex-wrap items-center justify-end self-start gap-2 sm:w-auto sm:shrink-0 sm:justify-end sm:self-center">
+              <div data-header-actions class="${LOCATION_HEADER_ACTIONS_CLASSNAME}">
+                <button data-header-switch class="h-8 w-[51px] shrink-0 rounded-full"></button>
+                <span data-header-status class="${LOCATION_HEADER_STATUS_CLASSNAME}">${label}</span>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </header>`,
   ).join("");
@@ -162,6 +174,11 @@ test.describe("One Location compact CTA layout", () => {
         const box = (selector: string) =>
           document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
         const publicCard = box("[data-public-card]");
+        const publicCardPaddingLeft = Number.parseFloat(
+          getComputedStyle(
+            document.querySelector<HTMLElement>("[data-public-card]")!,
+          ).paddingLeft,
+        );
         const publicControls = box("[data-public-controls]");
         const publicOptions = Array.from(
           document.querySelectorAll<HTMLElement>("[data-public-option]"),
@@ -200,10 +217,12 @@ test.describe("One Location compact CTA layout", () => {
             statusScrollHeight: status.scrollHeight,
             titleClientWidth: title.clientWidth,
             titleScrollWidth: title.scrollWidth,
+            title: title.getBoundingClientRect().toJSON(),
           };
         });
         return {
           publicCard: publicCard.toJSON(),
+          publicCardPaddingLeft,
           publicControls: publicControls.toJSON(),
           publicOptions: publicOptions.map((value) => value.toJSON()),
           publicCta: publicCta.toJSON(),
@@ -225,8 +244,7 @@ test.describe("One Location compact CTA layout", () => {
       expect(
         Math.abs(
           result.publicControls.left -
-            (result.publicCard.left +
-              (result.publicCard.width - result.publicControls.width) / 2),
+            (result.publicCard.left + result.publicCardPaddingLeft),
         ),
       ).toBeLessThanOrEqual(1);
       expect(
@@ -279,6 +297,27 @@ test.describe("One Location compact CTA layout", () => {
         expect(header.titleScrollWidth).toBeLessThanOrEqual(
           header.titleClientWidth + 1,
         );
+        if (width >= 640) {
+          expect(
+            header.actions.left - header.title.right,
+          ).toBeGreaterThanOrEqual(16);
+          expect(header.actions.left - header.title.right).toBeLessThanOrEqual(
+            32,
+          );
+        }
+        if (width >= 400) {
+          expect(
+            Math.abs(
+              header.toggle.top +
+                header.toggle.height / 2 -
+                (header.status.top + header.status.height / 2),
+            ),
+          ).toBeLessThanOrEqual(1);
+        } else {
+          expect(header.toggle.bottom).toBeLessThanOrEqual(
+            header.status.top + 1,
+          );
+        }
       }
     });
   }

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -45,6 +45,25 @@ export type TopShellBreadcrumbConfig = {
   hideBack?: boolean;
 };
 
+/**
+ * Keep the visible top-bar trail to immediate context only.
+ *
+ * Resolvers retain their complete hierarchy for deterministic back navigation,
+ * but rendering more than the parent and current page crowds the compact app
+ * bar and turns every ancestor into a truncated fragment. The app root remains
+ * implicit on inner One routes, matching the existing top-shell convention.
+ */
+export function visibleTopShellBreadcrumbItems(
+  items: TopShellBreadcrumbItem[],
+): TopShellBreadcrumbItem[] {
+  const cleaned = items.filter(
+    (item) => typeof item.label === "string" && item.label.trim().length > 0,
+  );
+  const withoutImplicitRoot =
+    cleaned[0]?.label === "One" ? cleaned.slice(1) : cleaned;
+  return withoutImplicitRoot.slice(-2);
+}
+
 function titleizeSegment(segment: string): string {
   return segment
     .split("-")


### PR DESCRIPTION
## Summary

- keep the Location status label and switch readable without detaching the control at desktop widths
- stack the status safely on very narrow phones, then use a compact inline layout from 400px upward
- left-align the temporary-link duration controls and Create link CTA with the card content edge
- render only the immediate parent and current page in deep top-bar breadcrumbs
- preserve existing toggle, link creation, breadcrumb routing, and back-navigation behavior

## Responsive coverage

- 320, 360, 393, 430, 600, and 768px layout contracts
- Chromium, WebKit, and mobile Chrome
- desktop title-to-toggle spacing and mobile overflow/truncation assertions
- explicit card-edge alignment assertion for Links controls

## Validation

- 18 Playwright layout checks passed
- 59 Vitest breadcrumb/top-bar tests passed
- TypeScript passed
- changed-file ESLint passed
- design-system verification passed
- service-boundary verification passed
- Capacitor/native static parity passed
- production Webpack build passed