### PR TITLE
fix(profile): distinguish Gmail and work account icons

### DIFF
--- a/hushh-webapp/__tests__/app/profile/profile-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/app/profile/profile-layout.contract.test.ts
@@ -57,7 +57,7 @@ describe("Profile canonical page layout", () => {
     );
   });
 
-  it("uses the original Google mark and semantic icon tones", () => {
+  it("uses the Google mark only for personal Gmail and the work icon otherwise", () => {
     const source = readFileSync(
       join(process.cwd(), "app/profile/profile-workspace-page.tsx"),
       "utf8",
@@ -71,8 +71,16 @@ describe("Profile canonical page layout", () => {
     expect(source).toContain(
       'import { AppleIcon, GoogleIcon } from "@/lib/morphy-ux/social-icons";',
     );
+    expect(source).toContain("BriefcaseBusiness,");
+    expect(source).toContain("shouldUseGoogleBrandMark(providerId, email)");
     expect(source).toContain(
       'return <GoogleIcon className="shrink-0" size={17} />;',
+    );
+    expect(source).toContain(
+      '<Icon icon={BriefcaseBusiness} size="xs" className="shrink-0" />',
+    );
+    expect(source).toContain(
+      '<ProviderIcon providerId={provider.id} email={user.email} />',
     );
     for (const brandColor of ["#4285F4", "#34A853", "#FBBC05", "#EA4335"]) {
       expect(socialIcons).toContain(brandColor);

--- a/hushh-webapp/__tests__/lib/profile/profile-auth-provider-presentation.test.ts
+++ b/hushh-webapp/__tests__/lib/profile/profile-auth-provider-presentation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isPersonalGmailEmail,
+  shouldUseGoogleBrandMark,
+} from "@/lib/profile/profile-auth-provider-presentation";
+
+describe("Profile auth-provider presentation", () => {
+  it("recognizes Gmail's consumer domains regardless of casing or whitespace", () => {
+    expect(isPersonalGmailEmail("  person@gmail.com ")).toBe(true);
+    expect(isPersonalGmailEmail("person@GOOGLEMAIL.COM")).toBe(true);
+  });
+
+  it("keeps the Google brand mark for personal Gmail Google sign-ins only", () => {
+    expect(shouldUseGoogleBrandMark("google", "person@gmail.com")).toBe(true);
+    expect(shouldUseGoogleBrandMark("google.com", "person@googlemail.com")).toBe(
+      true,
+    );
+    expect(shouldUseGoogleBrandMark("google", "person@hushh.ai")).toBe(false);
+    expect(shouldUseGoogleBrandMark("google", "person@example.com")).toBe(false);
+    expect(shouldUseGoogleBrandMark("apple", "person@gmail.com")).toBe(false);
+  });
+
+  it("fails closed to the work-profile presentation for missing or malformed email", () => {
+    expect(shouldUseGoogleBrandMark("google", null)).toBe(false);
+    expect(shouldUseGoogleBrandMark("google", "not-an-email")).toBe(false);
+  });
+});

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -11,6 +11,7 @@ import {
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   AlertTriangle,
+  BriefcaseBusiness,
   CodeXml,
   ContactRound,
   ExternalLink,
@@ -137,6 +138,7 @@ import { Icon } from "@/lib/morphy-ux/ui";
 import { SegmentedTabs } from "@/lib/morphy-ux/ui";
 import { Button, morphyToast } from "@/lib/morphy-ux/morphy";
 import { AppleIcon, GoogleIcon } from "@/lib/morphy-ux/social-icons";
+import { shouldUseGoogleBrandMark } from "@/lib/profile/profile-auth-provider-presentation";
 import { useScrollReset } from "@/lib/navigation/use-scroll-reset";
 import { cn } from "@/lib/utils";
 import { AccountService } from "@/lib/services/account-service";
@@ -428,9 +430,19 @@ function getProvider(user: ReturnType<typeof useAuth>["user"]) {
   }
 }
 
-function ProviderIcon({ providerId }: { providerId: string }) {
+function ProviderIcon({
+  providerId,
+  email,
+}: {
+  providerId: string;
+  email: string | null | undefined;
+}) {
   if (providerId === "google") {
-    return <GoogleIcon className="shrink-0" size={17} />;
+    if (shouldUseGoogleBrandMark(providerId, email)) {
+      return <GoogleIcon className="shrink-0" size={17} />;
+    }
+
+    return <Icon icon={BriefcaseBusiness} size="xs" className="shrink-0" />;
   }
 
   if (providerId === "apple") {
@@ -3345,7 +3357,7 @@ function ProfilePageContent() {
         <SettingsRow
           leading={
             <span className="profile-account-provider-icon inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg">
-              <ProviderIcon providerId={provider.id} />
+              <ProviderIcon providerId={provider.id} email={user.email} />
             </span>
           }
           title="Sign-in provider"
@@ -4403,7 +4415,7 @@ function ProfilePageContent() {
               className="profile-home-meta flex w-full min-w-0 items-center justify-start gap-1.5 text-xs font-normal text-muted-foreground"
               title={provider.name}
             >
-              <ProviderIcon providerId={provider.id} />
+              <ProviderIcon providerId={provider.id} email={user.email} />
               <span className="[overflow-wrap:anywhere]">
                 {user.email || "Not available"}
               </span>

--- a/hushh-webapp/lib/profile/profile-auth-provider-presentation.ts
+++ b/hushh-webapp/lib/profile/profile-auth-provider-presentation.ts
@@ -1,0 +1,28 @@
+/**
+ * Gmail's branded mark is reserved for consumer Gmail addresses. A Google
+ * Workspace address authenticates through the same Google provider, but its
+ * profile identity represents a work account instead.
+ */
+const PERSONAL_GMAIL_DOMAINS = new Set(["gmail.com", "googlemail.com"]);
+
+export function isPersonalGmailEmail(
+  email: string | null | undefined,
+): boolean {
+  const normalized = email?.trim().toLowerCase();
+  if (!normalized) return false;
+
+  const separatorIndex = normalized.lastIndexOf("@");
+  if (separatorIndex <= 0) return false;
+
+  return PERSONAL_GMAIL_DOMAINS.has(normalized.slice(separatorIndex + 1));
+}
+
+export function shouldUseGoogleBrandMark(
+  providerId: string | null | undefined,
+  email: string | null | undefined,
+): boolean {
+  return (
+    (providerId === "google" || providerId === "google.com") &&
+    isPersonalGmailEmail(email)
+  );
+}


### PR DESCRIPTION
## Description

Profile now shows the original multicolor Google “G” only for personal Gmail addresses authenticated through Google. Google-authenticated custom-domain addresses now show the existing work-profile icon beside the email and in the Account sign-in-provider row.

## Scope

- Personal Gmail: `@gmail.com` and `@googlemail.com`
- Work/custom-domain Google account: work-profile icon
- Apple and email/password providers: unchanged
- API, persistence, permissions, and native code: unchanged
- UAT: intentionally not deployed at the requester’s direction

## Validation

- Focused Profile tests: 8 passed
- Cache checks: 61 passed
- TypeScript, changed-source ESLint, design-system, docs, and diff hygiene passed

