### PR TITLE
test(connect): assert collapsed roster shell

### DIFF
--- a/hushh-webapp/__tests__/app/connect/page-client.test.tsx
+++ b/hushh-webapp/__tests__/app/connect/page-client.test.tsx
@@ -363,15 +363,20 @@ describe("Connect — People", () => {
       "aria-controls",
       "connect-my-connections-panel",
     );
+    const panel = document.getElementById(
+      "connect-my-connections-panel",
+    );
+    expect(panel).toBeTruthy();
     expect(
-      screen.queryByRole("button", {
-        name: "Remove connection with Collapsed Friend",
-      }),
-    ).toBeNull();
+      panel?.closest('[data-slot="settings-group-shell"]'),
+    ).toHaveClass("hidden");
 
     fireEvent.click(toggle);
 
     expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(
+      panel?.closest('[data-slot="settings-group-shell"]'),
+    ).not.toHaveClass("hidden");
     expect(
       await screen.findByRole("button", {
         name: "Remove connection with Collapsed Friend",
@@ -382,10 +387,8 @@ describe("Connect — People", () => {
 
     expect(toggle).toHaveAttribute("aria-expanded", "false");
     expect(
-      screen.queryByRole("button", {
-        name: "Remove connection with Collapsed Friend",
-      }),
-    ).toBeNull();
+      panel?.closest('[data-slot="settings-group-shell"]'),
+    ).toHaveClass("hidden");
   });
 
   it("discards a late append after a new search starts", async () => {


### PR DESCRIPTION
## Description

Repairs the Connect disclosure test that failed after #6706 merged. The UI already uses Tailwind's hidden shell correctly in a browser; JSDOM does not apply that CSS when computing accessible roles. The test now verifies the generated shell class and the disclosure's ARIA state instead of incorrectly treating the hidden class as DOM removal.

## Impact

- Routes, APIs, schemas, cache, runtime DB, trust boundaries: None
- Production behavior: None; test-only correction
- Production attach point covered: hushh-webapp/app/connect/page-client.tsx
- UAT relevance: clears the exact post-merge gate required before #6706's merged UI can be selected for deployment.

## Verification

- Passed: git diff --check
- Local test runner remains unavailable because this workstation's npm CLI module is missing.
- CI: Web Targeted Contracts on #6706 identified this single assertion mismatch; this PR directly corrects it.
- DCO signoff: e45ba389d