### PR TITLE
fix: make Location toggle interaction reliable

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1965,6 +1965,17 @@ describe("OneLocationAgentPage", () => {
     );
     expect(screen.getByText("Location off")).toBeTruthy();
     expect(mockRevokeGrant).not.toHaveBeenCalled();
+
+    // The caption is a separate, explicit action target. It must call the
+    // same transition once, without relying on native label forwarding.
+    mockCaptureCurrentPosition.mockClear();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Location off" }),
+    );
+    await waitFor(() => expect(mockCaptureCurrentPosition).toHaveBeenCalled());
+    expect(
+      screen.getByRole("switch", { name: "Turn location off" }),
+    ).toHaveAttribute("aria-checked", "true");
   });
 
   it("keeps Settings focused on auto approval and Saved Locations", async () => {

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -954,15 +954,27 @@ function locationHeaderStatusText(vm: LocationHubViewModel): string {
 }
 
 /** The status stays with the switch and may wrap rather than clip on a narrow phone. */
-function LocationHeaderStatus({ vm }: { vm: LocationHubViewModel }) {
+function LocationHeaderStatus({
+  vm,
+  onToggle,
+}: {
+  vm: LocationHubViewModel;
+  onToggle: () => void;
+}) {
   return (
-    <span
+    <button
+      type="button"
       id={LOCATION_HEADER_STATUS_ID}
       data-testid="one-location-header-status"
-      className={LOCATION_HEADER_STATUS_CLASSNAME}
+      aria-label={locationHeaderStatusText(vm)}
+      onClick={onToggle}
+      className={cn(
+        LOCATION_HEADER_STATUS_CLASSNAME,
+        "cursor-pointer select-none appearance-none border-0 bg-transparent p-0 text-inherit touch-manipulation",
+      )}
     >
       {locationHeaderStatusText(vm)}
-    </span>
+    </button>
   );
 }
 
@@ -978,6 +990,8 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
     }
     vm.onHideMyLocation();
   };
+
+  const handleLocationToggle = () => handleLocationChange(!locationOn);
 
   return (
     <div
@@ -1008,7 +1022,7 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
         // system green, so this toggle reads the same as every other one.
         className={cn("shrink-0", acquiring && "animate-pulse")}
       />
-      <LocationHeaderStatus vm={vm} />
+      <LocationHeaderStatus vm={vm} onToggle={handleLocationToggle} />
     </div>
   );
 }

--- a/hushh-webapp/e2e/location-cta-layout.spec.ts
+++ b/hushh-webapp/e2e/location-cta-layout.spec.ts
@@ -119,7 +119,7 @@ async function buildFixture(): Promise<string> {
             <div data-slot="page-header-actions" class="flex w-auto shrink-0 flex-wrap items-center justify-end self-start gap-2 sm:w-auto sm:shrink-0 sm:justify-end sm:self-center">
               <div data-header-actions class="${LOCATION_HEADER_ACTIONS_CLASSNAME}">
                 <button data-header-switch class="h-8 w-[51px] shrink-0 rounded-full"></button>
-                <span data-header-status class="${LOCATION_HEADER_STATUS_CLASSNAME}">${label}</span>
+                <button type="button" data-header-status class="${LOCATION_HEADER_STATUS_CLASSNAME}">${label}</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
The previous label-based status implementation could interfere with the Radix switch interaction on device. This PR keeps the Radix iOS switch as the single source of truth and makes the visible Location status an explicit action button that calls the same guarded transition once. Existing ARIA, layout, and voice-control contracts are preserved. Added regression coverage for status-button toggling and responsive header fixtures. Validation: focused One Location toggle test passed; responsive Playwright layout test passed 6/6; TypeScript check passed.