### PR TITLE
Fix Location switch animation, duration alignment and check-in filters

### DIFF
--- a/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/__tests__/nearby-check-in-sheet.test.tsx
@@ -256,19 +256,16 @@ describe("NearbyCheckInSheet", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("Stay visible for")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "See all places" }),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.queryByRole("button", { name: "Food" }),
+      screen.queryByRole("button", { name: "See all places" }),
     ).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "See all places" }));
+
+    expect(screen.getByRole("button", { name: "Food" })).toBeInTheDocument();
     expect(
       await screen.findByRole("radio", { name: /Place Four/ }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Food" })).toBeInTheDocument();
     // Attribution only. The place count that used to lead this line is
-    // already on the expansion control and in the list itself.
+    // already represented by the list itself.
     expect(screen.getByText("Google Maps")).toBeInTheDocument();
     expect(screen.queryByText(/places · Google Maps/)).not.toBeInTheDocument();
   });
@@ -351,14 +348,11 @@ describe("NearbyCheckInSheet", () => {
         .map((heading) => heading.textContent?.trim()),
     ).toEqual(["Nearby places", "Visible for", "Visibility"]);
 
-    // Compact setup keeps categories out of the first decision. They appear
-    // only after the person asks for the full chooser.
+    // Category filters are available immediately with their concise labels.
+    expect(screen.getByRole("button", { name: "Food" })).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Food" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Shops" }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: "Shops" }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Food & drink" }),
     ).not.toBeInTheDocument();
@@ -605,7 +599,7 @@ describe("NearbyCheckInSheet", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("tells the owner the fix is broad without blocking check-in", async () => {
+  it("allows coarse-position check-in without the accuracy notice", async () => {
     const coarsePoint = { ...point, accuracyM: 1_200 };
     const capture = vi.fn().mockResolvedValue(coarsePoint);
 
@@ -622,9 +616,7 @@ describe("NearbyCheckInSheet", () => {
     fireEvent.click(
       await screen.findByRole("radio", { name: /Stanford University/ }),
     );
-    expect(
-      await screen.findByText(/accurate to about 1\.2 km/i),
-    ).toBeInTheDocument();
+    expect(screen.queryByText(/accurate to about/i)).not.toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole("checkbox", {
@@ -954,7 +946,8 @@ describe("NearbyCheckInSheet", () => {
     expect(drift).not.toHaveTextContent(/match against the place/i);
   });
 
-  it("makes leaving the primary active action without using destructive red", async () => {    service.getNearbyPresence.mockResolvedValue({
+  it("makes leaving the primary active action without using destructive red", async () => {
+    service.getNearbyPresence.mockResolvedValue({
       presence: {
         status: "active",
         audience: "all_opted_in",
@@ -1269,7 +1262,6 @@ describe("NearbyCheckInSheet", () => {
     service.nearbyPlaces.mockClear();
 
     fireEvent.click(screen.getByPlaceholderText("Search places"));
-    fireEvent.click(screen.getByRole("button", { name: "See all places" }));
     const allPlaces = await screen.findByRole("button", { name: "All" });
     await act(async () => {
       // A failed refresh must degrade the drawer, not blank it.
@@ -1469,7 +1461,6 @@ describe("NearbyCheckInSheet", () => {
       category: "all",
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "See all places" }));
     fireEvent.click(screen.getByRole("button", { name: "Health" }));
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Health" })).toHaveAttribute(
@@ -1587,7 +1578,6 @@ describe("NearbyCheckInSheet", () => {
     fireEvent.click(
       await screen.findByRole("radio", { name: /Stanford University/ }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "See all places" }));
     fireEvent.click(screen.getByRole("button", { name: "Health" }));
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Health" })).toHaveAttribute(
@@ -1714,7 +1704,6 @@ describe("NearbyCheckInSheet", () => {
     );
 
     await screen.findByRole("radio", { name: /Stanford University/ });
-    fireEvent.click(screen.getByRole("button", { name: "See all places" }));
     fireEvent.click(screen.getByRole("button", { name: "Health" }));
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Health" })).toHaveAttribute(
@@ -1920,7 +1909,6 @@ describe("NearbyCheckInSheet", () => {
     );
 
     await screen.findByRole("radio", { name: /Stanford University/ });
-    fireEvent.click(screen.getByRole("button", { name: "See all places" }));
     fireEvent.click(screen.getByRole("button", { name: "Transit" }));
 
     const empty = await screen.findByTestId("nearby-category-empty");

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -10,7 +10,6 @@ import {
 } from "react";
 import {
   Check,
-  ChevronRight,
   Compass,
   Loader2,
   LocateFixed,
@@ -86,10 +85,7 @@ import {
   loadSavedLocations,
 } from "@/lib/one-location/saved-locations";
 import { OneLocationService } from "@/lib/one-location/service";
-import {
-  ONE_LOCATION_NEARBY_COARSE_ACCURACY_METERS,
-  ONE_LOCATION_NEARBY_MAX_ACCURACY_METERS,
-} from "@/lib/one-location/nearby-check-in-availability";
+import { ONE_LOCATION_NEARBY_MAX_ACCURACY_METERS } from "@/lib/one-location/nearby-check-in-availability";
 import type {
   OneLocationNearbyAttendee,
   OneLocationNearbyPlaceCategory,
@@ -339,7 +335,9 @@ function placesInCategory(
     // exhaustively and never sends an empty list, but a response cached before
     // that shipped still can -- and a row that answers no chip is a row the
     // person can see under "All" and then never find again.
-    (place.categories?.length ? place.categories : ["other"]).includes(category),
+    (place.categories?.length ? place.categories : ["other"]).includes(
+      category,
+    ),
   );
 }
 
@@ -417,27 +415,6 @@ function hasCheckInAccuracy(point: PlainLocationPoint): boolean {
     point.accuracyM >= 0 &&
     point.accuracyM <= ONE_LOCATION_NEARBY_MAX_ACCURACY_METERS
   );
-}
-
-/**
- * A usable-but-broad fix. Worth surfacing so a rejected place choice is not a
- * surprise, but never a reason to withhold the place list: browser geolocation
- * lands here routinely and the owner can still pick the venue they are standing
- * in.
- */
-function isCoarseAccuracy(point: PlainLocationPoint): boolean {
-  return (
-    typeof point.accuracyM === "number" &&
-    Number.isFinite(point.accuracyM) &&
-    point.accuracyM > ONE_LOCATION_NEARBY_COARSE_ACCURACY_METERS
-  );
-}
-
-function coarseAccuracyNotice(point: PlainLocationPoint): string {
-  const reading = Math.round(Number(point.accuracyM));
-  const distance =
-    reading >= 1_000 ? `${(reading / 1_000).toFixed(1)} km` : `${reading} m`;
-  return `Your location is accurate to about ${distance}. Pick the place you're actually at — if it's rejected, move to an open area or turn on precise location.`;
 }
 
 /**
@@ -665,7 +642,6 @@ export function NearbyCheckInSheet({
   const [durationMinutes, setDurationMinutes] = useState<30 | 60 | 120>(60);
   const [consentAccepted, setConsentAccepted] = useState(false);
   const [allowConnectionRequests, setAllowConnectionRequests] = useState(false);
-  const [showAllPlaces, setShowAllPlaces] = useState(false);
   const [addTimeOpen, setAddTimeOpen] = useState(false);
   const [addTimeBusy, setAddTimeBusy] = useState<30 | 60 | null>(null);
   const [busy, setBusy] = useState<"check-in" | "checkout" | string | null>(
@@ -704,9 +680,7 @@ export function NearbyCheckInSheet({
     null,
   );
   const [placesError, setPlacesError] = useState<string | null>(null);
-  const [accuracyNotice, setAccuracyNotice] = useState<string | null>(null);
   const typedSearchActive = search.trim().length >= 2;
-  const fullPlaceChooserOpen = showAllPlaces || typedSearchActive;
 
   /**
    * The rows on screen. Derived rather than stored: the merged nearby sweep is
@@ -716,9 +690,7 @@ export function NearbyCheckInSheet({
   const places = useMemo(() => {
     const visible = typedSearchActive
       ? searchResults
-      : fullPlaceChooserOpen
-        ? placesInCategory(automaticPlaces, category)
-        : automaticPlaces;
+      : placesInCategory(automaticPlaces, category);
     // Coordinates resolved on demand for searched places, which arrive without
     // them, so the map can pin whatever the owner is looking at.
     return visible.map((place) => {
@@ -729,7 +701,6 @@ export function NearbyCheckInSheet({
   }, [
     automaticPlaces,
     category,
-    fullPlaceChooserOpen,
     resolvedPlacePoints,
     searchResults,
     typedSearchActive,
@@ -949,7 +920,6 @@ export function NearbyCheckInSheet({
         setPoint(sessionFix);
         setPointOrigin("last-known");
         setLocationError(null);
-        setAccuracyNotice(null);
         void loadPlaces(sessionFix, generation, expectedOwnerEpoch);
         return true;
       }
@@ -964,7 +934,6 @@ export function NearbyCheckInSheet({
       setPoint(restored);
       setPointOrigin("last-known");
       setLocationError(null);
-      setAccuracyNotice(null);
       void loadPlaces(restored, generation, expectedOwnerEpoch);
       return true;
     },
@@ -972,17 +941,13 @@ export function NearbyCheckInSheet({
   );
 
   const captureAndLoadPlaces = useCallback(
-    async (
-      nextCategory: OneLocationNearbyPlaceCategory = "all",
-      options: { preserveChooser?: boolean } = {},
-    ) => {
+    async (nextCategory: OneLocationNearbyPlaceCategory = "all") => {
       if (!ownerId || !vaultOwnerToken) return;
       const expectedOwnerEpoch = ownerEpochRef.current;
       const generation = ++requestGenerationRef.current;
       searchGenerationRef.current += 1;
       setCapturing(true);
       setCategory(nextCategory);
-      if (!options.preserveChooser) setShowAllPlaces(false);
       setSearch("");
       setSearchResults([]);
       setSearching(false);
@@ -990,7 +955,6 @@ export function NearbyCheckInSheet({
       setLocationRecovery(null);
       setPresenceLoadError(null);
       setPlacesError(null);
-      setAccuracyNotice(null);
       try {
         let permission: Awaited<
           ReturnType<typeof OneLocationService.getPermissionState>
@@ -1099,9 +1063,6 @@ export function NearbyCheckInSheet({
         // an error and zero places instead of the venues it is standing in --
         // the owner still needs to pick where they are, and the backend does the
         // authoritative plausibility check at check-in.
-        setAccuracyNotice(
-          isCoarseAccuracy(nextPoint) ? coarseAccuracyNotice(nextPoint) : null,
-        );
         lastKnownPointRef.current = nextPoint;
         // Carry it past this page. The next cold start reads this instead of
         // starting from nothing, which is what turns a failed first GPS read
@@ -1158,7 +1119,6 @@ export function NearbyCheckInSheet({
   const selectCategory = useCallback(
     (nextCategory: OneLocationNearbyPlaceCategory) => {
       setCategory(nextCategory);
-      setShowAllPlaces(true);
       setSearch("");
       setSearchResults([]);
       setSearching(false);
@@ -1191,7 +1151,6 @@ export function NearbyCheckInSheet({
     setViewState("loading");
     setConsentAccepted(false);
     setAllowConnectionRequests(false);
-    setShowAllPlaces(false);
     setAddTimeOpen(false);
     setAddTimeBusy(null);
     setDurationMinutes(60);
@@ -1202,7 +1161,6 @@ export function NearbyCheckInSheet({
     setLocationRecovery(null);
     setPresenceLoadError(null);
     setPlacesError(null);
-    setAccuracyNotice(null);
     publishState(EMPTY_NEARBY_STATE);
     return () => {
       requestGenerationRef.current += 1;
@@ -1229,7 +1187,6 @@ export function NearbyCheckInSheet({
     setSearching(false);
     setConsentAccepted(false);
     setAllowConnectionRequests(false);
-    setShowAllPlaces(false);
     setAddTimeOpen(false);
     setAddTimeBusy(null);
     setDurationMinutes(60);
@@ -1642,9 +1599,6 @@ export function NearbyCheckInSheet({
         toast.error("A more precise location is needed before check-in.");
         return;
       }
-      setAccuracyNotice(
-        isCoarseAccuracy(freshPoint) ? coarseAccuracyNotice(freshPoint) : null,
-      );
       setPoint(freshPoint);
       const next = await OneLocationService.checkInNearby({
         vaultOwnerToken: ownerToken,
@@ -1672,7 +1626,6 @@ export function NearbyCheckInSheet({
       setSearchResults([]);
       setSelectedPlaceId("");
       setSearch("");
-      setAccuracyNotice(null);
       toast.success("You're checked in nearby.");
     } catch (error) {
       if (
@@ -1712,9 +1665,7 @@ export function NearbyCheckInSheet({
             }
           });
         } else {
-          void captureAndLoadPlaces(category, {
-            preserveChooser: fullPlaceChooserOpen,
-          });
+          void captureAndLoadPlaces(category);
         }
       } else if (details.message.toLowerCase().includes("closer place")) {
         setPlacesError(details.message);
@@ -1926,11 +1877,6 @@ export function NearbyCheckInSheet({
               "Couldn't confirm your location precisely enough. Nothing was shared — try again in a second.",
           };
         }
-        setAccuracyNotice(
-          isCoarseAccuracy(freshPoint)
-            ? coarseAccuracyNotice(freshPoint)
-            : null,
-        );
         setPoint(freshPoint);
         const next = await OneLocationService.checkInNearby({
           vaultOwnerToken,
@@ -1949,7 +1895,6 @@ export function NearbyCheckInSheet({
         setSearchResults([]);
         setSelectedPlaceId("");
         setSearch("");
-        setAccuracyNotice(null);
         toast.success("You're checked in nearby.");
         const placeName = place.name ?? place.text;
         return {
@@ -2158,7 +2103,9 @@ export function NearbyCheckInSheet({
         }).catch(() => undefined);
       }
       setCompletedCheckIn((current) =>
-        current ? { ...current, ratingSaved: true, ratingError: null } : current,
+        current
+          ? { ...current, ratingSaved: true, ratingError: null }
+          : current,
       );
       trackVisitRated({
         route_id: "one_location_check_in",
@@ -2231,7 +2178,6 @@ export function NearbyCheckInSheet({
       setRatingNote("");
       setConsentAccepted(false);
       setAllowConnectionRequests(false);
-      setShowAllPlaces(false);
       setAddTimeOpen(false);
       setAddTimeBusy(null);
       void offerSavePlace(savedPlaceOffer);
@@ -2807,11 +2753,7 @@ export function NearbyCheckInSheet({
                     to say what the list is. */}
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <h2 className="font-semibold">
-                        {fullPlaceChooserOpen
-                          ? "All nearby places"
-                          : "Nearby places"}
-                      </h2>
+                      <h2 className="font-semibold">Nearby places</h2>
                     </div>
                     {capturing ? (
                       <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
@@ -2852,11 +2794,7 @@ export function NearbyCheckInSheet({
                           type="button"
                           size="sm"
                           disabled={capturing || busy === "settings"}
-                          onClick={() =>
-                            void captureAndLoadPlaces(category, {
-                              preserveChooser: fullPlaceChooserOpen,
-                            })
-                          }
+                          onClick={() => void captureAndLoadPlaces(category)}
                         >
                           {capturing ? (
                             <Loader2 className="h-4 w-4 animate-spin" />
@@ -2901,23 +2839,13 @@ export function NearbyCheckInSheet({
                               className="font-semibold underline underline-offset-2"
                               disabled={capturing}
                               onClick={() =>
-                                void captureAndLoadPlaces(category, {
-                                  preserveChooser: fullPlaceChooserOpen,
-                                })
+                                void captureAndLoadPlaces(category)
                               }
                             >
                               update your location
                             </button>
                             .
                           </span>
-                        </p>
-                      ) : null}
-                      {accuracyNotice ? (
-                        <p
-                          className="mt-3 rounded-2xl border border-border/60 bg-muted/40 p-3 text-xs text-muted-foreground"
-                          role="status"
-                        >
-                          {accuracyNotice}
                         </p>
                       ) : null}
                       <label className="relative mt-3 block">
@@ -2946,150 +2874,123 @@ export function NearbyCheckInSheet({
                         ) : null}
                       </label>
 
-                      {fullPlaceChooserOpen ? (
-                        <div
-                          className={CHECK_IN_CATEGORY_ROW_CLASSNAME}
-                          aria-label="Nearby place categories"
-                        >
-                          {typedSearchActive ? (
-                            <span className="inline-flex h-9 shrink-0 items-center rounded-full bg-primary px-3 text-sm font-medium text-primary-foreground">
-                              Search results
-                            </span>
-                          ) : null}
-                          {PLACE_CATEGORIES.map((option) => (
-                            <Button
-                              key={option.value}
-                              type="button"
-                              size="sm"
-                              variant={
-                                !typedSearchActive && category === option.value
-                                  ? "default"
-                                  : "secondary"
-                              }
-                              className="shrink-0 rounded-full"
-                              aria-pressed={
-                                !typedSearchActive && category === option.value
-                              }
-                              disabled={
-                                !point || capturing || typedSearchActive
-                              }
-                              onClick={() => selectCategory(option.value)}
-                            >
-                              {option.label}
-                            </Button>
-                          ))}
-                        </div>
-                      ) : null}
+                      <div
+                        className={CHECK_IN_CATEGORY_ROW_CLASSNAME}
+                        role="group"
+                        aria-label="Nearby place categories"
+                      >
+                        {typedSearchActive ? (
+                          <span className="inline-flex h-9 shrink-0 items-center rounded-full bg-primary px-3 text-sm font-medium text-primary-foreground">
+                            Search results
+                          </span>
+                        ) : null}
+                        {PLACE_CATEGORIES.map((option) => (
+                          <Button
+                            key={option.value}
+                            type="button"
+                            size="sm"
+                            variant={
+                              !typedSearchActive && category === option.value
+                                ? "default"
+                                : "secondary"
+                            }
+                            className="shrink-0 rounded-full"
+                            aria-pressed={
+                              !typedSearchActive && category === option.value
+                            }
+                            disabled={!point || capturing || typedSearchActive}
+                            onClick={() => selectCategory(option.value)}
+                          >
+                            {option.label}
+                          </Button>
+                        ))}
+                      </div>
 
                       <div
-                        className={cn(
-                          "mt-3 space-y-2",
-                          fullPlaceChooserOpen &&
-                            "max-h-[35vh] overflow-y-auto pr-2",
-                        )}
+                        className="mt-3 max-h-[35vh] space-y-2 overflow-y-auto pr-2"
                         role="radiogroup"
                         aria-label="Nearby places"
                       >
-                        {places
-                          .slice(0, fullPlaceChooserOpen ? places.length : 3)
-                          .map((place) => {
-                            const selected = place.placeId === selectedPlaceId;
-                            const name = place.name?.trim() || place.text;
-                            // One supporting line, not two joined by a middot.
-                            //
-                            // The row is a choice between venues the person can
-                            // see out of the window, so the useful cue is what
-                            // kind of place it is. A postal address is longer than
-                            // the row, always truncates, and the tail that gets
-                            // cut is the part that would have disambiguated it —
-                            // so it cost a line and answered nothing. The address
-                            // still shows when there is no category to show
-                            // instead, and the full pair stays in the title
-                            // attribute for a pointer and for assistive tech.
-                            const category = place.category?.trim() || "";
-                            const address = place.address?.trim() || "";
-                            const metadataLabel = category || address;
-                            const ratingSummary = ratingSummaries[place.placeId];
-                            const metadataTitle = Array.from(
-                              new Set([category, address].filter(Boolean)),
-                            ).join(" · ");
-                            return (
-                              <button
-                                key={place.placeId}
-                                type="button"
-                                role="radio"
-                                aria-checked={selected}
-                                className={cn(
-                                  CHECK_IN_PLACE_ROW_CLASSNAME,
-                                  selected
-                                    ? CHECK_IN_PLACE_ROW_ON_CLASSNAME
-                                    : CHECK_IN_PLACE_ROW_OFF_CLASSNAME,
-                                )}
-                                onClick={() =>
-                                  setSelectedPlaceId(place.placeId)
-                                }
-                              >
-                                <MapPin className="h-4 w-4 shrink-0 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
-                                <span className="min-w-0 flex-1">
+                        {places.map((place) => {
+                          const selected = place.placeId === selectedPlaceId;
+                          const name = place.name?.trim() || place.text;
+                          // One supporting line, not two joined by a middot.
+                          //
+                          // The row is a choice between venues the person can
+                          // see out of the window, so the useful cue is what
+                          // kind of place it is. A postal address is longer than
+                          // the row, always truncates, and the tail that gets
+                          // cut is the part that would have disambiguated it —
+                          // so it cost a line and answered nothing. The address
+                          // still shows when there is no category to show
+                          // instead, and the full pair stays in the title
+                          // attribute for a pointer and for assistive tech.
+                          const category = place.category?.trim() || "";
+                          const address = place.address?.trim() || "";
+                          const metadataLabel = category || address;
+                          const ratingSummary = ratingSummaries[place.placeId];
+                          const metadataTitle = Array.from(
+                            new Set([category, address].filter(Boolean)),
+                          ).join(" · ");
+                          return (
+                            <button
+                              key={place.placeId}
+                              type="button"
+                              role="radio"
+                              aria-checked={selected}
+                              className={cn(
+                                CHECK_IN_PLACE_ROW_CLASSNAME,
+                                selected
+                                  ? CHECK_IN_PLACE_ROW_ON_CLASSNAME
+                                  : CHECK_IN_PLACE_ROW_OFF_CLASSNAME,
+                              )}
+                              onClick={() => setSelectedPlaceId(place.placeId)}
+                            >
+                              <MapPin className="h-4 w-4 shrink-0 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
+                              <span className="min-w-0 flex-1">
+                                <span
+                                  title={name}
+                                  className={CHECK_IN_PLACE_NAME_CLASSNAME}
+                                >
+                                  {name}
+                                </span>
+                                {metadataLabel || ratingSummary ? (
                                   <span
-                                    title={name}
-                                    className={CHECK_IN_PLACE_NAME_CLASSNAME}
+                                    title={metadataTitle}
+                                    className={CHECK_IN_PLACE_META_CLASSNAME}
                                   >
-                                    {name}
-                                  </span>
-                                  {metadataLabel || ratingSummary ? (
-                                    <span
-                                      title={metadataTitle}
-                                      className={CHECK_IN_PLACE_META_CLASSNAME}
-                                    >
-                                      {metadataLabel}
-                                      {ratingSummary ? (
-                                        <>
-                                          {metadataLabel ? " · " : null}
-                                          {/* A bucket, never an exact count:
+                                    {metadataLabel}
+                                    {ratingSummary ? (
+                                      <>
+                                        {metadataLabel ? " · " : null}
+                                        {/* A bucket, never an exact count:
                                               an exact count beside an exact
                                               average lets somebody watching
                                               the list recover each new rating
                                               by subtraction. */}
-                                          <span aria-hidden="true">★</span>
-                                          {ratingSummary.average.toFixed(1)} ·{" "}
-                                          {ratingSummary.countBucket}
-                                          <span className="sr-only">
-                                            {` Hushh rating ${ratingSummary.average.toFixed(1)} out of 5, from ${ratingSummary.countBucket} people`}
-                                          </span>
-                                        </>
-                                      ) : null}
-                                    </span>
-                                  ) : null}
-                                </span>
-                                <span
-                                  className={CHECK_IN_PLACE_DISTANCE_CLASSNAME}
-                                >
-                                  {compactDistanceLabel(place.distanceMeters)}
-                                </span>
-                                {selected ? (
-                                  <Check className="h-4 w-4 shrink-0 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
+                                        <span aria-hidden="true">★</span>
+                                        {ratingSummary.average.toFixed(
+                                          1,
+                                        )} · {ratingSummary.countBucket}
+                                        <span className="sr-only">
+                                          {` Hushh rating ${ratingSummary.average.toFixed(1)} out of 5, from ${ratingSummary.countBucket} people`}
+                                        </span>
+                                      </>
+                                    ) : null}
+                                  </span>
                                 ) : null}
-                              </button>
-                            );
-                          })}
-                      {!fullPlaceChooserOpen && automaticPlaces.length > 0 ? (
-                          <div className="pt-1 pb-2">
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              className="flex w-full items-center justify-between text-muted-foreground"
-                              onClick={() => setShowAllPlaces(true)}
-                            >
-                              <span>See all places</span>
-                              <ChevronRight
-                                className="h-4 w-4"
-                                aria-hidden="true"
-                              />
-                            </Button>
-                          </div>
-                        ) : null}
+                              </span>
+                              <span
+                                className={CHECK_IN_PLACE_DISTANCE_CLASSNAME}
+                              >
+                                {compactDistanceLabel(place.distanceMeters)}
+                              </span>
+                              {selected ? (
+                                <Check className="h-4 w-4 shrink-0 text-[var(--app-accent-deep)] dark:text-[var(--app-accent-bright)]" />
+                              ) : null}
+                            </button>
+                          );
+                        })}
                       </div>
                       {/*
                       The owner's point and their venue are two different places
@@ -3261,11 +3162,11 @@ export function NearbyCheckInSheet({
           if (busy === null) setAddTimeOpen(nextOpen);
         }}
       >
-      <SheetContent
-        side="bottom"
-        className="mx-auto w-full gap-0 rounded-t-[var(--app-card-radius-feature)] px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-4 sm:max-w-md md:left-auto md:right-6 md:max-w-sm md:rounded-[var(--app-card-radius-feature)]"
-        aria-describedby={undefined}
-      >
+        <SheetContent
+          side="bottom"
+          className="mx-auto w-full gap-0 rounded-t-[var(--app-card-radius-feature)] px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-4 sm:max-w-md md:left-auto md:right-6 md:max-w-sm md:rounded-[var(--app-card-radius-feature)]"
+          aria-describedby={undefined}
+        >
           <SheetHeader className="px-0 pb-3 text-left">
             <SheetTitle className="text-[17px] leading-6">Add time</SheetTitle>
           </SheetHeader>

--- a/hushh-webapp/components/one-location/redesign/duration-presets.tsx
+++ b/hushh-webapp/components/one-location/redesign/duration-presets.tsx
@@ -112,9 +112,9 @@ export const DURATION_CUSTOM_VISIBLE_ROWS = 3;
  */
 export const DURATION_GRID_CLASS =
   "grid grid-cols-2 gap-2 sm:flex sm:flex-wrap";
-/** A compact two-column block for the final share confirmation card. */
+/** A compact two-column block at the final share card's trailing edge. */
 export const DURATION_COMPACT_GRID_CLASS =
-  "mx-auto grid w-full max-w-[240px] grid-cols-2 gap-2";
+  "ml-auto grid w-full max-w-[240px] grid-cols-2 gap-2";
 export const DURATION_CELL_CLASS =
   "flex min-h-11 items-center justify-center whitespace-nowrap rounded-[14px] border px-2 text-center text-[15px] font-semibold leading-5 transition-colors touch-manipulation sm:px-4";
 export const DURATION_COMPACT_CELL_CLASS = "rounded-full px-3";

--- a/hushh-webapp/components/one-location/redesign/duration-presets.tsx
+++ b/hushh-webapp/components/one-location/redesign/duration-presets.tsx
@@ -112,9 +112,9 @@ export const DURATION_CUSTOM_VISIBLE_ROWS = 3;
  */
 export const DURATION_GRID_CLASS =
   "grid grid-cols-2 gap-2 sm:flex sm:flex-wrap";
-/** A compact two-column block at the final share card's trailing edge. */
+/** Fill the phone card; keep a compact, left-aligned two-column group on desktop. */
 export const DURATION_COMPACT_GRID_CLASS =
-  "ml-auto grid w-full max-w-[240px] grid-cols-2 gap-2";
+  "grid w-full grid-cols-2 gap-2 sm:max-w-[280px]";
 export const DURATION_CELL_CLASS =
   "flex min-h-11 items-center justify-center whitespace-nowrap rounded-[14px] border px-2 text-center text-[15px] font-semibold leading-5 transition-colors touch-manipulation sm:px-4";
 export const DURATION_COMPACT_CELL_CLASS = "rounded-full px-3";

--- a/hushh-webapp/components/one-location/redesign/location-cta-layout.ts
+++ b/hushh-webapp/components/one-location/redesign/location-cta-layout.ts
@@ -6,7 +6,7 @@
  */
 
 /** Keeps the public-link controls together and aligned to the card's content edge. */
-export const PUBLIC_LINK_CONTROLS_CLASSNAME = "w-full max-w-[280px] space-y-3";
+export const PUBLIC_LINK_CONTROLS_CLASSNAME = "w-full space-y-3 sm:max-w-[280px]";
 
 export const PUBLIC_LINK_PRIMARY_CTA_CLASSNAME =
   "h-11 min-h-11 w-full rounded-[13px] bg-[color:var(--app-accent)] text-[16px] font-semibold leading-[21px] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90";

--- a/hushh-webapp/docs/one-location-now-and-map.md
+++ b/hushh-webapp/docs/one-location-now-and-map.md
@@ -71,6 +71,14 @@ Approximate native permission and fixes worse than 100 m fail before
 publication with an app-settings recovery path. Active rosters refresh on a
 15-second, visible-app cadence without extending the server expiry.
 
+The nearby place chooser exposes search and category filters immediately, with
+the full result list in a bounded scroll area. Category changes filter the
+existing nearby results. The accuracy information box is omitted; permission,
+capture, and check-in rejection recovery still use their existing controls.
+
+The final sharing review keeps its duration choices in a compact two-column
+group aligned to the card's right edge on phones and desktop.
+
 ## Saved location onboarding
 
 Every Location onboarding run offers the saved-place flow after foreground

--- a/hushh-webapp/docs/one-location-now-and-map.md
+++ b/hushh-webapp/docs/one-location-now-and-map.md
@@ -76,8 +76,10 @@ the full result list in a bounded scroll area. Category changes filter the
 existing nearby results. The accuracy information box is omitted; permission,
 capture, and check-in rejection recovery still use their existing controls.
 
-The final sharing review keeps its duration choices in a compact two-column
-group aligned to the card's right edge on phones and desktop.
+The final sharing review keeps its duration choices in two equal columns,
+filling the card's inner width on phones and forming a compact 280px group
+aligned with the label and note on desktop. Temporary-link duration controls
+and the Create link button follow the same responsive width and left alignment.
 
 ## Saved location onboarding
 

--- a/hushh-webapp/e2e/fixtures/location-switch.tsx
+++ b/hushh-webapp/e2e/fixtures/location-switch.tsx
@@ -1,0 +1,98 @@
+import React, { useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { Switch } from "../../components/ui/switch";
+import { usePageEnterAnimation } from "../../lib/morphy-ux/hooks/use-page-enter";
+import { PageHeader } from "../../components/app-ui/page-sections";
+import { MapPin } from "lucide-react";
+import { DurationPresetPicker } from "../../components/one-location/redesign/duration-presets";
+import {
+  LOCATION_HEADER_ACTIONS_CLASSNAME,
+  LOCATION_HEADER_STATUS_CLASSNAME,
+  LOCATION_HUB_PAGE_HEADER_CLASSNAME,
+} from "../../components/one-location/redesign/location-header-layout";
+
+function Fixture() {
+  const [checked, setChecked] = useState(
+    document.body.dataset.initial === "on",
+  );
+  const [version, setVersion] = useState(0);
+  const [duration, setDuration] = useState("0.25");
+  const ref = useRef<HTMLDivElement>(null);
+  usePageEnterAnimation(ref);
+  return (
+    <main
+      ref={ref}
+      style={{ padding: "32px 20px", maxWidth: 880, margin: "auto" }}
+    >
+      <div key={version}>
+        <PageHeader
+          title="Location"
+          icon={MapPin}
+          accent="location"
+          actionsInlineMobile
+          className={LOCATION_HUB_PAGE_HEADER_CLASSNAME}
+          actions={
+            <div className={LOCATION_HEADER_ACTIONS_CLASSNAME}>
+              <Switch
+                size="ios"
+                checked={checked}
+                onCheckedChange={setChecked}
+                aria-label="Location"
+              />
+              <span className={LOCATION_HEADER_STATUS_CLASSNAME}>
+                Location {checked ? "on" : "off"}
+              </span>
+            </div>
+          }
+        />
+      </div>
+      <section style={{ marginTop: 32 }}>
+        <p style={{ color: "var(--app-secondary-label)" }}>Step 2 of 2</p>
+        <h2 style={{ fontSize: 28, fontWeight: 700, marginBottom: 20 }}>
+          Ready to share?
+        </h2>
+        <div
+          data-share-card
+          style={{
+            padding: 24,
+            borderRadius: 24,
+            background: "var(--app-primary-surface)",
+          }}
+        >
+          <p id="duration-label" style={{ marginBottom: 10 }}>
+            How long
+          </p>
+          <DurationPresetPicker
+            compact
+            value={duration}
+            onChange={setDuration}
+            labelledBy="duration-label"
+          />
+          <label
+            htmlFor="note"
+            style={{ display: "block", marginTop: 24, marginBottom: 8 }}
+          >
+            Optional note
+          </label>
+          <textarea
+            id="note"
+            placeholder="On my way to the meeting"
+            style={{
+              width: "100%",
+              minHeight: 92,
+              padding: 16,
+              border: "1px solid var(--app-separator)",
+              borderRadius: 14,
+            }}
+          />
+        </div>
+      </section>
+      <div data-fixture-tools style={{ marginTop: 24 }}>
+        <button onClick={() => setVersion((v) => v + 1)}>
+          Remount controls
+        </button>
+      </div>
+    </main>
+  );
+}
+createRoot(document.getElementById("root")!).render(<Fixture />);

--- a/hushh-webapp/e2e/location-cta-layout.spec.ts
+++ b/hushh-webapp/e2e/location-cta-layout.spec.ts
@@ -246,7 +246,14 @@ test.describe("One Location compact CTA layout", () => {
 
       expect(result.overflow).toBeLessThanOrEqual(1);
 
-      expect(result.publicControls.width).toBeLessThanOrEqual(280.5);
+      if (width < 640) {
+        expect(result.publicControls.width).toBeCloseTo(
+          result.publicCard.width - result.publicCardPaddingLeft * 2,
+          0,
+        );
+      } else {
+        expect(result.publicControls.width).toBeCloseTo(280, 0);
+      }
       expect(
         Math.abs(
           result.publicControls.left -
@@ -262,11 +269,16 @@ test.describe("One Location compact CTA layout", () => {
         Math.abs(result.publicCta.width - result.publicControls.width),
       ).toBeLessThanOrEqual(1);
 
-      expect(result.shareOptions.width).toBeLessThanOrEqual(240.5);
+      expect(result.shareOptions.width).toBeCloseTo(
+        width < 640
+          ? result.shareCard.width - result.shareCardPaddingRight * 2
+          : 280,
+        0,
+      );
       expect(
         Math.abs(
-          result.shareOptions.right -
-            (result.shareCard.right - result.shareCardPaddingRight),
+          result.shareOptions.left -
+            (result.shareCard.left + result.shareCardPaddingRight),
         ),
       ).toBeLessThanOrEqual(1);
       expect(

--- a/hushh-webapp/e2e/location-cta-layout.spec.ts
+++ b/hushh-webapp/e2e/location-cta-layout.spec.ts
@@ -3,10 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import {
-  awaitProductFont,
-  productFontStyle,
-} from "./fixtures/product-font";
+import { awaitProductFont, productFontStyle } from "./fixtures/product-font";
 import {
   DURATION_COMPACT_CELL_CLASS,
   DURATION_COMPACT_GRID_CLASS,
@@ -108,7 +105,9 @@ async function buildFixture(): Promise<string> {
     )
     .join("");
   const headers = STATUS_LABELS.map(
-    (label) => `<header data-header class="${LOCATION_HUB_PAGE_HEADER_CLASSNAME}">
+    (
+      label,
+    ) => `<header data-header class="${LOCATION_HUB_PAGE_HEADER_CLASSNAME}">
       <div class="flex items-stretch gap-3 sm:gap-4">
         <span class="h-11 w-11 shrink-0 self-center rounded-[10px]"></span>
         <div class="min-w-0 flex-1">
@@ -172,7 +171,9 @@ test.describe("One Location compact CTA layout", () => {
 
       const result = await page.evaluate(() => {
         const box = (selector: string) =>
-          document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
+          document
+            .querySelector<HTMLElement>(selector)!
+            .getBoundingClientRect();
         const publicCard = box("[data-public-card]");
         const publicCardPaddingLeft = Number.parseFloat(
           getComputedStyle(
@@ -227,6 +228,11 @@ test.describe("One Location compact CTA layout", () => {
           publicOptions: publicOptions.map((value) => value.toJSON()),
           publicCta: publicCta.toJSON(),
           shareCard: shareCard.toJSON(),
+          shareCardPaddingRight: parseFloat(
+            getComputedStyle(
+              document.querySelector<HTMLElement>("[data-share-card]")!,
+            ).paddingRight,
+          ),
           shareOptions: shareOptions.toJSON(),
           shareCells: shareCells.map((value) => value.toJSON()),
           shareActions: shareActions.toJSON(),
@@ -248,9 +254,7 @@ test.describe("One Location compact CTA layout", () => {
         ),
       ).toBeLessThanOrEqual(1);
       expect(
-        Math.abs(
-          result.publicOptions[0].width - result.publicOptions[1].width,
-        ),
+        Math.abs(result.publicOptions[0].width - result.publicOptions[1].width),
       ).toBeLessThanOrEqual(1);
       expect(result.publicOptions[0].height).toBeGreaterThanOrEqual(44);
       expect(result.publicOptions[1].height).toBeGreaterThanOrEqual(44);
@@ -261,12 +265,13 @@ test.describe("One Location compact CTA layout", () => {
       expect(result.shareOptions.width).toBeLessThanOrEqual(240.5);
       expect(
         Math.abs(
-          result.shareOptions.left -
-            (result.shareCard.left +
-              (result.shareCard.width - result.shareOptions.width) / 2),
+          result.shareOptions.right -
+            (result.shareCard.right - result.shareCardPaddingRight),
         ),
       ).toBeLessThanOrEqual(1);
-      expect(new Set(result.shareCells.map((cell) => Math.round(cell.top))).size).toBe(2);
+      expect(
+        new Set(result.shareCells.map((cell) => Math.round(cell.top))).size,
+      ).toBe(2);
       for (const cell of result.shareCells) {
         expect(cell.height).toBeGreaterThanOrEqual(44);
         expect(
@@ -281,7 +286,9 @@ test.describe("One Location compact CTA layout", () => {
       }
 
       for (const header of result.headers) {
-        expect(header.actions.right).toBeLessThanOrEqual(header.header.right + 1);
+        expect(header.actions.right).toBeLessThanOrEqual(
+          header.header.right + 1,
+        );
         expect(header.toggle.left).toBeGreaterThanOrEqual(
           header.actions.left - 1,
         );
@@ -299,14 +306,16 @@ test.describe("One Location compact CTA layout", () => {
         );
         if (width >= 640) {
           if (width >= 1024) {
-            expect(header.header.right - header.actions.right).toBeLessThanOrEqual(1);
+            expect(
+              header.header.right - header.actions.right,
+            ).toBeLessThanOrEqual(1);
           } else {
             expect(
               header.actions.left - header.title.right,
             ).toBeGreaterThanOrEqual(16);
-            expect(header.actions.left - header.title.right).toBeLessThanOrEqual(
-              32,
-            );
+            expect(
+              header.actions.left - header.title.right,
+            ).toBeLessThanOrEqual(32);
           }
         }
         if (width >= 400) {

--- a/hushh-webapp/e2e/location-switch.layout.spec.ts
+++ b/hushh-webapp/e2e/location-switch.layout.spec.ts
@@ -161,8 +161,8 @@ for (const width of [320, 393, 430, 1440]) {
           const grid = card.querySelector("[role=group] > div")!;
           const box = card.getBoundingClientRect();
           return Math.abs(
-            grid.getBoundingClientRect().right -
-              (box.right - parseFloat(getComputedStyle(card).paddingRight)),
+            grid.getBoundingClientRect().left -
+              (box.left + parseFloat(getComputedStyle(card).paddingLeft)),
           );
         });
       expect(alignment).toBeLessThanOrEqual(1);

--- a/hushh-webapp/e2e/location-switch.layout.spec.ts
+++ b/hushh-webapp/e2e/location-switch.layout.spec.ts
@@ -1,0 +1,186 @@
+import { expect, test, type Page } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { productFontStyle, stripAppFontFaces } from "./fixtures/product-font";
+
+let css: string;
+let script: string;
+test.beforeAll(async () => {
+  const root = process.cwd();
+  const { build } = await import("vite");
+  const { Scanner } = await import("@tailwindcss/oxide");
+  const scanner = new Scanner({});
+  const candidates = new Set<string>();
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "location-switch-"));
+  await build({
+    configFile: false,
+    logLevel: "error",
+    plugins: [
+      {
+        name: "fixture-css-candidates",
+        transform(source, id) {
+          if (!id.includes("node_modules") && /\.[tj]sx?$/.test(id)) {
+            for (const candidate of scanner.scanFiles([
+              { content: source, extension: "tsx" },
+            ]))
+              candidates.add(candidate);
+          }
+        },
+      },
+    ],
+    oxc: { jsx: { runtime: "automatic" } },
+    resolve: { alias: { "@": root } },
+    define: {
+      "process.env.NODE_ENV": JSON.stringify("production"),
+      "process.env": "{}",
+    },
+    build: {
+      outDir,
+      emptyOutDir: false,
+      lib: {
+        entry: path.join(root, "e2e/fixtures/location-switch.tsx"),
+        name: "Fixture",
+        formats: ["iife"],
+        fileName: () => "fixture.js",
+      },
+    },
+  });
+  script = fs.readFileSync(path.join(outDir, "fixture.js"), "utf8");
+  const { compile } = await import("tailwindcss");
+  const compiler = await compile(
+    fs
+      .readFileSync(path.join(root, "app/globals.css"), "utf8")
+      .replace(/^@source\s+[^;]+;\s*$/gm, ""),
+    {
+      base: path.join(root, "app"),
+      loadStylesheet: async (id, base) => {
+        const file =
+          id === "tailwindcss"
+            ? path.join(root, "node_modules/tailwindcss/index.css")
+            : id === "tw-animate-css"
+              ? path.join(
+                  root,
+                  "node_modules/tw-animate-css/dist/tw-animate.css",
+                )
+              : path.resolve(base, id);
+        return {
+          path: file,
+          base: path.dirname(file),
+          content: fs.readFileSync(file, "utf8"),
+        };
+      },
+    },
+  );
+  css = stripAppFontFaces(compiler.build([...candidates])) + productFontStyle();
+});
+
+async function expectThumbPosition(page: Page, checked: boolean) {
+  await expect(page.getByRole("switch")).toHaveAttribute(
+    "aria-checked",
+    String(checked),
+  );
+  await expect
+    .poll(async () =>
+      page.getByRole("switch").evaluate((el) => {
+        const track = el.getBoundingClientRect();
+        const thumb = el
+          .querySelector("[data-slot=switch-thumb]")!
+          .getBoundingClientRect();
+        return Math.round((thumb.left - track.left) / (track.width / 51));
+      }),
+    )
+    .toBe(checked ? 21 : 1);
+}
+
+// Inspect every animation frame: a settled screenshot alone misses the GSAP
+// transform being applied to the thumb during initial and deferred mounting.
+async function expectContainedDuringEnter(page: Page) {
+  const frames = await page.getByRole("switch").evaluate(async (el) => {
+    const result = [];
+    for (let i = 0; i < 24; i++) {
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve()),
+      );
+      const track = el.getBoundingClientRect();
+      const thumb = el.querySelector<HTMLElement>("[data-slot=switch-thumb]")!;
+      const box = thumb.getBoundingClientRect();
+      const scale = track.width / 51;
+      result.push({
+        top: (box.top - track.top) / scale,
+        bottom: (track.bottom - box.bottom) / scale,
+        left: (box.left - track.left) / scale,
+        right: (track.right - box.right) / scale,
+        transform: thumb.style.transform,
+      });
+    }
+    return result;
+  });
+  for (const frame of frames) {
+    expect(frame.transform).toBe("");
+    expect(frame.top).toBeCloseTo(2, 0);
+    expect(frame.bottom).toBeCloseTo(2, 0);
+    expect(frame.left).toBeGreaterThanOrEqual(0.9);
+    expect(frame.right).toBeGreaterThanOrEqual(0.9);
+  }
+}
+
+for (const width of [320, 393, 430, 1440]) {
+  for (const dark of [false, true]) {
+    test(`Location controls at ${width}px ${dark ? "dark" : "light"}`, async ({
+      page,
+    }, testInfo) => {
+      const errors: string[] = [];
+      page.on("pageerror", (error) => errors.push(error.message));
+      await page.setViewportSize({ width, height: 900 });
+      await page.setContent(
+        `<html class="${dark ? "dark" : ""}"><head><style>${css}</style></head><body data-initial="on"><div id="root"></div></body></html>`,
+      );
+      await page.addScriptTag({ content: script });
+      await expect(page.getByRole("switch")).toBeVisible();
+      await expect(page.locator("main")).toHaveAttribute(
+        "data-gsap-auto-fade-ready",
+        "1",
+      );
+      await expectContainedDuringEnter(page);
+      await expectThumbPosition(page, true);
+      for (const checked of [false, true, false, true]) {
+        await page.getByRole("switch").click();
+        await expectThumbPosition(page, checked);
+      }
+      // The MutationObserver must apply the same exclusion to deferred views.
+      await page.getByRole("button", { name: "Remount controls" }).click();
+      await expectContainedDuringEnter(page);
+      await expectThumbPosition(page, true);
+      await page.getByRole("switch").press("Space");
+      await expectThumbPosition(page, false);
+
+      const alignment = await page
+        .locator("[data-share-card]")
+        .evaluate((card) => {
+          const grid = card.querySelector("[role=group] > div")!;
+          const box = card.getBoundingClientRect();
+          return Math.abs(
+            grid.getBoundingClientRect().right -
+              (box.right - parseFloat(getComputedStyle(card).paddingRight)),
+          );
+        });
+      expect(alignment).toBeLessThanOrEqual(1);
+      await page.getByRole("button", { name: "1 hour", exact: true }).click();
+      await expect(
+        page.getByRole("button", { name: "1 hour", exact: true }),
+      ).toHaveAttribute("aria-pressed", "true");
+      expect(errors).toEqual([]);
+      await page.screenshot({
+        path: testInfo.outputPath("location-controls-off.png"),
+        style: "[data-fixture-tools] { visibility: hidden }",
+      });
+      await page.getByRole("switch").click();
+      await expectThumbPosition(page, true);
+      await page.screenshot({
+        path: testInfo.outputPath("location-controls-on.png"),
+        style: "[data-fixture-tools] { visibility: hidden }",
+      });
+    });
+  }
+}

--- a/hushh-webapp/lib/morphy-ux/README.md
+++ b/hushh-webapp/lib/morphy-ux/README.md
@@ -29,6 +29,11 @@ Those stay in:
 - `motion.ts`
 - `tokens/*`
 
+Page-entry animation excludes switch controls and their descendants on both
+initial and deferred mounts. Switches own their thumb movement; applying a GSAP
+transform on top of CSS translation can double the thumb's travel. Animate the
+surrounding section instead.
+
 ## Accent system (single switchable identity)
 
 All accent color flows through the `--app-accent-*` CSS family declared in

--- a/hushh-webapp/lib/morphy-ux/hooks/use-page-enter.ts
+++ b/hushh-webapp/lib/morphy-ux/hooks/use-page-enter.ts
@@ -13,6 +13,11 @@ const useIsoLayoutEffect =
 
 const AUTO_FADE_DATASET_KEY = "gsapAutoFadeReady";
 const AUTO_FADE_MAX_TARGETS = 140;
+// A switch owns the thumb's transform. GSAP can bake its CSS `translate`
+// into an inline transform, doubling the travel and leaving stale geometry
+// when checked changes. Animate its surrounding section, never the control.
+const AUTO_FADE_EXCLUDE_SELECTOR =
+  "[data-no-auto-fade='true'], [role='switch']";
 
 function collectFadeTargets(root: HTMLElement): HTMLElement[] {
   const candidates: HTMLElement[] = [root];
@@ -38,7 +43,7 @@ function collectFadeTargets(root: HTMLElement): HTMLElement[] {
     // A controlled pager is already animating its rail. Staggering every
     // mounted descendant while the user drags competes with that transform,
     // particularly in a native WebView.
-    if (node.closest("[data-no-auto-fade='true']")) continue;
+    if (node.closest(AUTO_FADE_EXCLUDE_SELECTOR)) continue;
     if (
       (node.dataset as Record<string, string | undefined>)[
         AUTO_FADE_DATASET_KEY
@@ -68,6 +73,7 @@ export function usePageEnterAnimation(
     if (prefersReducedMotion()) return;
     const el = ref.current;
     if (!el) return;
+    if (el.closest(AUTO_FADE_EXCLUDE_SELECTOR)) return;
 
     let revert: null | (() => void) = null;
     let observer: MutationObserver | null = null;
@@ -142,7 +148,7 @@ export function usePageEnterAnimation(
           for (const record of records) {
             for (const node of Array.from(record.addedNodes)) {
               if (!(node instanceof HTMLElement)) continue;
-              if (node.closest("[data-no-auto-fade='true']")) continue;
+              if (node.closest(AUTO_FADE_EXCLUDE_SELECTOR)) continue;
               for (const target of collectFadeTargets(node)) {
                 added.push(target);
                 if (added.length >= AUTO_FADE_MAX_TARGETS) break;

--- a/hushh-webapp/playwright.config.ts
+++ b/hushh-webapp/playwright.config.ts
@@ -73,7 +73,7 @@ export default defineConfig({
       // ships in. Its fixture builds its own shell, so the two known failures
       // above cannot reach it either.
       testMatch:
-        /(account-session-recovery|connect-sticky-header\.layout|circle-join-responsive-contract|circle-member-row\.layout|connect-circle-cta\.layout|location-cta-layout|active-share-actions\.layout|one-location-requests-sent-row\.layout|one-location-duration-ladder\.layout|gemini-endpoint-fields\.layout|feed-needs-you-row\.layout|one-location-tab-strip\.layout|one-location-ready-panel\.layout|one-location-map-consent-panel\.layout|one-location-flow-action-footer\.layout|app-shell-top-clearance\.layout|app-shell-bottom-clearance\.layout|save-location-sheet\.layout|one-location-check-in-panel\.layout)\.spec\.ts/,
+        /(account-session-recovery|connect-sticky-header\.layout|circle-join-responsive-contract|circle-member-row\.layout|connect-circle-cta\.layout|location-cta-layout|location-switch\.layout|active-share-actions\.layout|one-location-requests-sent-row\.layout|one-location-duration-ladder\.layout|gemini-endpoint-fields\.layout|feed-needs-you-row\.layout|one-location-tab-strip\.layout|one-location-ready-panel\.layout|one-location-map-consent-panel\.layout|one-location-flow-action-footer\.layout|app-shell-top-clearance\.layout|app-shell-bottom-clearance\.layout|save-location-sheet\.layout|one-location-check-in-panel\.layout)\.spec\.ts/,
     },
     {
       name: "firefox",


### PR DESCRIPTION
# Description
Fix intermittent Location switch thumb clipping and incorrect position: automatic page-entry GSAP animations were targeting the switch and thumb, baking CSS translation into an additional inline transform. Exclude switches and their descendants from initial and deferred auto-fade targets while preserving surrounding page animation and switch behavior.

Use full card-content width for temporary-link controls and the existing 2-by-2 share duration buttons on phones. At 640px and above, keep both groups compact at 280px and left-aligned with their labels; the Create link CTA matches its option group. Show nearby check-in search and categories immediately, remove the expansion step and accuracy notice, and preserve accuracy eligibility, permissions, stale-result guards and failure recovery.

## Impact Map (Required)
- Routes touched: `/one/location`, share confirmation, and its nearby check-in sheet; shared page-entry animation consumers.
- API / schema / type changes: None.
- Cache keys touched: None.
- Runtime DB data-plane changes: None.
- World-model domain summary effects: None.
- Mobile parity impacts: shared React UI used in iOS/Android WebViews; no native plugin changes.
- Docs updated: `hushh-webapp/docs/one-location-now-and-map.md`, `hushh-webapp/lib/morphy-ux/README.md`.
- Config: `hushh-webapp/playwright.config.ts` includes the real switch regression in the existing WebKit project.
- Trust boundary touched: None; check-in accuracy enforcement is retained.
- Caller / proxy / backend pairing: Not applicable, presentation changes only.
- Rollback: revert this commit; no migrations or environment changes.
- UI browser proof: production Switch, PageHeader, DurationPresetPicker and page-entry hook bundled with app CSS in `e2e/location-switch.layout.spec.ts`; existing `e2e/location-cta-layout.spec.ts` also verified.

## Review-Ready Contract
- [x] Title, body, diff and tests describe the same contract; related open PRs checked.
- [x] Reachable attach points: Location header, share duration picker, nearby check-in sheet; shared page-entry hook.
- [x] New browser regression imports real production components and hook, including deferred mounts. The regression fails against the original animation targeting and passes with the fix restored.
- [x] Maintainer edits enabled; single PR, no predecessor.
- Exact-head checks and mergeability will be rechecked before landing; commits are signed off.

## Tri-Flow Architecture Check
- Web: existing Next.js/React UI; no API changes.
- iOS: shared WebView UI, no Swift/plugin change. WebKit engine tested locally; physical iPhone not tested in this session.
- Android: shared WebView UI, no Kotlin/plugin change. Mobile Chromium tested locally; physical Android not tested in this session.

## Testing
- 45 Playwright checks passed: `CI=1 npx playwright test e2e/location-switch.layout.spec.ts e2e/location-cta-layout.spec.ts --project=chromium --project=webkit --project=mobile-chrome --reporter=line --workers=3 --retries=0`.
- Covers 320/393/430/1440px, light/dark, repeated on/off, keyboard interaction, initial/deferred animation frames, contained thumb geometry and responsive, left-aligned durations.
- 66 nearby check-in tests passed, including immediate filters, category/search behavior, coarse accuracy eligibility and recovery.
- 154 existing page-entry and Location page tests passed. Cache verification: 61 tests passed.
- Typecheck, changed-source ESLint, design-system, service-boundary, surface-map, frontend docs and `git diff --check` passed.
- DCO and exact-commit secret scan executed before push.
- Local aggregate CI could not complete: Windows launcher uses the WSL bash stub; direct Git Bash run reaches a shareable-link check that rejects pre-existing ignored `tmp` artifacts. Those unrelated artifacts were left untouched. Clean-checkout GitHub CI must pass before merging. Full native builds/device checks are not claimed.

## Screenshots / Video
Local component-fixture screenshots for mobile WebKit on and desktop Chromium off were shown in the task. The Playwright specs above reproduce on/off screenshots at all four widths using production CSS/components; this is browser component proof, not an authenticated device end-to-end claim.

## Privacy & Consent
No new collection, telemetry, storage, permissions or sending. Removing the explanatory accuracy notice does not remove location quality checks. Existing error paths and recovery remain covered by nearby check-in tests.

## Licensing
First-party changes remain Apache-2.0 compatible. No dependency changes.
