### PR TITLE
fix(gmail): align feature CTA buttons consistently on mobile screens

### DIFF
--- a/hushh-webapp/components/gmail/gmail-receipts-page.tsx
+++ b/hushh-webapp/components/gmail/gmail-receipts-page.tsx
@@ -1959,6 +1959,7 @@ export default function GmailReceiptsPage({
                 type="button"
                 variant="muted"
                 onClick={() => setWorkspace("kyc")}
+                className="w-full justify-center sm:w-auto"
               >
                 Open KYC
               </Button>
@@ -1982,6 +1983,7 @@ export default function GmailReceiptsPage({
                 type="button"
                 variant="muted"
                 onClick={() => setWorkspace("receipts")}
+                className="w-full justify-center sm:w-auto"
               >
                 Open receipts
               </Button>


### PR DESCRIPTION
## Problem
On mobile screen sizes (`< sm`), the CTAs across the 3 feature cards in the Gmail workspace (`/one/gmail`) displayed inconsistent layouts:
- **Draft with One** (`AskOneButton`) rendered full-width and centered (`w-full justify-center sm:w-auto`).
- **KYC requests** (`Open KYC`) and **Receipts** (`Open receipts`) rendered left-aligned and narrow (`w-auto`).

## Solution
Updated the **Open KYC** and **Open receipts** buttons in `components/gmail/gmail-receipts-page.tsx` with `className="w-full justify-center sm:w-auto"`.
Now, all 3 CTAs span full-width and center uniformly on mobile viewports, while reverting gracefully to intrinsic widths on desktop viewports.

## File Changed
- [gmail-receipts-page.tsx](file:///e:/Hussh/hushh-research/hushh-webapp/components/gmail/gmail-receipts-page.tsx#L1958-L1988) (1 file modified, 2 lines added)