### PR TITLE
fix(agent-bar): hover fill follows each half of the split launcher

### DIFF
--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -80,7 +80,7 @@ describe("Navbar bottom chrome contract", () => {
     expect(agentBar).toContain("hover:bg-current/[0.09]");
     expect(agentBar).toContain("focus-visible:ring-inset");
     expect(agentBar).toContain(
-      'className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-full"',
+      'className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]"',
     );
     expect(agentBar).toContain("min-w-[88px]");
     expect(agentBar).toContain("MessageCircle");
@@ -173,5 +173,34 @@ describe("Navbar bottom chrome contract", () => {
     expect(providers).toContain(
       "!pinnedBottomChrome &&\n      !bottomChromeHidden",
     );
+  });
+
+  it("clips each ripple to its own button's radius, not a hardcoded pill", () => {
+    // The idle launcher is two halves of ONE pill: the voice half is
+    // rounded-l-full/rounded-r-none and the chat half is the mirror.
+    // MaterialRipple already inherits its clip -- the host sets
+    // `borderRadius: "inherit"` -- but each call site wrapped it in a span that
+    // hardcoded `rounded-full`. The ripple inherited a FULL pill from that span
+    // while sitting on a HALF-pill button, so the hover fill curved away from
+    // the divider and left a visible gap on the flat side. The selection read
+    // as a floating pill rather than the half a person was pointing at.
+    //
+    // `rounded-[inherit]` is byte-identical in effect on the three genuinely
+    // round buttons and correct on the two halves, which is why this guard
+    // covers every wrapper instead of only the two that were visibly wrong: the
+    // defect is the hardcoded radius, not the two places it happened to show.
+    const agentBar = read("components/agent/agent-bar.tsx");
+
+    const clips = [
+      ...agentBar.matchAll(
+        /className="pointer-events-none absolute inset-0[^"]*overflow-hidden ([^"]*)"/g,
+      ),
+    ].map((match) => match[1]!);
+
+    expect(clips.length).toBeGreaterThan(0);
+    for (const clip of clips) {
+      expect(clip).toContain("rounded-[inherit]");
+      expect(clip).not.toMatch(/\brounded-full\b/);
+    }
   });
 });

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -2652,7 +2652,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       )}
       <span
         aria-hidden
-        className="pointer-events-none absolute inset-0 overflow-hidden rounded-full"
+        className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]"
       >
         <MaterialRipple variant="gradient" effect="fill" />
       </span>
@@ -2678,7 +2678,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
       />
       <span
         aria-hidden
-        className="pointer-events-none absolute inset-0 overflow-hidden rounded-full"
+        className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]"
       >
         <MaterialRipple variant="gradient" effect="fill" />
       </span>
@@ -2729,7 +2729,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
         />
         <span
           aria-hidden
-          className="pointer-events-none absolute inset-0 overflow-hidden rounded-full"
+          className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]"
         >
           <MaterialRipple variant="gradient" effect="fill" />
         </span>
@@ -2802,7 +2802,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
         </span>
         <span
           aria-hidden
-          className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-full"
+          className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]"
         >
           <MaterialRipple variant="gradient" effect="fill" />
         </span>
@@ -2826,7 +2826,7 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
           </span>
           <span
             aria-hidden
-            className="pointer-events-none absolute inset-0 overflow-hidden rounded-full"
+            className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]"
           >
             <MaterialRipple variant="gradient" effect="fill" />
           </span>


### PR DESCRIPTION
## What a person sees

Hovering either half of the idle One launcher painted a **floating pill** that curved away from the divider, leaving a visible gap on the flat side. The selection did not cover the half being pointed at.

## Why

The launcher is two halves of one pill: the voice half is `rounded-l-full rounded-r-none`, the chat half the mirror.

`MaterialRipple` already does the right thing — its host sets `borderRadius: "inherit"` and `.morphy-ripple-host` repeats it in CSS. But every call site in `agent-bar.tsx` wrapped it in a span that **hardcoded `rounded-full`**. The ripple therefore inherited a full pill from that span while sitting on a half-pill button.

So the component was correct and the five call sites overrode it.

## The change

`rounded-full` → `rounded-[inherit]` on all five clip wrappers.

Three of the five sit on genuinely round buttons, where this is identical in effect. Two sit on the split halves, where it is the fix. They move together because the defect is the hardcoded radius, not the two places it happened to be visible.

## Verification

- New contract assertion covers **every** clip wrapper in the file, not just the two that were wrong — a hand-written sixth would otherwise reintroduce it silently.
- `navbar-agent-trigger.contract.test.ts` 4/4.
- Every test that reads `agent-bar.tsx` — 10 files, **76/76** (`register-phone-safe-area`, `providers-bottom-clearance`, `circle-join-shell-layout`, `setup-completion-footer`, `agent-voice-single-owner`, `providers-theme-contract`, `agent-chat-shell`, `interaction-intent-coordinator`, `kai-bottom-chrome-visibility`, `lib/auth`).

## Noted, not changed

`hover:bg-current/[0.09]` on both halves never applies: `.bottom-chrome-surface` sets `background: … !important` in `globals.css:4855`, which outranks it. The hover affordance is carried entirely by the ripple. Left alone deliberately — resolving it would double the hover, and that is a separate design decision.