### PR TITLE
fix: keep desktop Location toggle at container edge

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1909,6 +1909,12 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByTestId("page-header").className).toContain(
       "sm:[&_[data-slot=page-header-actions]]:!ml-5",
     );
+    expect(screen.getByTestId("page-header").className).toContain(
+      "lg:[&_[data-slot=page-header-row]]:!justify-between",
+    );
+    expect(screen.getByTestId("page-header").className).toContain(
+      "lg:[&_[data-slot=page-header-actions]]:!ml-auto",
+    );
     expect(heading).toHaveClass("ui-text-agent-title");
     expect(screen.getByTestId("one-location-header-icon")).toBeTruthy();
     expect(

--- a/hushh-webapp/components/one-location/redesign/location-header-layout.ts
+++ b/hushh-webapp/components/one-location/redesign/location-header-layout.ts
@@ -8,9 +8,8 @@
  * Keep the switch legible without letting it become a detached desktop island.
  *
  * Very narrow phones stack the caption under the switch to preserve the title.
- * From 400px onward the caption sits beside the switch, and the desktop header
- * keeps the whole control next to the title instead of at the far edge of the
- * 880px agent shell.
+ * From 400px onward the caption sits beside the switch. Desktop headers use
+ * the full shell width and keep the control at the container's right edge.
  */
 export const LOCATION_HEADER_ACTIONS_CLASSNAME =
   "ml-auto flex min-h-[64px] w-[104px] max-w-[45vw] shrink-0 flex-col items-center justify-center min-[400px]:min-h-11 min-[400px]:w-auto min-[400px]:max-w-none min-[400px]:flex-row-reverse min-[400px]:gap-2 sm:ml-0";
@@ -19,4 +18,4 @@ export const LOCATION_HEADER_STATUS_CLASSNAME =
   "mt-1 block max-w-full whitespace-nowrap text-center font-[family-name:var(--font-app-body)] text-[12px] font-normal leading-4 tracking-[-0.01em] text-[color:var(--app-secondary-label)] min-[400px]:mt-0";
 
 export const LOCATION_HUB_PAGE_HEADER_CLASSNAME =
-  "[&>div:first-child]:!gap-3 sm:[&>div:first-child]:!gap-3.5 [&_[data-slot=page-header-actions]]:!self-center [&_[data-slot=page-header-row]]:!items-center [&_[data-slot=page-header-row]]:!gap-2 min-[400px]:[&_[data-slot=page-header-row]]:!gap-3 sm:[&_[data-slot=page-header-row]]:!justify-start sm:[&_[data-slot=page-header-row]]:!gap-0 sm:[&_[data-slot=page-header-copy]]:!flex-none sm:[&_[data-slot=page-header-actions]]:!ml-5 sm:[&_[data-slot=page-header-actions]]:!justify-start";
+  "[&>div:first-child]:!gap-3 sm:[&>div:first-child]:!gap-3.5 [&_[data-slot=page-header-actions]]:!self-center [&_[data-slot=page-header-row]]:!items-center [&_[data-slot=page-header-row]]:!gap-2 min-[400px]:[&_[data-slot=page-header-row]]:!gap-3 sm:[&_[data-slot=page-header-row]]:!justify-start sm:[&_[data-slot=page-header-row]]:!gap-0 sm:[&_[data-slot=page-header-copy]]:!flex-none sm:[&_[data-slot=page-header-actions]]:!ml-5 sm:[&_[data-slot=page-header-actions]]:!justify-start lg:[&_[data-slot=page-header-row]]:!justify-between lg:[&_[data-slot=page-header-actions]]:!ml-auto lg:[&_[data-slot=page-header-actions]]:!justify-end";

--- a/hushh-webapp/e2e/location-cta-layout.spec.ts
+++ b/hushh-webapp/e2e/location-cta-layout.spec.ts
@@ -29,7 +29,7 @@ import {
 } from "../components/one-location/redesign/location-header-layout";
 import { cn } from "../lib/utils";
 
-const WIDTHS = [320, 360, 393, 430, 600, 768] as const;
+const WIDTHS = [320, 360, 393, 430, 600, 768, 1024] as const;
 const STATUS_LABELS = [
   "Location on",
   "Location off",
@@ -298,12 +298,16 @@ test.describe("One Location compact CTA layout", () => {
           header.titleClientWidth + 1,
         );
         if (width >= 640) {
-          expect(
-            header.actions.left - header.title.right,
-          ).toBeGreaterThanOrEqual(16);
-          expect(header.actions.left - header.title.right).toBeLessThanOrEqual(
-            32,
-          );
+          if (width >= 1024) {
+            expect(header.header.right - header.actions.right).toBeLessThanOrEqual(1);
+          } else {
+            expect(
+              header.actions.left - header.title.right,
+            ).toBeGreaterThanOrEqual(16);
+            expect(header.actions.left - header.title.right).toBeLessThanOrEqual(
+              32,
+            );
+          }
         }
         if (width >= 400) {
           expect(


### PR DESCRIPTION
Desktop web Location headers now right-align the toggle within the container at the lg breakpoint, matching the prior desktop placement. Compact phone and tablet placement remains unchanged. Added responsive regression coverage at 1024px and preserved the existing toggle interaction tests. Local validation: focused toggle test passed; Playwright layout suite passed 7/7.