### PR TITLE
fix: keep onboarding auth screens responsive

### DIFF
--- a/hushh-webapp/app/register-phone/page.module.css
+++ b/hushh-webapp/app/register-phone/page.module.css
@@ -98,7 +98,7 @@
 }
 
 :global(.dark) .phoneTitle h1 {
-  width: 324px;
+  width: 402px;
   height: 32px;
   margin: 0 auto;
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
@@ -107,6 +107,7 @@
   line-height: 32px;
   letter-spacing: -0.7px;
   text-align: center;
+  white-space: nowrap;
 }
 
 :global(.dark) .inputRegion {

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -407,7 +407,7 @@ export function PhoneMandatePageContent() {
                 ? "Enter verification code"
                 : "Verify your phone number"
             }
-            className="font-[family-name:var(--font-app-display)] text-[27px] font-bold leading-[1.1] tracking-[-0.7px] text-[#0a0a0a] dark:text-[#fafafa]"
+            className="whitespace-nowrap font-[family-name:var(--font-app-display)] text-[27px] font-bold leading-[1.1] tracking-[-0.7px] text-[#0a0a0a] dark:text-[#fafafa]"
           >
             {verificationStep === "code"
               ? "Enter verification code"

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -1092,7 +1092,8 @@ export function PhoneVerificationFlow({
                   className={cn(
                     FLOW_CONTROL_SHELL_CLASS_NAME,
                     "relative w-full",
-                    !countryComboboxOpen && "[&_input]:text-transparent",
+                    !countryComboboxOpen &&
+                      "[&_input]:min-w-0 [&_input]:truncate [&_input]:whitespace-nowrap [&_input]:text-transparent [&_input]:caret-transparent",
                   )}
                   autoComplete="off"
                   autoCorrect="off"
@@ -1100,9 +1101,12 @@ export function PhoneVerificationFlow({
                   showTrigger
                 >
                   {!countryComboboxOpen ? (
-                    <span className="pointer-events-none absolute inset-y-0 left-4 z-10 flex items-center gap-3 text-[15px] text-[#17130c] dark:text-[#f5f5f7]">
+                    <span
+                      aria-hidden="true"
+                      className="pointer-events-none absolute inset-y-0 left-4 z-10 flex min-w-0 max-w-[calc(100%-3.5rem)] items-center gap-2 whitespace-nowrap text-[15px] text-[#17130c] dark:text-[#f5f5f7]"
+                    >
                       <FigmaCountryFlag />
-                      <span>{selectedCountryDisplayLabel}</span>
+                      <span className="min-w-0 truncate">{selectedCountryDisplayLabel}</span>
                     </span>
                   ) : null}
                 </ComboboxInput>

--- a/hushh-webapp/components/onboarding/AuthStep.module.css
+++ b/hushh-webapp/components/onboarding/AuthStep.module.css
@@ -92,8 +92,8 @@
 :global(.dark) .authTitle {
   position: absolute;
   top: 357px;
-  left: 76px;
-  width: 250px;
+  left: 0;
+  width: 402px;
   height: 32px;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
@@ -102,6 +102,7 @@
   line-height: 32px;
   letter-spacing: -0.7px;
   text-align: center;
+  white-space: nowrap;
 }
 
 :global(.dark) .providerActionsShell {

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -1119,7 +1119,7 @@ export function AuthStep({
               aria-level={1}
               aria-label="Welcome to One"
               className={cn(
-                "font-[family-name:var(--font-app-display)] text-[27px] font-bold leading-[1.1] tracking-[-0.7px] text-[#0a0a0a] dark:text-[#fafafa]",
+                "whitespace-nowrap font-[family-name:var(--font-app-display)] text-[27px] font-bold leading-[1.1] tracking-[-0.7px] text-[#0a0a0a] dark:text-[#fafafa]",
                 styles.authTitle,
               )}
             >


### PR DESCRIPTION
Deploy the responsive Figma onboarding/auth corrections to UAT.

- Keep Welcome to One and Verify your phone number on one line across responsive sizes.
- Prevent country-code flag/input text overlap with a bounded, single display.
- Preserve the current Figma implementations already on main for welcome, login, phone verification, and OTP.