### PR TITLE
fix(vault): separate write protocol from app version

### DIFF
--- a/hushh-webapp/.env.example
+++ b/hushh-webapp/.env.example
@@ -47,6 +47,8 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # CAPACITOR_BUILD is set by npm run cap:build
 NEXT_PUBLIC_APP_ENV=development
 NEXT_PUBLIC_CLIENT_VERSION=1.1.0
+# Vault wrapper protocol compatibility. This is not the app/analytics version.
+NEXT_PUBLIC_VAULT_WRITE_PROTOCOL_VERSION=2.0.0
 # NODE_ENV is set by Next.js
 
 # ============================================================================

--- a/hushh-webapp/__tests__/api/vault-write-protocol.test.ts
+++ b/hushh-webapp/__tests__/api/vault-write-protocol.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { forwardVaultBackendError } from "@/app/api/vault/_utils/backend-error";
+import { VAULT_WRITE_PROTOCOL_VERSION } from "@/lib/vault/write-protocol-version";
+
+describe("vault write protocol compatibility", () => {
+  it("keeps the vault protocol independent from the app release version", () => {
+    expect(VAULT_WRITE_PROTOCOL_VERSION).toBe("2.0.0");
+  });
+
+  it("preserves a structured upgrade error for the vault service", async () => {
+    const response = await forwardVaultBackendError(
+      new Response(
+        JSON.stringify({
+          detail: {
+            error: "Client upgrade required",
+            code: "CLIENT_UPGRADE_REQUIRED",
+            minimum_version: "2.0.0",
+          },
+        }),
+        { status: 426 },
+      ),
+    );
+
+    expect(response.status).toBe(426);
+    await expect(response.json()).resolves.toEqual({
+      detail: {
+        error: "Client upgrade required",
+        code: "CLIENT_UPGRADE_REQUIRED",
+        minimum_version: "2.0.0",
+      },
+    });
+  });
+});

--- a/hushh-webapp/app/api/vault/_utils/backend-error.ts
+++ b/hushh-webapp/app/api/vault/_utils/backend-error.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Keep the backend error shape intact so the service layer can extract its
+ * machine-readable code and user-facing message. Wrapping JSON in `error`
+ * turns a structured 426 into a raw JSON toast in the Vault flow.
+ */
+export async function forwardVaultBackendError(
+  response: Response,
+): Promise<NextResponse> {
+  const raw = await response.text();
+  if (!raw) {
+    return NextResponse.json({ error: "Backend error" }, { status: response.status });
+  }
+
+  try {
+    const payload: unknown = JSON.parse(raw);
+    if (isJsonObject(payload)) {
+      return NextResponse.json(payload, { status: response.status });
+    }
+  } catch {
+    // Preserve a non-JSON backend error as text below.
+  }
+
+  return NextResponse.json({ error: raw }, { status: response.status });
+}

--- a/hushh-webapp/app/api/vault/primary/set/route.ts
+++ b/hushh-webapp/app/api/vault/primary/set/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
+import { forwardVaultBackendError } from "@/app/api/vault/_utils/backend-error";
 import { validateFirebaseToken } from "@/lib/auth/validate";
 import { isDevelopment } from "@/lib/config";
+import { VAULT_WRITE_PROTOCOL_VERSION } from "@/lib/vault/write-protocol-version";
 
 export const dynamic = "force-dynamic";
 
@@ -35,28 +37,23 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const clientVersion =
+    const vaultWriteProtocolVersion =
       request.headers.get("x-hushh-client-version") ||
       request.headers.get("x-client-version") ||
-      process.env.NEXT_PUBLIC_CLIENT_VERSION ||
-      "2.0.0";
+      VAULT_WRITE_PROTOCOL_VERSION;
 
     const response = await fetch(`${PYTHON_API_URL}/db/vault/primary/set`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "x-hushh-client-version": clientVersion,
+        "x-hushh-client-version": vaultWriteProtocolVersion,
         ...(authHeader ? { Authorization: authHeader } : {}),
       },
       body: JSON.stringify({ userId, primaryMethod, primaryWrapperId }),
     });
 
     if (!response.ok) {
-      const errorText = await response.text();
-      return NextResponse.json(
-        { error: errorText || "Backend error" },
-        { status: response.status }
-      );
+      return forwardVaultBackendError(response);
     }
 
     const result = await response.json();

--- a/hushh-webapp/app/api/vault/setup/route.ts
+++ b/hushh-webapp/app/api/vault/setup/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
+import { forwardVaultBackendError } from "@/app/api/vault/_utils/backend-error";
 import {
   invalidJsonPayloadResponse,
   readJsonObject,
 } from "@/app/api/_utils/json-body";
 import { validateFirebaseToken } from "@/lib/auth/validate";
 import { isDevelopment, logSecurityEvent } from "@/lib/config";
+import { VAULT_WRITE_PROTOCOL_VERSION } from "@/lib/vault/write-protocol-version";
 
 export const dynamic = "force-dynamic";
 
@@ -86,17 +88,16 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const clientVersion =
+    const vaultWriteProtocolVersion =
       request.headers.get("x-hushh-client-version") ||
       request.headers.get("x-client-version") ||
-      process.env.NEXT_PUBLIC_CLIENT_VERSION ||
-      "2.0.0";
+      VAULT_WRITE_PROTOCOL_VERSION;
 
     const response = await fetch(`${PYTHON_API_URL}/db/vault/setup`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "x-hushh-client-version": clientVersion,
+        "x-hushh-client-version": vaultWriteProtocolVersion,
         ...(authHeader ? { Authorization: authHeader } : {}),
       },
       body: JSON.stringify({
@@ -112,11 +113,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      const errorText = await response.text();
-      return NextResponse.json(
-        { error: errorText || "Backend error" },
-        { status: response.status },
-      );
+      return forwardVaultBackendError(response);
     }
 
     const result = await response.json();

--- a/hushh-webapp/app/api/vault/wrapper/delete/route.ts
+++ b/hushh-webapp/app/api/vault/wrapper/delete/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
+import { forwardVaultBackendError } from "@/app/api/vault/_utils/backend-error";
 import { validateFirebaseToken } from "@/lib/auth/validate";
 import { isDevelopment } from "@/lib/config";
+import { VAULT_WRITE_PROTOCOL_VERSION } from "@/lib/vault/write-protocol-version";
 
 export const dynamic = "force-dynamic";
 
@@ -59,17 +61,16 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const clientVersion =
+    const vaultWriteProtocolVersion =
       request.headers.get("x-hushh-client-version") ||
       request.headers.get("x-client-version") ||
-      process.env.NEXT_PUBLIC_CLIENT_VERSION ||
-      "2.0.0";
+      VAULT_WRITE_PROTOCOL_VERSION;
 
     const response = await fetch(`${PYTHON_API_URL}/db/vault/wrapper/delete`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "x-hushh-client-version": clientVersion,
+        "x-hushh-client-version": vaultWriteProtocolVersion,
         "X-Hushh-Consent": normalizedVaultOwnerHeader,
         ...(authHeader ? { Authorization: authHeader } : {}),
       },
@@ -84,10 +85,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      const errorPayload = await response
-        .json()
-        .catch(async () => ({ error: await response.text().catch(() => "") }));
-      return NextResponse.json(errorPayload, { status: response.status });
+      return forwardVaultBackendError(response);
     }
 
     const result = await response.json();

--- a/hushh-webapp/app/api/vault/wrapper/upsert/route.ts
+++ b/hushh-webapp/app/api/vault/wrapper/upsert/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
+import { forwardVaultBackendError } from "@/app/api/vault/_utils/backend-error";
 import { validateFirebaseToken } from "@/lib/auth/validate";
 import { isDevelopment } from "@/lib/config";
+import { VAULT_WRITE_PROTOCOL_VERSION } from "@/lib/vault/write-protocol-version";
 
 export const dynamic = "force-dynamic";
 
@@ -59,17 +61,16 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const clientVersion =
+    const vaultWriteProtocolVersion =
       request.headers.get("x-hushh-client-version") ||
       request.headers.get("x-client-version") ||
-      process.env.NEXT_PUBLIC_CLIENT_VERSION ||
-      "2.0.0";
+      VAULT_WRITE_PROTOCOL_VERSION;
 
     const response = await fetch(`${PYTHON_API_URL}/db/vault/wrapper/upsert`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "x-hushh-client-version": clientVersion,
+        "x-hushh-client-version": vaultWriteProtocolVersion,
         ...(authHeader ? { Authorization: authHeader } : {}),
       },
       body: JSON.stringify({
@@ -90,11 +91,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      const errorText = await response.text();
-      return NextResponse.json(
-        { error: errorText || "Backend error" },
-        { status: response.status }
-      );
+      return forwardVaultBackendError(response);
     }
 
     const result = await response.json();

--- a/hushh-webapp/lib/services/vault-service.ts
+++ b/hushh-webapp/lib/services/vault-service.ts
@@ -14,6 +14,7 @@ import {
   isPasskeyRpIdCompatibleWithHost,
   resolvePasskeyRpId,
 } from "@/lib/vault/passkey-rp";
+import { VAULT_WRITE_PROTOCOL_VERSION } from "@/lib/vault/write-protocol-version";
 import { auth } from "@/lib/firebase/config";
 import { apiJson } from "@/lib/services/api-client";
 import {
@@ -1345,8 +1346,7 @@ export class VaultService {
       const authToken = await this.getFirebaseToken();
       const headers: HeadersInit = {
         "Content-Type": "application/json",
-        "x-hushh-client-version":
-          process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
+        "x-hushh-client-version": VAULT_WRITE_PROTOCOL_VERSION,
       };
       if (authToken) {
         headers.Authorization = `Bearer ${authToken}`;
@@ -1419,8 +1419,7 @@ export class VaultService {
         const authToken = await this.getFirebaseToken();
         const headers: HeadersInit = {
           "Content-Type": "application/json",
-          "x-hushh-client-version":
-            process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
+          "x-hushh-client-version": VAULT_WRITE_PROTOCOL_VERSION,
         };
         if (authToken) headers.Authorization = `Bearer ${authToken}`;
 
@@ -1504,8 +1503,7 @@ export class VaultService {
         const authToken = await this.getFirebaseToken();
         const headers: HeadersInit = {
           "Content-Type": "application/json",
-          "x-hushh-client-version":
-            process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
+          "x-hushh-client-version": VAULT_WRITE_PROTOCOL_VERSION,
         };
         if (authToken) headers.Authorization = `Bearer ${authToken}`;
         headers["X-Hushh-Consent"] = `Bearer ${params.vaultOwnerToken}`;
@@ -1565,8 +1563,7 @@ export class VaultService {
         const authToken = await this.getFirebaseToken();
         const headers: HeadersInit = {
           "Content-Type": "application/json",
-          "x-hushh-client-version":
-            process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
+          "x-hushh-client-version": VAULT_WRITE_PROTOCOL_VERSION,
         };
         if (authToken) headers.Authorization = `Bearer ${authToken}`;
 

--- a/hushh-webapp/lib/vault/write-protocol-version.ts
+++ b/hushh-webapp/lib/vault/write-protocol-version.ts
@@ -1,0 +1,4 @@
+/** Compatibility level for vault writes, independent of the app release version. */
+export const VAULT_WRITE_PROTOCOL_VERSION =
+  String(process.env.NEXT_PUBLIC_VAULT_WRITE_PROTOCOL_VERSION || "").trim() ||
+  "2.0.0";

--- a/hushh-webapp/next.config.capacitor.ts
+++ b/hushh-webapp/next.config.capacitor.ts
@@ -27,10 +27,14 @@ const clientVersion =
   String(process.env.NEXT_PUBLIC_CLIENT_VERSION || "").trim() ||
   String(packageJson.version || "").trim() ||
   "unknown";
+const vaultWriteProtocolVersion =
+  String(process.env.NEXT_PUBLIC_VAULT_WRITE_PROTOCOL_VERSION || "").trim() ||
+  "2.0.0";
 
 const capacitorConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_CLIENT_VERSION: clientVersion,
+    NEXT_PUBLIC_VAULT_WRITE_PROTOCOL_VERSION: vaultWriteProtocolVersion,
   },
 
   // Keep file tracing and workspace discovery scoped to this monorepo.

--- a/hushh-webapp/next.config.ts
+++ b/hushh-webapp/next.config.ts
@@ -33,10 +33,14 @@ const clientVersion =
   String(process.env.NEXT_PUBLIC_CLIENT_VERSION || "").trim() ||
   String(packageJson.version || "").trim() ||
   "unknown";
+const vaultWriteProtocolVersion =
+  String(process.env.NEXT_PUBLIC_VAULT_WRITE_PROTOCOL_VERSION || "").trim() ||
+  "2.0.0";
 
 const config: NextConfig = {
   env: {
     NEXT_PUBLIC_CLIENT_VERSION: clientVersion,
+    NEXT_PUBLIC_VAULT_WRITE_PROTOCOL_VERSION: vaultWriteProtocolVersion,
   },
 
   // Native static exports may run while the local web dev server is active.


### PR DESCRIPTION
## Summary
- keep the web app/analytics release version at 1.1.0 while declaring vault wrapper protocol v2 separately
- preserve structured vault backend errors through every web write proxy
- add focused protocol and error-forwarding coverage

## Verification
- git diff --check passed
- 
pm run typecheck could not run locally because the machine's npm launcher is missing its global npm CLI path