### PR TITLE
fix(observability): stamp a real app_version instead of "unknown"

### DIFF
--- a/hushh-webapp/__tests__/lib/observability/client-version.test.ts
+++ b/hushh-webapp/__tests__/lib/observability/client-version.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import packageJson from "../../../package.json";
+
+/**
+ * Every observability event on every platform was reporting
+ * `app_version: "unknown"`. `NEXT_PUBLIC_CLIENT_VERSION` is documented in
+ * `.env.example` but was never supplied to a build, and the fallback was the
+ * literal string "unknown" -- so the schema was satisfied, the tests passed,
+ * and the field carried no information for months.
+ *
+ * These assert the field is a real version, not merely present.
+ */
+async function load() {
+  vi.resetModules();
+  return import("@/lib/observability/client-version");
+}
+
+describe("client version", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("never falls back to the literal 'unknown'", async () => {
+    vi.stubEnv("NEXT_PUBLIC_CLIENT_VERSION", "");
+    const { resolveClientVersion } = await load();
+    expect(resolveClientVersion()).not.toBe("unknown");
+  });
+
+  it("falls back to the package version when nothing is supplied", async () => {
+    vi.stubEnv("NEXT_PUBLIC_CLIENT_VERSION", "");
+    const { resolveClientVersion } = await load();
+    expect(resolveClientVersion()).toBe(packageJson.version);
+  });
+
+  it("prefers an explicitly supplied build version", async () => {
+    vi.stubEnv("NEXT_PUBLIC_CLIENT_VERSION", "2.4.7-rc1");
+    const { resolveClientVersion } = await load();
+    expect(resolveClientVersion()).toBe("2.4.7-rc1");
+  });
+
+  it("ignores a whitespace-only value rather than stamping blanks on events", async () => {
+    vi.stubEnv("NEXT_PUBLIC_CLIENT_VERSION", "   ");
+    const { resolveClientVersion } = await load();
+    expect(resolveClientVersion()).toBe(packageJson.version);
+  });
+
+  it("resolves to something that looks like a version", async () => {
+    vi.stubEnv("NEXT_PUBLIC_CLIENT_VERSION", "");
+    const { resolveClientVersion } = await load();
+    expect(resolveClientVersion()).toMatch(/^\d+\.\d+/);
+  });
+});

--- a/hushh-webapp/lib/observability/client-version.ts
+++ b/hushh-webapp/lib/observability/client-version.ts
@@ -1,0 +1,31 @@
+import packageJson from "../../package.json";
+
+/**
+ * The app version stamped on every observability event.
+ *
+ * Every event on every platform was reporting `app_version: "unknown"`,
+ * because `NEXT_PUBLIC_CLIENT_VERSION` is documented in `.env.example` but
+ * never supplied to a real build. With no version on any event you cannot
+ * answer whether a release changed a metric, whether an old build is still in
+ * the wild, or whether new instrumentation actually shipped -- which is
+ * exactly the question the native surfaces raise, since the last Android build
+ * predates the identity module entirely.
+ *
+ * `NEXT_PUBLIC_*` is inlined at build time, so this is resolved in
+ * `next.config.ts` (web) and `next.config.capacitor.ts` (iOS/Android) rather
+ * than read at runtime. An explicitly supplied value still wins; the package
+ * version is the floor, so the worst case is a real version rather than
+ * "unknown".
+ *
+ * Known limitation: `package.json` moves per release, not per build, so two
+ * builds of 1.1.0 are indistinguishable. Making it per-build needs a build ARG
+ * threaded through `deploy/frontend.cloudbuild.yaml`, which is a protected
+ * pipeline surface.
+ */
+export const CLIENT_VERSION_FALLBACK =
+  String(packageJson.version || "").trim() || "unknown";
+
+export function resolveClientVersion(): string {
+  const version = String(process.env.NEXT_PUBLIC_CLIENT_VERSION || "").trim();
+  return version || CLIENT_VERSION_FALLBACK;
+}

--- a/hushh-webapp/lib/observability/client.ts
+++ b/hushh-webapp/lib/observability/client.ts
@@ -32,6 +32,7 @@ import {
 } from "@/lib/observability/route-map";
 import { validateAndSanitizeEvent } from "@/lib/observability/schema";
 import { redactObservabilityLogValue } from "@/lib/observability/log-redactor";
+import { resolveClientVersion } from "@/lib/observability/client-version";
 
 interface TrackOptions {
   dedupeKey?: string;
@@ -42,7 +43,6 @@ const ADAPTERS: ObservabilityAdapter[] = [webGtmAdapter, nativeFirebaseAdapter];
 const lastEventAtByKey = new Map<string, number>();
 
 const DEFAULT_DEDUPE_WINDOW_MS = 750;
-const CLIENT_VERSION_FALLBACK = "unknown";
 
 function resolvePlatform(): ObservabilityPlatform {
   if (!Capacitor.isNativePlatform()) {
@@ -54,11 +54,6 @@ function resolvePlatform(): ObservabilityPlatform {
 
 function nowMs(): number {
   return Date.now();
-}
-
-function resolveClientVersion(): string {
-  const version = String(process.env.NEXT_PUBLIC_CLIENT_VERSION || "").trim();
-  return version || CLIENT_VERSION_FALLBACK;
 }
 
 function shouldDropByDedupe(key: string, dedupeWindowMs: number): boolean {

--- a/hushh-webapp/lib/observability/growth.ts
+++ b/hushh-webapp/lib/observability/growth.ts
@@ -15,9 +15,9 @@ import type {
   GrowthInvestorStep,
 } from "@/lib/observability/events";
 import { getLocalItem, setLocalItem } from "@/lib/utils/session-storage";
+import { resolveClientVersion } from "@/lib/observability/client-version";
 
 const GROWTH_CONTEXT_STORAGE_KEY = "hushh_growth_context_v1";
-const CLIENT_VERSION_FALLBACK = "unknown";
 
 interface GrowthJourneyContext {
   entrySurface?: GrowthEntrySurface;
@@ -167,11 +167,6 @@ function hasAttributionTag(searchParams: URLSearchParams): boolean {
     "fbclid",
     "msclkid",
   ].some((key) => searchParams.has(key));
-}
-
-function resolveClientVersion(): string {
-  const version = String(process.env.NEXT_PUBLIC_CLIENT_VERSION || "").trim();
-  return version || CLIENT_VERSION_FALLBACK;
 }
 
 export function resolveGrowthJourneyForPath(pathname: string): GrowthJourney | null {

--- a/hushh-webapp/next.config.capacitor.ts
+++ b/hushh-webapp/next.config.capacitor.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from "next";
 import path from "path";
 
+import packageJson from "./package.json";
+
 /**
  * Next.js Configuration for Capacitor iOS/Android Static Export
  *
@@ -9,7 +11,28 @@ import path from "path";
  *
  * Usage: npm run cap:build
  */
+/**
+ * Stamp a real app version into the client bundle.
+ *
+ * `NEXT_PUBLIC_*` is inlined at build time, and nothing was supplying
+ * `NEXT_PUBLIC_CLIENT_VERSION`, so every observability event on every platform
+ * reported `app_version: "unknown"`. That makes it impossible to tell whether
+ * a release moved a metric, whether an old build is still in the wild, or
+ * whether new instrumentation actually shipped.
+ *
+ * An explicitly supplied value still wins. The package version is the floor,
+ * so the worst case is a real version instead of "unknown".
+ */
+const clientVersion =
+  String(process.env.NEXT_PUBLIC_CLIENT_VERSION || "").trim() ||
+  String(packageJson.version || "").trim() ||
+  "unknown";
+
 const capacitorConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_CLIENT_VERSION: clientVersion,
+  },
+
   // Keep file tracing and workspace discovery scoped to this monorepo.
   outputFileTracingRoot: path.join(process.cwd(), ".."),
 

--- a/hushh-webapp/next.config.ts
+++ b/hushh-webapp/next.config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from "next";
 import path from "path";
 
+import packageJson from "./package.json";
+
 /**
  * Next.js Configuration
  *
@@ -15,7 +17,28 @@ import path from "path";
 
 const isCapacitorBuild = process.env.CAPACITOR_BUILD === "true";
 
+/**
+ * Stamp a real app version into the client bundle.
+ *
+ * `NEXT_PUBLIC_*` is inlined at build time, and nothing was supplying
+ * `NEXT_PUBLIC_CLIENT_VERSION`, so every observability event on every platform
+ * reported `app_version: "unknown"`. That makes it impossible to tell whether
+ * a release moved a metric, whether an old build is still in the wild, or
+ * whether new instrumentation actually shipped.
+ *
+ * An explicitly supplied value still wins. The package version is the floor,
+ * so the worst case is a real version instead of "unknown".
+ */
+const clientVersion =
+  String(process.env.NEXT_PUBLIC_CLIENT_VERSION || "").trim() ||
+  String(packageJson.version || "").trim() ||
+  "unknown";
+
 const config: NextConfig = {
+  env: {
+    NEXT_PUBLIC_CLIENT_VERSION: clientVersion,
+  },
+
   // Native static exports may run while the local web dev server is active.
   // Keep their compiler caches isolated so `next build` cannot corrupt the
   // live `.next` module graph and turn local API routes into transient 500s.


### PR DESCRIPTION
Every observability event on every platform reports **`app_version: "unknown"`**.

`NEXT_PUBLIC_CLIENT_VERSION` is documented in `.env.example` and read by `resolveClientVersion`, but nothing supplies it to a build — so the literal fallback string wins every time.

Verified in BigQuery, last 90 days:

| Platform | Devices | Distinct versions | Value |
| --- | ---: | ---: | --- |
| iOS | 349 | 1 | `unknown` |
| Android | 101 | 1 | `unknown` |

## Why it matters

No event can be attributed to a build. You cannot ask whether a release moved a metric, whether an old build is still in the wild, or whether new instrumentation actually shipped.

That last one came up concretely: the last Android build (**2026-08-08**) predates `lib/observability/identity.ts` (**2026-08-13**), so no shipped Android build can contain the identity module — which is why Android reports zero bound accounts. Establishing that took a `git log` dig. `app_version` should have answered it directly.

## The change

`NEXT_PUBLIC_*` is inlined at build time, so the value is resolved in `next.config.ts` **and `next.config.capacitor.ts`**. Both matter — the Capacitor config is the one that governs iOS and Android, which is where the question originated.

An explicitly supplied value still wins. The package version is the floor, so the worst case becomes a real version rather than `"unknown"`.

Also consolidates `resolveClientVersion`, which existed **twice** with two copies of the fallback constant (`client.ts` and `growth.ts`), into one module. Two copies of the same env read is a standing invitation to fix one and not the other.

## Deliberately not done

Making the version move **per build** rather than per release. That needs a build ARG threaded through `deploy/frontend.cloudbuild.yaml` — a protected pipeline surface I'm not a sanctioned actor for. Noted in the code as a follow-up.

## Tests

5 new, including one that fails on the literal `"unknown"`. The existing suite passed happily while the field carried no information, which is how this survived — so the test asserts the value is a *real version*, not merely present.

Verified they **fail against the previous behaviour** (4 of 5) and pass against this one. `verify:analytics` still passes (41 tests). Typecheck clean on all touched files.

## Not verified — worth a reviewer's eye

**I could not run a production build.** My worktree symlinks `node_modules`, which Turbopack rejects outright (`Symlink ... points out of the filesystem root`), and webpack then fails on optional deps absent from that tree. Both failures reproduce **without** this change, so they aren't caused by it — but it means I have not observed the inlined value in a built bundle.

The `env` key in `next.config` is documented Next.js behaviour and I'd expect it to work, but a reviewer with a working build should confirm the bundle carries `1.1.0` rather than `unknown`.

## Context

Refs `hushh-labs/hussh-matrix-dashboard#28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)