### PR TITLE
fix(deploy): refuse to build a frontend image with the wrong GA4 property

### DIFF
--- a/deploy/frontend.cloudbuild.yaml
+++ b/deploy/frontend.cloudbuild.yaml
@@ -109,6 +109,42 @@ steps:
           fi
         done
 
+        # The analytics measurement id must belong to the environment being
+        # built. uat.hushh.ai currently ships G-2PCECPSKCR -- the production id
+        # -- so every UAT session writes into the production GA4 property
+        # (~1,052 events from 14 devices over a month), and the UAT property
+        # receives none of the validation traffic it exists for.
+        #
+        # The pipeline itself is correct: the id is read from Secret Manager in
+        # $PROJECT_ID, so each environment already resolves its own secret. The
+        # wrong value is stored in the secret. This check refuses to bake a
+        # swapped id into an image, in either direction, so the next occurrence
+        # fails the build instead of silently polluting a property for months.
+        #
+        # Both ids are public -- they ship in the HTML of every page -- and are
+        # the ones recorded in
+        # .codex/skills/analytics-observability-governance/references/property-stream-dataset-matrix.md
+        prod_measurement_id="G-2PCECPSKCR"
+        uat_measurement_id="G-H1KGXGZTCF"
+        case "${_DEPLOY_ENV}" in
+          uat)
+            if [ "$${NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID_VAL}" = "$${prod_measurement_id}" ]; then
+              echo "UAT build resolved the PRODUCTION analytics measurement id ($${prod_measurement_id})."
+              echo "UAT traffic would be written to the production GA4 property."
+              echo "Fix: set secret NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID in $PROJECT_ID to the UAT id."
+              exit 1
+            fi
+            ;;
+          prod|production)
+            if [ "$${NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID_VAL}" = "$${uat_measurement_id}" ]; then
+              echo "Production build resolved the UAT analytics measurement id ($${uat_measurement_id})."
+              echo "Production traffic would be written to the UAT GA4 property."
+              echo "Fix: set secret NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID in $PROJECT_ID to the production id."
+              exit 1
+            fi
+            ;;
+        esac
+
         google_contacts_client_id_file="/workspace/.google-contacts-client-id"
         if [[ ! -f "$${google_contacts_client_id_file}" ]]; then
           echo "Google Contacts OAuth client resolver artifact is missing."


### PR DESCRIPTION
Refs #6693.

`uat.hushh.ai` currently ships **`G-2PCECPSKCR`** — the *production* measurement id — so every UAT web session writes into the production GA4 property.

```bash
curl -s https://uat.hushh.ai/ | grep -o 'gtag/js?id=G-[A-Z0-9]*'
# googletagmanager.com/gtag/js?id=G-2PCECPSKCR      <- production
```

Over 2026-08-08 → 2026-09-06 that put **~1,052 events from 14 devices** with a `uat.hushh.ai` page_location into `hushh-pda.analytics_526603671`, and left the UAT property (`533362555`) without the validation traffic it exists for. Any query over the production export that does not filter by host is reporting UAT activity as production.

## Important: the pipeline is not the bug

The id is read from Secret Manager in `$PROJECT_ID`, so **each environment already resolves its own secret correctly**. The wrong value is stored in the UAT project's `NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID` secret.

**That still needs fixing separately** — this PR does not fix it, and cannot. What it does is stop a swapped value being baked into an image again, in either direction, so the next occurrence fails the build instead of quietly polluting a property for months.

Once the secret is corrected, this guard is what keeps it corrected.

## The check

Added to the existing required-vars validation in `deploy/frontend.cloudbuild.yaml`. Verified against all four combinations:

| `_DEPLOY_ENV` | measurement id | result |
| --- | --- | --- |
| `uat` | `G-2PCECPSKCR` | **exit 1 — blocked** |
| `uat` | `G-H1KGXGZTCF` | exit 0 |
| `prod` | `G-2PCECPSKCR` | exit 0 |
| `prod` | `G-H1KGXGZTCF` | **exit 1 — blocked** |

`bash -n` clean; no tabs introduced; `case`/`esac` balanced.

## On hardcoding the ids

Both are public — they ship in the HTML of every page — and they are the values already recorded in `.codex/skills/analytics-observability-governance/references/property-stream-dataset-matrix.md`. Hardcoding them is the point: the guard exists to detect a swap, so it needs to know which id belongs where.

## Related

`#6695` fixes web GA4 User-ID binding — a different bug on the same measurement surface. Downstream context in `hushh-labs/hussh-matrix-dashboard#28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
