### PR TITLE
feat(connect): collapse connected roster

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -323,7 +323,7 @@ describe("Connect — People", () => {
     });
     expect(
       screen
-        .getByRole("heading", { name: "My connections (0)" })
+        .getByRole("button", { name: "My connections (0)" })
         .compareDocumentPosition(selector) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
@@ -341,6 +341,51 @@ describe("Connect — People", () => {
       ).toHaveLength(1);
     }
     await screen.findByText("Person 0");
+  });
+
+  it("keeps My connections collapsed until its disclosure pill is pressed", async () => {
+    mocks.listConnections.mockResolvedValue([
+      {
+        connectionId: "c-disclosure",
+        userId: "u-disclosure",
+        displayName: "Collapsed Friend",
+        photoUrl: null,
+      },
+    ]);
+
+    render(<ConnectPageClient />);
+
+    const toggle = await screen.findByRole("button", {
+      name: "My connections (1)",
+    });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(toggle).toHaveAttribute(
+      "aria-controls",
+      "connect-my-connections-panel",
+    );
+    expect(
+      screen.queryByRole("button", {
+        name: "Remove connection with Collapsed Friend",
+      }),
+    ).toBeNull();
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(
+      await screen.findByRole("button", {
+        name: "Remove connection with Collapsed Friend",
+      }),
+    ).toBeTruthy();
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByRole("button", {
+        name: "Remove connection with Collapsed Friend",
+      }),
+    ).toBeNull();
   });
 
   it("discards a late append after a new search starts", async () => {
@@ -454,6 +499,9 @@ describe("Connect — People", () => {
     const myConnections = await screen.findByTestId(
       "connect-my-connections-group",
     );
+    fireEvent.click(
+      screen.getByRole("button", { name: "My connections (1)" }),
+    );
     const connectionName =
       await within(myConnections).findByText("Scoped Friend");
     const connectionAction = connectionName.closest("button");
@@ -510,7 +558,10 @@ describe("Connect — People", () => {
 
     render(<ConnectPageClient />);
 
-    expect(await screen.findByText("My connections (5000)")).toBeTruthy();
+    const connectionsToggle = await screen.findByRole("button", {
+      name: "My connections (5000)",
+    });
+    fireEvent.click(connectionsToggle);
     fireEvent.click(
       screen.getByRole("button", { name: "Load more connections" }),
     );
@@ -595,6 +646,9 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
 
     expect(await screen.findByText("Current Person")).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "My connections (3)" }),
+    );
     fireEvent.click(
       screen.getByRole("button", { name: "Load more connections" }),
     );
@@ -705,22 +759,17 @@ describe("Connect — People", () => {
     expect(await screen.findByText("Current Person")).toBeTruthy();
     expect(mocks.listConnectionsPage).toHaveBeenCalledTimes(1);
 
-    // Refresh is a control, not part of the heading text. It used to be a
-    // child of the `title` node, which SettingsGroup renders inside an element
-    // carrying `role="heading"` -- a button there is folded into the heading's
-    // accessible name and is never offered as something to press. The two
-    // assertions below are what keep it out: the heading's name is the plain
-    // text, and the button is not a descendant of it.
-    const connectionsHeading = screen
-      .getAllByRole("heading")
-      .find((node) => node.textContent?.includes("connections"));
-    expect(connectionsHeading).toBeTruthy();
+    // The disclosure and refresh controls are siblings. This prevents an
+    // interactive refresh button from being folded into the disclosure's
+    // accessible name.
+    const connectionsDisclosure = screen.getByRole("button", {
+      name: "My connections (1)",
+    });
     expect(
-      connectionsHeading?.contains(
+      connectionsDisclosure.contains(
         screen.getByRole("button", { name: "Refresh contacts" }),
       ),
     ).toBe(false);
-    expect(connectionsHeading?.textContent).not.toContain("Refresh");
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh contacts" }));
 
@@ -826,6 +875,9 @@ describe("Connect — People", () => {
     render(<ConnectPageClient />);
 
     expect(await screen.findByText("First Person")).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "My connections (2)" }),
+    );
     fireEvent.click(
       screen.getByRole("button", { name: "Load more connections" }),
     );

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -558,6 +558,7 @@ export default function ConnectPageClient() {
   const [connectionsPage, setConnectionsPage] = useState(1);
   const [connectionsHasMore, setConnectionsHasMore] = useState(false);
   const [connectionsTotalCount, setConnectionsTotalCount] = useState(0);
+  const [connectionsExpanded, setConnectionsExpanded] = useState(false);
   const [connectionsLoadingMore, setConnectionsLoadingMore] = useState(false);
   const [connectionsRefreshingFirstPage, setConnectionsRefreshingFirstPage] =
     useState(false);
@@ -744,7 +745,11 @@ export default function ConnectPageClient() {
           setConnectionsHasMore(true);
           setConnectionsTotalCount((current) => Math.max(0, current - 1));
         }
-        if (!result) setConnectionsRefreshError(true);
+        if (!result) {
+          setConnectionsRefreshError(true);
+          // A collapsed panel must not conceal its only retry affordance.
+          setConnectionsExpanded(true);
+        }
         return true;
       } finally {
         if (connectionsFirstPageRequestRef.current === requestId) {
@@ -2406,18 +2411,34 @@ export default function ConnectPageClient() {
                       ) : (
                         <div className="space-y-3 sm:space-y-4">
                           <SettingsGroup
-                            title={
-                              <span className={CONNECT_WRAPPING_TEXT_CLASSNAME}>
-                                {connectionsHeading}
-                              </span>
+                            titleControl={
+                              <Button
+                                type="button"
+                                variant="none"
+                                effect="fade"
+                                aria-controls="connect-my-connections-panel"
+                                aria-expanded={connectionsExpanded}
+                                onClick={() =>
+                                  setConnectionsExpanded((expanded) => !expanded)
+                                }
+                                data-testid="connect-my-connections-toggle"
+                                className="group h-11 min-h-11 max-w-full rounded-full border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-secondary-fill)] px-3 text-[14px] font-semibold text-[color:var(--app-label)] shadow-none hover:bg-[color:var(--app-tertiary-fill)] focus-visible:ring-2 focus-visible:ring-[color:var(--app-accent)] focus-visible:ring-offset-2"
+                              >
+                                <span className={CONNECT_WRAPPING_TEXT_CLASSNAME}>
+                                  {connectionsHeading}
+                                </span>
+                                <ChevronDown
+                                  aria-hidden="true"
+                                  className={cn(
+                                    "ml-1.5 h-4 w-4 shrink-0 transition-transform duration-200",
+                                    connectionsExpanded && "rotate-180",
+                                  )}
+                                />
+                              </Button>
                             }
-                            // Refresh sits in `titleAction`, not inside `title`. It used
-                            // to be a child of the title node, which `SettingsGroup`
-                            // renders inside an element carrying `role="heading"` -- and
-                            // a control there is not a control. A screen reader folds its
-                            // label into the heading's accessible name, so the heading
-                            // announced as "Your connections Refresh contacts", and the
-                            // button itself was never offered as something to press.
+                            // Refresh stays beside the disclosure, never inside it: nested
+                            // controls are invalid and would make one of the two actions
+                            // unreachable to keyboard and assistive-technology users.
                             titleAction={
                               <Button
                                 type="button"
@@ -2442,6 +2463,10 @@ export default function ConnectPageClient() {
                               </Button>
                             }
                             separatorInset
+                            contentId="connect-my-connections-panel"
+                            shellClassName={cn(
+                              !connectionsExpanded && "hidden",
+                            )}
                             contentClassName={
                               sortedConnections.length > 0
                                 ? CONNECT_CONNECTION_LIST_CLASSNAME


### PR DESCRIPTION
## Description

Collapses the connected roster on /one/connect behind a compact My connections (n) disclosure pill. The pill has an explicit chevron, keyboard-accessible expanded state, and reveals the existing roster without changing its loading, refresh, removal, pagination, or audience filtering behavior.

A failed roster refresh opens the disclosure so its existing retry action cannot be concealed.

## Impact Map

- Routes touched: /one/connect (web UI only)
- API / schema / type changes: None
- Cache keys / runtime DB data-plane / trust boundary: None
- Mobile parity: Not applicable; this is a web-only presentation state in the Next.js Connect page.
- Docs / config / generated files: None
- Rollback / safe failure: Collapse can be toggled off at any time; refresh failure expands the panel and preserves the existing retry path.
- Production attach point: hushh-webapp/app/connect/page-client.tsx
- Tests: Added production-page coverage for collapsed default, accessible control wiring, and reveal/hide interaction. Updated affected roster-action tests to open the disclosure before interacting.

## Verification

- Passed: ./bin/hushh docs verify
- Passed: git diff --check
- Blocked locally: frontend tests and typecheck cannot start because this workstation's npm CLI installation is missing C:\Users\parth\AppData\Roaming\npm\node_modules\npm\bin\npm-cli.js; no dependencies were installed or changed.
- Browser proof: Browser plugin/runtime is unavailable locally, so no rendered screenshot was produced. CI should run the normal web checks on this PR head.

## Tri-Flow

- Web: implemented in the reachable Next.js Connect client.
- iOS / Android: not applicable; no shared API, schema, Capacitor plugin, or native behavior changed.

## Review-ready contract

- Title, body, changed files, and focused test all describe the same Connect roster disclosure.
- Current base: main
- DCO signoff: included in commit a7c14fde8
- Maintainer edits: enabled