### PR TITLE
fix(ci): preserve TestFlight readiness evidence

### DIFF
--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -259,15 +259,36 @@ jobs:
           python3 scripts/ci/test_ios_uat_passkey_config.py
 
       - name: Verify UAT local voice packs match this release
+        if: always()
         shell: bash
         env:
           EXPECTED_SHA: ${{ needs.preflight.outputs.release_sha }}
         run: |
           set -euo pipefail
-          uv run python scripts/ci/verify-one-voice-local-runtime-readiness.py \
-            --backend-url "$NEXT_PUBLIC_BACKEND_URL" \
-            --source-sha "$EXPECTED_SHA" \
-            > "$RUNNER_TEMP/one-voice-local-runtime-readiness.json"
+          output="$RUNNER_TEMP/one-voice-local-runtime-readiness.json"
+          temporary_output="${output}.tmp"
+          rm -f "$output" "$temporary_output"
+
+          verification_status=1
+          if [[ -n "${NEXT_PUBLIC_BACKEND_URL:-}" ]] && \
+            uv run python scripts/ci/verify-one-voice-local-runtime-readiness.py \
+              --backend-url "$NEXT_PUBLIC_BACKEND_URL" \
+              --source-sha "$EXPECTED_SHA" \
+              > "$temporary_output" && \
+            test -s "$temporary_output"; then
+            if mv "$temporary_output" "$output"; then
+              exit 0
+            fi
+          else
+            verification_status=$?
+          fi
+
+          # Keep the release failure fail-closed while preserving a redacted,
+          # machine-readable evidence record for the always-run uploader.
+          printf '{"status":"failed","source_sha":"%s","reason":"UAT local voice readiness verification did not complete"}\n' \
+            "$EXPECTED_SHA" > "$output"
+          rm -f "$temporary_output"
+          exit "$verification_status"
 
       - name: Prepare UAT native project
         shell: bash


### PR DESCRIPTION
## Summary
- Always produce the One Voice local-runtime readiness evidence at the runner temp path before the required artifact upload.
- Preserve fail-closed verification semantics and the existing required artifact upload.

## Validation
- Workflow YAML syntax validated.
- Readiness and TestFlight distribution focused checks passed locally.
- Exact head commit: 86840aa1777495ca6ca525f8433dbd54be60c877

No UAT deployment or TestFlight workflow was run.