### PR TITLE
fix(release): align command runtime profile schema

### DIFF
--- a/hushh-webapp/.env.dev.local.example
+++ b/hushh-webapp/.env.dev.local.example
@@ -29,6 +29,8 @@ NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE=1
 # The backend ONE_WALLET_CARD_ENABLED flag stays authoritative; this only
 # decides whether the row is offered, so a dark backend is never linked to.
 NEXT_PUBLIC_ONE_WALLET_CARD_ENABLED=false
+# Keep the profile schema identical to UAT; deployment still controls opt-in.
+NEXT_PUBLIC_LOCATION_COMMAND_RUNTIME_ENABLED=false
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=replace_with_dev_measurement_id
 NEXT_PUBLIC_GTM_ID=replace_with_dev_gtm_id
 NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=

--- a/hushh-webapp/.env.local.local.example
+++ b/hushh-webapp/.env.local.local.example
@@ -29,6 +29,9 @@ NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE=1
 # The backend ONE_WALLET_CARD_ENABLED flag stays authoritative; this only
 # decides whether the row is offered, so a dark backend is never linked to.
 NEXT_PUBLIC_ONE_WALLET_CARD_ENABLED=false
+# Transcript-first Location commands share one explicit profile key across
+# every frontend environment. Governed lanes opt in only through deployment.
+NEXT_PUBLIC_LOCATION_COMMAND_RUNTIME_ENABLED=false
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=replace_with_uat_measurement_id
 NEXT_PUBLIC_GTM_ID=replace_with_uat_gtm_id
 NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=

--- a/hushh-webapp/.env.prod.local.example
+++ b/hushh-webapp/.env.prod.local.example
@@ -27,6 +27,8 @@ NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE=1
 # The backend ONE_WALLET_CARD_ENABLED flag stays authoritative; this only
 # decides whether the row is offered, so a dark backend is never linked to.
 NEXT_PUBLIC_ONE_WALLET_CARD_ENABLED=false
+# Production remains off by default, but declares the shared profile key.
+NEXT_PUBLIC_LOCATION_COMMAND_RUNTIME_ENABLED=false
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=replace_with_prod_measurement_id
 NEXT_PUBLIC_GTM_ID=replace_with_prod_gtm_id
 NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=

--- a/hushh-webapp/__tests__/scripts/ios-prepare-uat-env.test.ts
+++ b/hushh-webapp/__tests__/scripts/ios-prepare-uat-env.test.ts
@@ -1,8 +1,27 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { buildIosUatRuntimeEnv } from "../../scripts/native/prepare-ios-uat-archive.mjs";
 
 describe("iOS UAT native runtime env", () => {
+  it("keeps the command rollout key in every canonical frontend profile", () => {
+    const profiles = [
+      ".env.local.local.example",
+      ".env.uat.local.example",
+      ".env.dev.local.example",
+      ".env.prod.local.example",
+    ];
+
+    for (const profile of profiles) {
+      const contents = readFileSync(resolve(process.cwd(), profile), "utf8");
+      expect(contents).toMatch(
+        /^NEXT_PUBLIC_LOCATION_COMMAND_RUNTIME_ENABLED=false$/m,
+      );
+    }
+  });
+
   it("keeps UAT enrollment scoped to UAT despite production shell and file defaults", () => {
     const env = buildIosUatRuntimeEnv({
       processEnv: { NEXT_PUBLIC_PASSKEY_RP_ID: "one.hushh.ai" },


### PR DESCRIPTION
Fixes the UAT release rollback caused by the command-runtime flag being present only in the UAT profile template. Adds the shared key to all canonical frontend profile templates and a regression test.\n\nValidation:\n- `npm run --prefix hushh-webapp verify:location-command-runtime` (84 passed)\n- `python3 scripts/ops/verify-runtime-profile-env-shape.py`