### PR TITLE
fix: hide duplicate country selector text

### DIFF
--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -1093,7 +1093,7 @@ export function PhoneVerificationFlow({
                     FLOW_CONTROL_SHELL_CLASS_NAME,
                     "relative w-full",
                     !countryComboboxOpen &&
-                      "[&_input]:min-w-0 [&_input]:truncate [&_input]:whitespace-nowrap [&_input]:text-transparent [&_input]:caret-transparent",
+                      "[&_input]:min-w-0 [&_input]:truncate [&_input]:whitespace-nowrap [&_input]:!text-transparent [&_input]:!caret-transparent",
                   )}
                   autoComplete="off"
                   autoCorrect="off"


### PR DESCRIPTION
Fix the dark phone-verification country selector overlap. The global ui-text-input-value rule uses !important, so the closed combobox input text was visible underneath the custom flag and country display. Apply an equally explicit closed-state override while keeping the search input visible when the picker opens.