### PR TITLE
fix(connect): repair legacy disconnect actor migration

### DIFF
--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dev_minimum_schema",
-  "expected_migration_version": 205,
+  "expected_migration_version": 206,
   "migration_version_policy": "minimum",
   "required_functions": [
     "resolve_feed_counterpart_user_id",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 205,
+  "expected_migration_version": 206,
   "migration_version_policy": "exact",
   "required_functions": [
     "resolve_feed_counterpart_user_id",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 205,
+  "expected_migration_version": 206,
   "migration_version_policy": "exact",
   "required_functions": [
     "resolve_feed_counterpart_user_id",

--- a/consent-protocol/db/migrations/206_contact_sync_disconnect_actor_upgrade.sql
+++ b/consent-protocol/db/migrations/206_contact_sync_disconnect_actor_upgrade.sql
@@ -1,0 +1,52 @@
+BEGIN;
+
+-- Migration 205 briefly stored the disconnecting actor as a mutable user ID.
+-- It was later corrected to the immutable participant side, but replay-mode
+-- environments can already contain the earlier column and its exact-episode
+-- annotations. Preserve those verified historical removals during the
+-- expand-only upgrade; unknown, stale, and non-participant values stay NULL
+-- and therefore fail closed for automatic reconnection.
+ALTER TABLE connections
+  ADD COLUMN IF NOT EXISTS revoked_by_side TEXT,
+  ADD COLUMN IF NOT EXISTS revoked_by_at TIMESTAMPTZ;
+
+DO $$
+DECLARE
+  has_legacy_actor_column BOOLEAN;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name = 'connections'
+      AND column_name = 'revoked_by_user_id'
+  )
+  INTO has_legacy_actor_column;
+
+  IF has_legacy_actor_column THEN
+    EXECUTE $upgrade$
+      UPDATE connections
+      SET revoked_by_side = CASE
+        WHEN user_a_id = revoked_by_user_id THEN 'a'
+        WHEN user_b_id = revoked_by_user_id THEN 'b'
+      END
+      WHERE revoked_by_side IS NULL
+        AND revoked_by_at = revoked_at
+        AND revoked_by_user_id IN (user_a_id, user_b_id)
+    $upgrade$;
+  END IF;
+
+  -- 205 may have installed the old constraint under this same name. Replace
+  -- it on every replay so upgraded databases enforce the current invariant.
+  ALTER TABLE connections
+    DROP CONSTRAINT IF EXISTS connections_revocation_actor_pair;
+  ALTER TABLE connections
+    ADD CONSTRAINT connections_revocation_actor_pair
+    CHECK (revoked_by_side IS NULL OR revoked_by_side IN ('a', 'b'));
+END;
+$$;
+
+COMMENT ON COLUMN connections.revoked_by_side IS
+  'Canonical participant side (a/b) of an explicit disconnect. Historical user-ID annotations are upgraded only when they match an immutable participant and the current revocation episode.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/206_contact_sync_disconnect_actor_upgrade.rollback.sql
+++ b/consent-protocol/db/migrations/rollback/206_contact_sync_disconnect_actor_upgrade.rollback.sql
@@ -1,0 +1,37 @@
+BEGIN;
+
+-- Roll back application readers before this migration. Keep the additive
+-- side/episode annotations intact: the previous schema can ignore them, while
+-- removing them would discard verified historical disconnect evidence.
+DO $$
+DECLARE
+  has_legacy_actor_column BOOLEAN;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name = 'connections'
+      AND column_name = 'revoked_by_user_id'
+  )
+  INTO has_legacy_actor_column;
+
+  ALTER TABLE connections
+    DROP CONSTRAINT IF EXISTS connections_revocation_actor_pair;
+
+  IF has_legacy_actor_column THEN
+    ALTER TABLE connections
+      ADD CONSTRAINT connections_revocation_actor_pair
+      CHECK (
+        revoked_by_user_id IS NULL
+        OR revoked_by_user_id IN (user_a_id, user_b_id)
+      );
+  ELSE
+    ALTER TABLE connections
+      ADD CONSTRAINT connections_revocation_actor_pair
+      CHECK (revoked_by_side IS NULL OR revoked_by_side IN ('a', 'b'));
+  END IF;
+END;
+$$;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -177,7 +177,8 @@
     "202_feed_counterpart_identity.sql",
     "203_feed_counterpart_recipient_index.sql",
     "204_feed_counterpart_indexed_lookup.sql",
-    "205_contact_sync_disconnect_actor.sql"
+    "205_contact_sync_disconnect_actor.sql",
+    "206_contact_sync_disconnect_actor_upgrade.sql"
   ],
   "environment_overlays": {
     "uat": [
@@ -306,7 +307,8 @@
       "202_feed_counterpart_identity.sql",
       "203_feed_counterpart_recipient_index.sql",
       "204_feed_counterpart_indexed_lookup.sql",
-      "205_contact_sync_disconnect_actor.sql"
+      "205_contact_sync_disconnect_actor.sql",
+      "206_contact_sync_disconnect_actor_upgrade.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",
@@ -351,6 +353,7 @@
   "rollback_migrations": {
     "203_feed_counterpart_recipient_index.sql": "rollback/203_feed_counterpart_recipient_index.rollback.sql",
     "204_feed_counterpart_indexed_lookup.sql": "rollback/204_feed_counterpart_indexed_lookup.rollback.sql",
-    "205_contact_sync_disconnect_actor.sql": "rollback/205_contact_sync_disconnect_actor.rollback.sql"
+    "205_contact_sync_disconnect_actor.sql": "rollback/205_contact_sync_disconnect_actor.rollback.sql",
+    "206_contact_sync_disconnect_actor_upgrade.sql": "rollback/206_contact_sync_disconnect_actor_upgrade.rollback.sql"
   }
 }

--- a/consent-protocol/tests/test_contact_sync_disconnect_actor_upgrade_migration.py
+++ b/consent-protocol/tests/test_contact_sync_disconnect_actor_upgrade_migration.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION_NAME = "206_contact_sync_disconnect_actor_upgrade.sql"
+
+
+def test_disconnect_actor_upgrade_is_registered_in_every_release_contract() -> None:
+    manifest = json.loads((ROOT / "db/release_migration_manifest.json").read_text())
+
+    assert MIGRATION_NAME in manifest["ordered_migrations"]
+    assert manifest["ordered_migrations"].index(MIGRATION_NAME) > manifest[
+        "ordered_migrations"
+    ].index("205_contact_sync_disconnect_actor.sql")
+    assert MIGRATION_NAME in manifest["groups"]["iam"]
+    assert manifest["rollback_migrations"][MIGRATION_NAME] == (
+        "rollback/206_contact_sync_disconnect_actor_upgrade.rollback.sql"
+    )
+
+    for contract_name in (
+        "dev_minimum_schema.json",
+        "prod_core_schema.json",
+        "uat_integrated_schema.json",
+    ):
+        contract = json.loads((ROOT / "db/contracts" / contract_name).read_text())
+        assert contract["expected_migration_version"] >= 206
+
+
+def test_disconnect_actor_upgrade_translates_only_verified_current_episodes() -> None:
+    migration = (ROOT / "db/migrations" / MIGRATION_NAME).read_text()
+
+    assert "column_name = 'revoked_by_user_id'" in migration
+    assert "revoked_by_at = revoked_at" in migration
+    assert "revoked_by_user_id IN (user_a_id, user_b_id)" in migration
+    assert "WHEN user_a_id = revoked_by_user_id THEN 'a'" in migration
+    assert "WHEN user_b_id = revoked_by_user_id THEN 'b'" in migration
+    assert "DROP CONSTRAINT IF EXISTS connections_revocation_actor_pair" in migration
+    assert "CHECK (revoked_by_side IS NULL OR revoked_by_side IN ('a', 'b'))" in migration

--- a/consent-protocol/tests/test_contact_sync_postgres_integration.py
+++ b/consent-protocol/tests/test_contact_sync_postgres_integration.py
@@ -65,7 +65,11 @@ class _LiveMatcher(RIAIAMService):
 
 
 async def _prepare_schema(
-    schema: str, *, postgres_url: str = POSTGRES_URL, full_deletion_guards: bool = False
+    schema: str,
+    *,
+    postgres_url: str = POSTGRES_URL,
+    full_deletion_guards: bool = False,
+    legacy_disconnect_actor_schema: bool = False,
 ) -> None:
     connection = await asyncpg.connect(postgres_url)
     try:
@@ -183,7 +187,26 @@ async def _prepare_schema(
             actor_migration = actor_migration.replace(
                 "SELECT install_account_deletion_write_guards();", ""
             )
-        await connection.execute(actor_migration)
+        if legacy_disconnect_actor_schema:
+            # This is the released pre-19c756995 shape. It exists only in the
+            # fixture to prove that 206 repairs a previously applied schema;
+            # do not edit 205 again to make this fixture pass.
+            await connection.execute(
+                """
+                ALTER TABLE connections
+                  ADD COLUMN revoked_by_user_id TEXT,
+                  ADD COLUMN revoked_by_at TIMESTAMPTZ;
+                ALTER TABLE connections ADD CONSTRAINT connections_revocation_actor_pair
+                  CHECK (revoked_by_user_id IS NULL OR revoked_by_user_id IN (user_a_id, user_b_id));
+                """
+            )
+            upgrade = (
+                ROOT / "db/migrations/206_contact_sync_disconnect_actor_upgrade.sql"
+            ).read_text()
+            await connection.execute(upgrade)
+            await connection.execute(upgrade)
+        else:
+            await connection.execute(actor_migration)
         await connection.executemany(
             """
             INSERT INTO actor_profiles (
@@ -510,6 +533,109 @@ def test_disconnect_waiting_on_graph_lock_wins_over_older_sync_cutoff() -> None:
     finally:
         engine.dispose()
         asyncio.run(_drop_schema(schema))
+
+
+@pytest.mark.db
+@pytest.mark.skipif(
+    not POSTGRES_URL,
+    reason="set CONTACT_SYNC_POSTGRES_TEST_URL to a disposable PostgreSQL database",
+)
+def test_legacy_disconnect_actor_schema_replays_into_owner_resync_on_postgres() -> None:
+    """206 converts only a verified old 205 episode into current authority."""
+    database = f"codex_contact_upgrade_{uuid.uuid4().hex}"
+    admin_engine = create_engine(
+        make_url(POSTGRES_URL).set(drivername="postgresql+psycopg2"),
+        isolation_level="AUTOCOMMIT",
+    )
+    url = make_url(POSTGRES_URL).set(database=database)
+    engine = create_engine(url.set(drivername="postgresql+psycopg2"))
+    try:
+        with admin_engine.connect() as admin:
+            admin.exec_driver_sql(f'CREATE DATABASE "{database}"')
+        asyncio.run(
+            _prepare_schema(
+                "public",
+                postgres_url=url.render_as_string(hide_password=False),
+                full_deletion_guards=True,
+                legacy_disconnect_actor_schema=True,
+            )
+        )
+        with engine.begin() as connection:
+            connection.execute(
+                text("""CREATE TABLE feed_events (
+                    id BIGSERIAL PRIMARY KEY, user_id TEXT, source_domain TEXT,
+                    event_type TEXT, metadata JSONB, source_row_id TEXT,
+                    created_at TIMESTAMPTZ DEFAULT NOW(),
+                    UNIQUE(user_id, source_domain, event_type, source_row_id)
+                )""")
+            )
+            connection.execute(
+                text(
+                    """
+                    WITH episode AS MATERIALIZED (SELECT clock_timestamp() AS revoked_at)
+                    UPDATE connections
+                    SET status='revoked', revoked_at=episode.revoked_at,
+                        revoked_by_at=episode.revoked_at, revoked_by_user_id='owner'
+                    FROM episode
+                    WHERE user_a_id=LEAST('owner', 'manish')
+                      AND user_b_id=GREATEST('owner', 'manish')
+                    """
+                )
+            )
+            # Run 206 again after the old episode exists: release migrations
+            # replay, and historical conversion must be idempotent.
+            upgrade = (
+                ROOT / "db/migrations/206_contact_sync_disconnect_actor_upgrade.sql"
+            ).read_text()
+            connection.exec_driver_sql(upgrade.replace("BEGIN;", "").replace("COMMIT;", ""))
+            connection.exec_driver_sql(upgrade.replace("BEGIN;", "").replace("COMMIT;", ""))
+
+            row = connection.execute(
+                text(
+                    """
+                    SELECT revoked_by_side, revoked_by_at = revoked_at AS episode_matches
+                    FROM connections
+                    WHERE user_a_id=LEAST('owner', 'manish')
+                      AND user_b_id=GREATEST('owner', 'manish')
+                    """
+                )
+            ).mappings().one()
+            assert row["revoked_by_side"] == "b"
+            assert row["episode_matches"] is True
+            constraint = connection.execute(
+                text(
+                    """
+                    SELECT pg_get_constraintdef(oid)
+                    FROM pg_constraint
+                    WHERE conrelid='connections'::regclass
+                      AND conname='connections_revocation_actor_pair'
+                    """
+                )
+            ).scalar_one()
+            assert "revoked_by_side" in constraint
+            assert "revoked_by_user_id" not in constraint
+
+            service = ConnectionsService()
+            service._transaction_connection = connection
+            with (
+                patch.object(service, "_join_trusted_system_circles_bulk"),
+                patch.object(service, "_cancel_pending_pair_requests"),
+                patch.object(service, "_revoke_pair_capabilities"),
+                patch.object(service, "_end_one_location_circle_memberships"),
+            ):
+                result = service.sync_contact_matches(
+                    "owner",
+                    phone_lookups=[_lookup("manish", "+919876500001")],
+                    matches=[{"lookup_id": "manish", "user_id": "manish"}],
+                    sync_started_at=service.begin_contact_sync(),
+                )
+            assert result["autoConnectedCount"] == 1
+    finally:
+        engine.dispose()
+        assert database.startswith("codex_contact_upgrade_")
+        with admin_engine.connect() as admin:
+            admin.exec_driver_sql(f'DROP DATABASE IF EXISTS "{database}" WITH (FORCE)')
+        admin_engine.dispose()
 
 
 @pytest.mark.db

--- a/docs/guides/contact-invitations.md
+++ b/docs/guides/contact-invitations.md
@@ -67,8 +67,13 @@ does not restore revoked location/information grants or named Circle membership.
 
 Migration `205_contact_sync_disconnect_actor.sql` adds nullable actor-side and
 revocation-episode fields on the existing `connections` authority table.
-Apply it before deploying the updated backend. The timestamp pair also fails
-closed during a mixed-version rollout when an older writer removes a connection.
+Migration `206_contact_sync_disconnect_actor_upgrade.sql` is the append-only
+compatibility bridge for environments that applied the earlier user-ID form of
+205: it translates only a participant-matching actor on the exact current
+revocation episode, leaving unknown or stale history suppressed. Apply the
+release lane through 206 before deploying the updated backend. The timestamp
+pair also fails closed during a mixed-version rollout when an older writer
+removes a connection.
 The fields share the connection's retention and account-deletion lifecycle;
 the actor side refers to the existing immutable A/B account columns, never
 address-book information or a mutable account-ID copy. Migration 201 deletion


### PR DESCRIPTION
## Summary
- adds append-only migration 206 to translate verified legacy 205 user-ID disconnect annotations to immutable participant sides
- replaces the old named constraint on replay while preserving ambiguous or stale history as fail-closed
- registers release/rollback contracts and adds static plus opt-in Postgres regression coverage

## Verification
- `./bin/hushh db verify-release-contract`
- `./bin/hushh codex data-model-audit`
- `./bin/hushh docs verify`
- migration contract tests and Python syntax checks

## UAT notes
- apply the release lane through migration 206 before testing Connect resync
- no live database migration or backfill was executed by this PR
- a database that previously ledgered the edited 205 checksum may need one-time checksum-drift recovery before it can apply 206