### PR TITLE
fix(observability): bind web GA4 User-ID with set(), not a second config()

### DIFF
--- a/hushh-webapp/__tests__/lib/observability/identity-web-user-id.test.ts
+++ b/hushh-webapp/__tests__/lib/observability/identity-web-user-id.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression cover for the web GA4 User-ID binding.
+ *
+ * `applyWebUserId` previously issued a second `gtag('config', id, { user_id })`
+ * after the stream was already initialised. That does not attach `user_id` to
+ * subsequent hits and it fails silently, so the function reported success and
+ * the id was memoised as applied. The result was 67 completed web sign-ins in
+ * a month with zero `user_id` reaching GA4, while iOS -- which binds through
+ * Firebase Analytics rather than gtag -- worked.
+ *
+ * These tests assert the command actually issued, because the observable
+ * symptom of the bug was that everything else looked correct.
+ */
+
+const setUserIdMock = vi.fn();
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false },
+}));
+
+vi.mock("@capacitor-firebase/analytics", () => ({
+  FirebaseAnalytics: { setUserId: setUserIdMock },
+}));
+
+vi.mock("@/lib/observability/env", () => ({
+  resolveAnalyticsMeasurementId: () => "G-TESTID0001",
+}));
+
+async function loadIdentity() {
+  vi.resetModules();
+  return import("@/lib/observability/identity");
+}
+
+describe("web GA4 User-ID binding", () => {
+  let gtag: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    gtag = vi.fn();
+    vi.stubGlobal("window", { gtag } as unknown as Window & typeof globalThis);
+    setUserIdMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("binds the identity with set(), not a second config()", async () => {
+    const { setObservabilityUserId } = await loadIdentity();
+    await setObservabilityUserId("firebase-uid-1");
+
+    expect(gtag).toHaveBeenCalledTimes(1);
+    const [command, params] = gtag.mock.calls[0];
+    expect(command).toBe("set");
+    expect(params).toMatchObject({ user_id: expect.any(String) });
+
+    // The regression itself: a second config() is silently ignored by gtag
+    // once the stream is initialised, so it must never be the mechanism here.
+    expect(gtag).not.toHaveBeenCalledWith("config", expect.anything(), expect.anything());
+  });
+
+  it("sends a digest, never the raw Firebase UID", async () => {
+    const { setObservabilityUserId } = await loadIdentity();
+    await setObservabilityUserId("firebase-uid-1");
+
+    const [, params] = gtag.mock.calls[0];
+    expect(params.user_id).not.toBe("firebase-uid-1");
+    expect(params.user_id).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("clears the identity with an explicit null on sign-out", async () => {
+    const { setObservabilityUserId } = await loadIdentity();
+    await setObservabilityUserId(null);
+
+    const [command, params] = gtag.mock.calls[0];
+    expect(command).toBe("set");
+    // Explicitly null, not undefined: gtag drops undefined fields, which would
+    // leave the previous account's id bound to the next person's events.
+    expect(params).toHaveProperty("user_id", null);
+  });
+
+  it("does not report success when gtag is unavailable, so the caller retries", async () => {
+    vi.stubGlobal("window", {} as unknown as Window & typeof globalThis);
+    const { setObservabilityUserId } = await loadIdentity();
+
+    await setObservabilityUserId("firebase-uid-1");
+    // Nothing was applied, so nothing may be memoised: a later call once gtag
+    // exists has to be able to bind.
+    vi.stubGlobal("window", { gtag } as unknown as Window & typeof globalThis);
+    await setObservabilityUserId("firebase-uid-1");
+
+    expect(gtag).toHaveBeenCalledTimes(1);
+    expect(gtag.mock.calls[0][0]).toBe("set");
+  });
+});

--- a/hushh-webapp/lib/observability/identity.ts
+++ b/hushh-webapp/lib/observability/identity.ts
@@ -90,11 +90,40 @@ function applyWebUserId(userId: string | null): boolean {
     // the caller retry instead of memoizing a binding that never happened.
     return false;
   }
+  // Kept as a guard even though `set` is not scoped to a measurement id: with
+  // no id configured, gtag was never initialised for a stream, so there is
+  // nothing to bind to. Reporting failure keeps the caller retrying instead of
+  // memoizing a binding that could not have happened.
   const measurementId = resolveAnalyticsMeasurementId();
   if (!measurementId) return false;
 
-  // `config` rather than `set` so the id binds to this measurement id only,
-  // matching how the adapter scopes events with `send_to`.
+  // `set`, not a second `config`.
+  //
+  // This used to re-`config` the measurement id, on the reasoning that it
+  // would scope the identity to that id the way the adapter scopes events
+  // with `send_to`. Sound reasoning, but the runtime does not honour it: a
+  // `config` issued after the stream is already initialised does not attach
+  // `user_id` to subsequent hits, and it fails silently -- no error, no
+  // exception, and this function returned true, so the id was memoised as
+  // applied and never retried.
+  //
+  // Measured on the live production page with the transport intercepted:
+  //
+  //   gtag('config', id, { user_id })  ->  next event sent  uid absent
+  //   gtag('set', { user_id })         ->  next event sent  uid present
+  //
+  // Which matches what we saw in BigQuery: 67 completed web sign-ins over a
+  // month and not one `user_id`, while iOS -- which goes through Firebase
+  // Analytics rather than gtag -- bound 16 of 17.
+  //
+  // `set` is page-global rather than scoped to one measurement id. That is
+  // fine while the page configures exactly one; if a second property is ever
+  // added, this needs revisiting.
+  //
+  // `send_page_view` is deliberately gone: it was only needed because a
+  // repeated `config` re-applies gtag's default of true and would have fired
+  // a spurious page view on every sign-in. `set` does not re-initialise the
+  // stream, so that hazard disappears with it.
   //
   // Guarded because this is third-party code called from the auth state
   // handler. Analytics identity is never allowed to disturb a sign-in.
@@ -102,20 +131,14 @@ function applyWebUserId(userId: string | null): boolean {
     (
       window.gtag as unknown as (
         command: string,
-        target: string,
-        params?: Record<string, unknown>
+        params: Record<string, unknown>
       ) => void
-    )("config", measurementId, {
+    )("set", {
       // `null`, not `undefined`: gtag drops undefined fields, so signing out
       // with undefined would leave the previous account's id bound and
       // attribute the next person's events to them. On a shared family device
       // that is exactly the wrong outcome.
       user_id: userId,
-      // The app bootstraps this measurement id with `send_page_view: false`
-      // (app/layout.tsx) because page views are emitted by the adapter. Every
-      // `config` re-applies gtag's default of true unless we repeat it, so
-      // omitting this would fire a spurious page view on every sign-in.
-      send_page_view: false,
     });
     return true;
   } catch {


### PR DESCRIPTION
Fixes #6692.

`applyWebUserId` re-issued `gtag('config', measurementId, { user_id })` after the stream was already initialised. That does not attach `user_id` to subsequent hits — and it fails **silently**. No error, no exception, so the function returned `true`, the id was memoised as applied, and it never retried.

## The evidence

Over 2026-08-10 → 2026-09-08 on the One app surface:

| Platform | Devices | Completed sign-in | **Sign-ins with no `user_id`** |
| --- | ---: | ---: | ---: |
| **Web** | 256 | **67** | **67 — 100%** |
| iOS | 103 | 17 | 1 |

iOS binds through Firebase Analytics rather than gtag, so it was unaffected. And web authenticates at a *higher* rate than iOS — 26.2% of devices versus 16.5% — so this was never users declining to sign in.

Confirmed on the live production page with the outbound transport intercepted, so **no test data reached the property**:

```
event=probe_config     uid=None            <- gtag('config', id, { user_id })
event=probe_set        uid=UID_VIA_SET     <- gtag('set', { user_id })
```

## Why this was hard to see

Every other check passes, which is why it survived: the measurement id resolves to `G-2PCECPSKCR` client-side, `typeof gtag === 'function'`, `crypto.subtle` is available, `Capacitor.isNativePlatform()` correctly returns `false`, and the adapter scopes events to the right property. The only thing wrong was one gtag command behaving differently than its author reasonably expected.

## On the comment being replaced

The existing comment argued for `config` over `set` *"so the id binds to this measurement id only, matching how the adapter scopes events with `send_to`"*. That reasoning is sound — the runtime just does not honour it.

`set` is page-global rather than scoped to a measurement id. That is fine while the page configures exactly one, and I have noted it in the code for whenever a second is added.

`send_page_view: false` goes with it. It existed only because a repeated `config` re-applies gtag's default of `true` and would otherwise fire a spurious page view on every sign-in. `set` does not re-initialise the stream, so that hazard disappears rather than needing to be guarded.

The measurement-id guard **stays**: with no id configured, gtag was never initialised for a stream, so reporting failure keeps the caller retrying rather than memoizing a binding that could not have happened.

## Tests

`lib/observability/identity.ts` had **no coverage at all** — which is how a module whose entire purpose is cross-surface identity could be a no-op on web without anyone noticing.

Adds `__tests__/lib/observability/identity-web-user-id.test.ts` covering the command actually issued, that a digest is sent rather than the raw UID, that sign-out clears with an explicit `null`, and that an unavailable gtag is not memoised as success.

I verified the tests **fail against the previous implementation** — all four — and pass against this one. Adjacent observability and firebase auth suites still pass (33 tests).

## Downstream

`metrics.hushh.ai` currently reports **devices rather than people** because of this, and web and app figures cannot be added together. Once this lands, person-level reporting and per-account "agents claimed" become possible. Context in `hushh-labs/hussh-matrix-dashboard#28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
