### PR TITLE
feat(observability): actually emit ria_verification_status_changed

### DIFF
--- a/docs/reference/operations/observability-event-matrix.md
+++ b/docs/reference/operations/observability-event-matrix.md
@@ -69,7 +69,7 @@ Every emitted observability event carries centrally added shared params:
 | --- | --- | --- | --- | --- | --- |
 | `persona_switched` | App persona switch surface selected investor or RIA | `action`, `result` | `hushh-webapp/components/app-ui/top-app-bar.tsx` | RIA top-of-funnel continuity for authenticated users | GA DebugView, RIA funnel SQL |
 | `ria_onboarding_submitted` | RIA onboarding form submitted | `result` | `hushh-webapp/app/ria/onboarding/page.tsx` | RIA onboarding start/completion quality | GA DebugView |
-| `ria_verification_status_changed` | RIA verification status transition | `action`, `result` | `hushh-webapp/app/ria/onboarding/page.tsx` | RIA status progression | GA DebugView |
+| `ria_verification_status_changed` | Verification decision returned for an RIA onboarding submission | `action` (status reached), `result` (`expected_error` on rejection) | `hushh-webapp/lib/observability/ria-events.ts` via `hushh-webapp/app/ria/onboarding/page.tsx` | RIA verification outcome rate; distinguishes a submitted profile from an approved one | `npm run verify:analytics`, GA DebugView |
 | `marketplace_profile_viewed` | Marketplace RIA profile rendered usable public profile state | `action`, `result` | `hushh-webapp/app/marketplace/ria/page-client.tsx` | marketplace high-intent engagement | GA DebugView, feature engagement SQL |
 | `ria_request_created` | RIA request creation result | `result` | `hushh-webapp/lib/services/ria-service.ts` | RIA request creation KPI support | GA DebugView, RIA funnel SQL |
 | `ria_workspace_opened` | RIA client workspace opened | `result` | `hushh-webapp/components/ria/use-ria-client-workspace-state.ts` | workspace readiness and activation support | GA DebugView, RIA funnel SQL |
@@ -161,7 +161,7 @@ These events are declared in the schema, but there is no current live emitter in
 
 | Event | Current status | Next action before dashboard use |
 | --- | --- | --- |
-| `ria_request_blocked_policy` | declared only | add emitter or remove from contract |
-| `mcp_ria_read_tool_called` | declared only | add emitter or remove from contract |
+| `ria_request_blocked_policy` | declared only | add emitter or remove from contract. No policy-block path exists on the RIA request flow today, so emitting it would mean inventing the concept first. |
+| `mcp_ria_read_tool_called` | declared only | add emitter or remove from contract. This is a server-side MCP concern; the web client cannot emit it, and no emitter exists in `consent-protocol` either. |
 
 Do not build dashboard assumptions on declared-only events.

--- a/hushh-webapp/__tests__/lib/observability/ria-verification-status.test.ts
+++ b/hushh-webapp/__tests__/lib/observability/ria-verification-status.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted above module init, so the spy has to be hoisted with it.
+const { trackEvent } = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+vi.mock("@/lib/observability/client", () => ({ trackEvent }));
+
+import {
+  riaVerificationAction,
+  riaVerificationResult,
+  trackRiaVerificationStatusChanged,
+} from "@/lib/observability/ria-events";
+
+/**
+ * `ria_verification_status_changed` was declared in the observability
+ * contract, and the event matrix documented an emitter in
+ * app/ria/onboarding/page.tsx -- but none existed. Anything built on it would
+ * have read a permanent zero, indistinguishable from "nobody verified".
+ */
+describe("RIA verification status event", () => {
+  beforeEach(() => trackEvent.mockReset());
+
+  it.each([
+    ["verified", "verified"],
+    ["active", "active"],
+    ["rejected", "rejected"],
+    ["draft", "draft"],
+  ] as const)("maps %s onto the contract value %s", (outcome, expected) => {
+    expect(riaVerificationAction(outcome)).toBe(expected);
+  });
+
+  it("settles an unrecognised status on submitted rather than dropping it", () => {
+    // The upstream service may add statuses; the submission still happened.
+    expect(riaVerificationAction("awaiting_finra_backfill")).toBe("submitted");
+    expect(riaVerificationAction("")).toBe("submitted");
+    expect(riaVerificationAction(null)).toBe("submitted");
+  });
+
+  it("is case and whitespace insensitive", () => {
+    expect(riaVerificationAction("  VERIFIED ")).toBe("verified");
+  });
+
+  it("treats a rejection as an expected outcome, not a system error", () => {
+    expect(riaVerificationResult("rejected")).toBe("expected_error");
+    expect(riaVerificationResult("verified")).toBe("success");
+  });
+
+  it("emits the contract event with both required params", () => {
+    trackRiaVerificationStatusChanged("verified");
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledWith("ria_verification_status_changed", {
+      action: "verified",
+      result: "success",
+    });
+  });
+
+  it("reports a rejection rather than staying silent about it", () => {
+    trackRiaVerificationStatusChanged("rejected");
+    expect(trackEvent.mock.calls[0][1]).toEqual({
+      action: "rejected",
+      result: "expected_error",
+    });
+  });
+});

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -58,6 +58,7 @@ import {
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { trackEvent } from "@/lib/observability/client";
 import { trackGrowthFunnelStepCompleted } from "@/lib/observability/growth";
+import { trackRiaVerificationStatusChanged } from "@/lib/observability/ria-events";
 import { resolveAppEnvironment } from "@/lib/app-env";
 import { openKaiCommandBar } from "@/lib/navigation/kai-command-bar-events";
 import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
@@ -960,6 +961,11 @@ export default function RiaOnboardingPage({
         result.verification_status ||
         ""
       ).toLowerCase();
+
+      // Verification is the step that gates a profile going live in the
+      // directory. `ria_onboarding_submitted` above only says the form went
+      // in. See lib/observability/ria-events.ts for why this is bucketed.
+      trackRiaVerificationStatusChanged(advisoryOutcome);
 
       await RiaService.setRiaMarketplaceDiscoverability(idToken, {
         enabled: advisoryOutcome === "verified" || advisoryOutcome === "active",

--- a/hushh-webapp/lib/observability/ria-events.ts
+++ b/hushh-webapp/lib/observability/ria-events.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { trackEvent } from "@/lib/observability/client";
+import type { EventPayloadFor } from "@/lib/observability/events";
+
+type VerificationPayload = EventPayloadFor<"ria_verification_status_changed">;
+
+/**
+ * Maps the advisory/verification status a submission came back with onto the
+ * statuses the observability contract declares.
+ *
+ * The upstream service is free to add statuses, so anything unrecognised
+ * settles on `submitted`: the submission demonstrably happened, and dropping
+ * it would understate the funnel. Only the contract's five values are ever
+ * emitted.
+ */
+export function riaVerificationAction(
+  advisoryOutcome: string | null | undefined,
+): VerificationPayload["action"] {
+  const outcome = String(advisoryOutcome ?? "").trim().toLowerCase();
+  switch (outcome) {
+    case "verified":
+      return "verified";
+    case "active":
+      return "active";
+    case "rejected":
+      return "rejected";
+    case "draft":
+      return "draft";
+    default:
+      return "submitted";
+  }
+}
+
+/**
+ * A rejection is an ordinary business outcome, not a failure of the flow, so
+ * it is `expected_error` rather than `error`. `error` stays reserved for a
+ * submission that could not be processed, which this call site never sees --
+ * that path throws and is reported by `ria_onboarding_submitted`.
+ */
+export function riaVerificationResult(
+  advisoryOutcome: string | null | undefined,
+): VerificationPayload["result"] {
+  return riaVerificationAction(advisoryOutcome) === "rejected"
+    ? "expected_error"
+    : "success";
+}
+
+/**
+ * Records the verification decision an RIA onboarding submission produced.
+ *
+ * `ria_onboarding_submitted` says the form went in; it says nothing about what
+ * came back. Verification is the step that gates a profile going live in the
+ * directory, and its outcome was previously not measured at all -- the event
+ * was declared in the contract and the event matrix documented an emitter in
+ * `app/ria/onboarding/page.tsx` that did not exist. Any chart built on it
+ * would have shown a permanent zero, indistinguishable from "nobody verified".
+ */
+export function trackRiaVerificationStatusChanged(
+  advisoryOutcome: string | null | undefined,
+): void {
+  trackEvent("ria_verification_status_changed", {
+    action: riaVerificationAction(advisoryOutcome),
+    result: riaVerificationResult(advisoryOutcome),
+  });
+}


### PR DESCRIPTION
The event was declared in the observability contract, and `observability-event-matrix.md` documented an emitter in `app/ria/onboarding/page.tsx`. **No emitter existed.**

Anything built on it would have read a permanent zero — indistinguishable from *"nobody verified"* rather than *"nobody is counting"*. That is exactly the failure mode the contract exists to prevent.

## What was missing

`ria_onboarding_submitted` already records that the form went in. It says nothing about what came back — and verification is the step that actually gates a profile going live in the directory. That outcome was not measured at all.

Now emitted on the submission result, where the advisory/verification status resolves.

## Shape

I followed the `location-events.ts` pattern: the mapping lives in `lib/observability/ria-events.ts` so it is unit-testable, and the page calls one function.

**I conformed to the declared payload rather than inventing values.** My first attempt used its own buckets (`pending` / `unknown`) and TypeScript rejected it — the contract doing its job. The declared shape is better than what I reached for:

- `action` — the status reached: `draft` / `submitted` / `verified` / `active` / `rejected`
- `result` — `success`, or `expected_error` on a rejection

A rejection is an ordinary business outcome, not a failure of the flow, so it is `expected_error`. `error` stays reserved for a submission that could not be processed — a path this call site never reaches, since that throws and is already reported by `ria_onboarding_submitted`.

An unrecognised upstream status settles on `submitted` rather than being dropped. The service is free to add statuses; the submission demonstrably happened, and dropping it would understate the funnel.

## Tests

9 tests covering the mapping, the rejection case, case and whitespace handling, unrecognised statuses, and the emitted payload.

`npm run verify:analytics` still passes (41 tests). Typecheck clean on all touched files.

## The other two declared-only events

This PR does **not** resolve them, but it records why each is stuck, replacing the bare "add emitter or remove from contract" note:

- **`ria_request_blocked_policy`** — there is no policy-block path on the RIA request flow to fire from. Emitting it would mean inventing the concept first.
- **`mcp_ria_read_tool_called`** — a server-side MCP concern the web client cannot emit, and there is no emitter in `consent-protocol` either.

Both still need someone to decide: emit, or remove from the contract. I did not make that call — removing declarations someone else added, without knowing the roadmap, is not mine to decide.

## Context

Surfaced by the instrumentation-health panel on `metrics.hushh.ai`, which counts contract events with no emitter. Refs `hushh-labs/hussh-matrix-dashboard#28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
