### PR TITLE
fix(ios): match phone verification viewport

### DIFF
--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5551,7 +5551,7 @@
     "one_specialist_tools": "230fdc0ad8faf257511fc37fc3a5d3b5d859e914bce5bacc7ddc86c885dc2ae4",
     "route_index": "3b4d9edd7c3a70d2ae7a352e26639b95aa328c8604fc05f1c6717a78114d0d54",
     "route_layout": "642c8ebcc34e77ef646d747914c2d9972ed006fd8c8657137283be274a5ae2c6",
-    "surface_map": "b8938c3e4d144e8f1e62f7fa8384b2202ca2e8622b6379390974125d73affc12",
+    "surface_map": "615a004f2742b64ae51aa8e48ab69bc87f57be4ca3fe5d17806d7bb21edfe8fc",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5550,7 +5550,7 @@
     "in_process_dispatch": "022c40c305a11e06510f2688041a96c1523cae5b5c03d7876fd122ce027e98c3",
     "one_specialist_tools": "230fdc0ad8faf257511fc37fc3a5d3b5d859e914bce5bacc7ddc86c885dc2ae4",
     "route_index": "3b4d9edd7c3a70d2ae7a352e26639b95aa328c8604fc05f1c6717a78114d0d54",
-    "route_layout": "5df348a7ca9785aacc47b20a6e8434375bae432718ce2dbd30e83a59a6a8abb4",
+    "route_layout": "642c8ebcc34e77ef646d747914c2d9972ed006fd8c8657137283be274a5ae2c6",
     "surface_map": "b8938c3e4d144e8f1e62f7fa8384b2202ca2e8622b6379390974125d73affc12",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"

--- a/hushh-webapp/__tests__/app/register-phone-safe-area.contract.test.ts
+++ b/hushh-webapp/__tests__/app/register-phone-safe-area.contract.test.ts
@@ -4,42 +4,33 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("/register-phone safe-area shell contract", () => {
-  it("sizes the page to exactly one viewport and keeps the compact OTP step above the native keyboard", () => {
+  it("owns a full viewport without persistent Talk to One chrome and keeps the form above the native keyboard", () => {
     const source = readFileSync(
       join(process.cwd(), "app/register-phone/page.tsx"),
       "utf8",
     );
+    const routeContract = readFileSync(
+      join(process.cwd(), "lib/navigation/app-route-layout.contract.json"),
+      "utf8",
+    );
+    const styles = readFileSync(
+      join(process.cwd(), "app/register-phone/page.module.css"),
+      "utf8",
+    );
 
-    // The outer app scroll root (app/providers.tsx) already reserves
-    // --app-scroll-bottom-pad for the fixed onboarding Agent Bar on every
-    // hidden-shell route, including /register-phone. Reserving it a second
-    // time (or via --onboarding-agent-bar-clearance directly) doubled the
-    // bottom clearance and caused visible excess scroll on mobile.
+    // This is an immersive verification route, not a hidden-shell route that
+    // still carries the persistent Agent Bar. The route contract makes the
+    // provider unmount that chrome and clears its reserved scroll padding.
+    expect(routeContract).toContain('"route": "/register-phone"');
+    expect(routeContract).toContain('"persistentChrome": "none"');
     expect(source).not.toContain("var(--onboarding-agent-bar-clearance)");
-    expect(source).toContain("var(--app-safe-area-top-effective");
+    expect(source).not.toContain("--app-scroll-bottom-pad");
     expect(source).not.toContain("--phone-mandate-agent-bar-clearance");
-    // Height/offsets are inline styles, not Tailwind arbitrary-value
-    // classes: Tailwind's arbitrary calc() parser requires escaped
-    // whitespace around +/- operators ("100dvh_-_var(...)"); without it the
-    // declaration is invalid CSS and silently dropped, which is what
-    // produced 0px paddings/heights and forced full-page scroll here.
-    expect(source).toContain(
-      "calc(100dvh - var(--app-scroll-bottom-pad, 0px))",
-    );
-    expect(source).toContain(
-      "calc(100svh - var(--app-scroll-bottom-pad, 0px))",
-    );
-    expect(source).toContain(
-      "calc(18px + var(--app-safe-area-top-effective, 0px))",
-    );
     expect(source).toContain('data-phone-mandate-input-region="true"');
-    expect(source).toContain("var(--kb-height, 0px)");
-    expect(source).not.toContain("mt-auto");
-    // The active field region owns keyboard clearance; it can scroll only as a
-    // compact-screen fallback instead of letting fields slip beneath iOS.
-    expect(source).toContain("overflow-y-auto overscroll-contain");
-    expect(source).not.toContain("min-h-[24rem]");
-    expect(source).not.toContain("4vh");
+    expect(styles).toContain("block-size: 100dvh");
+    expect(styles).toContain("min-block-size: 100svh");
+    expect(styles).toContain("bottom: var(--kb-height, 0px)");
+    expect(styles).toContain("overflow-y: auto");
   });
 
   it("exposes a signed-in sign-out escape without account deletion", () => {
@@ -56,14 +47,24 @@ describe("/register-phone safe-area shell contract", () => {
     expect(source).not.toContain("Delete account");
   });
 
-  it("keeps phone verification focused without decorative artwork", () => {
+  it("uses the measured Figma phone composition and shared primary CTA", () => {
     const source = readFileSync(
       join(process.cwd(), "app/register-phone/page.tsx"),
+      "utf8",
+    );
+    const styles = readFileSync(
+      join(process.cwd(), "app/register-phone/page.module.css"),
       "utf8",
     );
 
     expect(source).not.toContain("🤫");
     expect(source).not.toContain("one-quiet-emoji.png");
-    expect(source).toContain("Verification is a focused task, not a hero");
+    expect(source).toContain('sendCodeLabel="Send a verification code"');
+    expect(source).toContain("primaryActionClassName={styles.primaryAction}");
+    expect(styles).toContain("max-inline-size: 402px");
+    expect(styles).toContain("inline-size: min(357px");
+    expect(styles).toContain("top: clamp(406px, 105.97vw, 426px)");
+    expect(styles).toContain("max-inline-size: 330px");
+    expect(styles).toContain("min-block-size: clamp(48px, 12.935vw, 52px)");
   });
 });

--- a/hushh-webapp/app/register-phone/page.module.css
+++ b/hushh-webapp/app/register-phone/page.module.css
@@ -1,320 +1,217 @@
-/* Figma screen 7 is a 402 × 874 composition. Keeping the visual layout on
-   that canvas and scaling the whole canvas preserves the exact relationships
-   between artwork, fields, and CTA on smaller responsive surfaces. */
-.stage,
-.composition {
-  display: contents;
-}
+/*
+ * Phone verification is the Figma 402 × 874 iPhone composition. The layout
+ * keeps its measured relationships at that reference size, but never scales
+ * the document: inputs and hit targets remain native-size and the form alone
+ * becomes scrollable when the software keyboard is visible.
+ */
 
-:global(.dark) .shell {
+.shell {
+  position: relative;
+  block-size: 100dvh;
+  min-block-size: 100svh;
+  inline-size: 100%;
+  overflow: hidden;
   background: #000;
   color: #f2f2f7;
+  isolation: isolate;
 }
 
-:global(.dark) .stage {
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
+.composition {
+  position: relative;
+  block-size: 100%;
+  min-block-size: 100%;
+  inline-size: 100%;
+  max-inline-size: 402px;
+  margin-inline: auto;
   overflow: hidden;
 }
 
-:global(.dark) .composition {
-  position: relative;
-  display: block;
-  flex: none;
-  width: 402px !important;
-  height: 874px !important;
-  min-height: 874px !important;
-  max-width: none !important;
-  margin: 0 !important;
-  transform: scale(
-    min(
-      1,
-      calc(100vw / 402px),
-      calc((100svh - var(--app-scroll-bottom-pad, 0px)) / 874px)
-    )
-  );
-  transform-origin: top center;
-}
-
-:global(.dark) .topBar {
-  inset: unset !important;
-  top: 72px !important;
-  right: auto !important;
-  bottom: auto !important;
-  left: 27px !important;
-  width: 43px;
-  height: 43px;
-  padding: 0 !important;
-  display: block !important;
-}
-
-:global(.dark) .phoneBackButton {
-  width: 43px !important;
-  height: 43px !important;
-  padding: 0 !important;
-  background: #1c1c1e !important;
-  color: rgba(255, 255, 255, 0.96) !important;
-  box-shadow: none !important;
-}
-
-:global(.dark) .accountButton {
-  display: none !important;
-}
-
-:global(.dark) .phoneIllustrationSlot {
-  position: static !important;
-  width: 0;
-  height: 0;
-  transform: none !important;
-}
-
-:global(.dark) .phoneIllustration {
+.topBar {
   position: absolute;
-  top: 107px;
-  left: 17px;
-  width: 357px !important;
-  height: 238px !important;
-  aspect-ratio: auto !important;
+  inset-inline: clamp(20px, 6.716vw, 27px);
+  top: calc(var(--app-safe-area-top-effective, 0px) + 13px);
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
-:global(.dark) .phoneIllustration img {
-  width: 100%;
-  height: 100%;
-  max-width: none;
+.backButton,
+.accountButton {
+  display: grid;
+  block-size: 43px;
+  inline-size: 43px;
+  place-items: center;
+  border: 0;
+  border-radius: 9999px;
+  background: #1c1c1e;
+  color: rgba(255, 255, 255, 0.96);
+  box-shadow: none;
+}
+
+.backButton:focus-visible,
+.accountButton:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+/* FigmaIllustration keeps the design-exported dark asset local. Override its
+   compact default without scaling the form or its touch targets. */
+.hero {
+  position: absolute;
+  inset-inline-start: 50%;
+  top: calc(var(--app-safe-area-top-effective, 0px) + 48px);
+  display: block;
+  block-size: auto !important;
+  inline-size: min(357px, calc(100% - 44px)) !important;
+  max-inline-size: none;
+  aspect-ratio: 357 / 238 !important;
+  transform: translateX(-50%);
+}
+
+.hero :global(img) {
+  block-size: 100%;
+  inline-size: 100%;
   object-fit: contain;
-  object-position: center;
 }
 
-:global(.dark) .phoneTitle {
-  top: 345px !important;
-  right: 0 !important;
-  left: 0 !important;
-  width: 402px;
-  height: 32px;
-}
-
-:global(.dark) .phoneTitle h1 {
-  width: 402px;
-  height: 32px;
-  margin: 0 auto;
+.title {
+  position: absolute;
+  inset-inline: 0;
+  top: clamp(304px, 85.821vw, 345px);
+  z-index: 2;
+  margin: 0;
+  padding-inline: 16px;
+  color: #f2f2f7;
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
-  font-size: 27px;
+  font-size: clamp(23px, 6.716vw, 27px);
   font-weight: 700;
-  line-height: 32px;
   letter-spacing: -0.7px;
+  line-height: 32px;
   text-align: center;
-  white-space: nowrap;
 }
 
-:global(.dark) .inputRegion {
-  inset: 0 !important;
-  width: 402px;
-  height: 874px;
-  padding: 0 !important;
-  overflow: visible !important;
-}
-
-:global(.dark) .phoneForm {
-  position: absolute !important;
-  inset: 0 !important;
-  width: 402px !important;
-  height: 874px !important;
-  display: block !important;
-  overflow: visible;
-}
-
-:global(.dark) .phoneForm :global([data-slot="field-set"]) {
-  position: relative;
-  display: block;
-  width: 402px;
-  height: 874px;
-  margin: 0;
-  padding: 0;
-}
-
-:global(.dark) .phoneForm :global([data-figma-phone-fields]) {
-  position: static;
-  display: block;
-}
-
-:global(.dark) .phoneForm :global([data-figma-phone-field]) {
+.inputRegion {
   position: absolute;
-  left: 29px;
-  width: 344px;
-  height: 87px;
-  display: block;
-  gap: 0;
+  inset-inline: 0;
+  top: clamp(406px, 105.97vw, 426px);
+  bottom: var(--kb-height, 0px);
+  z-index: 5;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-inline: clamp(20px, 7.214vw, 29px);
+  padding-block: 0
+    max(24px, calc(16px + var(--app-safe-area-bottom-effective, 0px)));
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
 }
 
-:global(.dark) .phoneForm :global([data-figma-phone-field="country"]) {
-  top: 426px;
+.inputRegion::-webkit-scrollbar {
+  display: none;
 }
 
-:global(.dark) .phoneForm :global([data-figma-phone-field="number"]) {
-  top: 524px;
+.phoneForm {
+  inline-size: 100%;
 }
 
-:global(.dark) .phoneForm :global([data-figma-phone-field]) :global([data-slot="field-label"]) {
-  position: absolute;
-  top: 0;
-  left: 11px;
-  width: 250px;
-  height: 16px;
+/* Field geometry mirrors the Figma measurements: label 16px + 11px gap +
+   60px control; 11px between the two fields; 37px before the 52px CTA. */
+.phoneForm :global([data-slot="field-set"]) {
+  gap: clamp(28px, 9.204vw, 37px) !important;
+}
+
+.phoneForm :global([data-slot="field-group"]) {
+  gap: clamp(9px, 2.736vw, 11px) !important;
+}
+
+.phoneForm :global([data-slot="field"]) {
+  gap: clamp(9px, 2.736vw, 11px) !important;
+}
+
+.phoneForm :global([data-slot="field-label"]) {
   margin: 0;
-  padding: 0;
+  padding-inline-start: clamp(9px, 2.736vw, 11px);
   color: #8d8d94 !important;
-  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
-  font-size: 13px;
-  font-weight: 590;
-  line-height: 16px;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif !important;
+  font-size: 13px !important;
+  font-weight: 590 !important;
+  letter-spacing: 0 !important;
+  line-height: 16px !important;
 }
 
-:global(.dark) .phoneForm :global([data-figma-phone-field]) :global([data-slot="input-group"]) {
-  position: absolute;
-  top: 27px;
-  left: 0;
-  width: 344px !important;
-  height: 60px !important;
-  min-height: 60px;
+.phoneForm :global([data-slot="input-group"]) {
+  block-size: 60px !important;
+  min-block-size: 60px;
   border: 0 !important;
   border-radius: 16px !important;
   background: #1c1c1e !important;
   box-shadow: none !important;
 }
 
-:global(.dark) .phoneForm :global([data-figma-phone-field]) :global([data-slot="input-group-control"]) {
-  height: 60px !important;
-  min-height: 60px;
-  padding: 0 16px !important;
-  border: 0 !important;
-  background: transparent !important;
+.phoneForm :global([data-slot="input-group-control"]) {
+  block-size: 60px !important;
+  min-block-size: 60px;
+  padding-inline: 16px !important;
+  color: #f2f2f7 !important;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif !important;
+  font-size: 17px !important;
+  font-weight: 400 !important;
+  letter-spacing: -0.43px !important;
+  line-height: 22px !important;
+}
+
+.phoneForm :global([data-slot="input-group"] > span[aria-hidden="true"]) {
+  inset-inline-start: 22px !important;
+  gap: 8px !important;
   color: #f2f2f7 !important;
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
-  font-size: 17px;
-  font-weight: 400;
-  line-height: 22px;
+  font-size: 17px !important;
   letter-spacing: -0.43px;
+  line-height: 22px !important;
 }
 
-:global(.dark) .phoneForm :global([data-figma-phone-field="country"]) :global([data-slot="input-group"]) > span {
-  left: 22px;
-  gap: 8px;
-  color: #f2f2f7;
-  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
-  font-size: 17px;
-  line-height: 22px;
-}
-
-:global(.dark) .phoneForm :global([data-figma-phone-field]) :global([data-slot="input-group-addon"]) {
-  padding-right: 16px;
-}
-
-:global(.dark) .phoneForm :global([data-figma-phone-field]) :global([data-slot="combobox-trigger-icon"]) {
-  width: 16px;
-  height: 16px;
-  color: #98989d !important;
-}
-
-:global(.dark) .phoneForm :global([data-figma-phone-field="number"]) :global([role="alert"]) {
-  position: absolute;
-  top: 91px;
-  left: 0;
-  width: 344px;
-}
-
-:global(.dark) .phoneForm :global([data-figma-phone-helper]) {
-  display: none !important;
-}
-
-:global(.dark) .phoneSubmitButton {
-  position: absolute !important;
-  top: 648px;
-  left: 36px;
-  width: 330px !important;
-  max-width: 330px !important;
-  height: 52px !important;
-  min-height: 52px !important;
-  margin: 0 !important;
-  padding: 0 16px !important;
-  border: 0 !important;
-  border-radius: 26px !important;
+.primaryAction {
+  block-size: clamp(48px, 12.935vw, 52px) !important;
+  min-block-size: clamp(48px, 12.935vw, 52px) !important;
+  inline-size: calc(100% - clamp(12px, 3.483vw, 14px)) !important;
+  max-inline-size: 330px !important;
+  margin-inline: auto !important;
+  padding-inline: 16px !important;
+  border-radius: 9999px !important;
   background: var(--app-accent) !important;
-  color: #fff !important;
-  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
-  font-size: 17px;
-  font-weight: 400;
-  line-height: 22px;
+  color: var(--app-accent-fg) !important;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif !important;
+  font-size: 17px !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.2px !important;
+  line-height: 22px !important;
 }
 
-/* The OTP state keeps the same Figma art/title/back composition and replaces
-   only the verification controls owned by PhoneVerificationFlow. */
-:global(.dark) .phoneForm :global([data-figma-otp-intro]) {
-  position: absolute;
-  top: 402px;
-  left: 39px;
-  width: 324px;
-  margin: 0;
-  color: rgba(245, 245, 247, 0.72);
-  font-size: 13px;
-  line-height: 18px;
-  text-align: center;
+/* The code and already-linked states reuse the primary button, while their
+   longer content can scroll above the keyboard instead of shifting the hero. */
+.phoneForm :global([data-slot="field-set"]) > :global(p) {
+  margin-block: 0;
 }
 
-:global(.dark) .phoneForm :global([data-figma-otp-field]) {
-  position: absolute;
-  top: 451px;
-  left: 36px;
-  width: 330px;
-  display: block;
-  gap: 0;
+.recaptcha {
+  display: none;
 }
 
-:global(.dark) .phoneForm :global([data-figma-otp-field]) :global([data-slot="field-label"]) {
-  display: block;
-  width: 330px;
-  margin: 0 0 10px;
-  color: rgba(245, 245, 247, 0.5) !important;
-  font-size: 13px;
-  font-weight: 400;
-  line-height: 16px;
-}
+@media (max-height: 700px) {
+  .hero {
+    top: max(72px, calc(var(--app-safe-area-top-effective, 0px) + 24px));
+    inline-size: min(300px, calc(100% - 48px)) !important;
+  }
 
-:global(.dark) .phoneForm :global([data-figma-otp-field]) > div {
-  width: 330px;
-}
+  .title {
+    top: clamp(264px, 76vw, 305px);
+  }
 
-:global(.dark) .phoneForm :global([data-figma-otp-field]) > div > div {
-  gap: 6px;
-}
-
-:global(.dark) .phoneForm :global([data-figma-otp-field]) > div > div > div {
-  height: 52px;
-  min-height: 52px;
-  border-radius: 14px;
-  border-color: rgba(255, 255, 255, 0.12);
-  background: #1c1c1e;
-  font-size: 20px;
-}
-
-:global(.dark) .phoneForm[data-figma-phone-step="code"] :global([data-figma-otp-primary]) {
-  top: 584px;
-}
-
-:global(.dark) .phoneForm[data-figma-phone-step="code"] > :global([data-slot="field-set"]) > div:last-child {
-  position: absolute;
-  top: 661px;
-  left: 36px;
-  width: 330px;
-  padding: 0;
-  justify-content: center;
-  gap: 12px;
-  font-size: 15px;
-}
-
-:global(.dark) .recaptcha {
-  display: none !important;
+  .inputRegion {
+    top: clamp(350px, 92vw, 390px);
+  }
 }

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -9,7 +9,6 @@ import { HushhLoader } from "@/components/app-ui/hushh-loader";
 import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
 import { PhoneVerificationFlow } from "@/components/auth/phone-verification-flow";
 import { FigmaIllustration } from "@/components/onboarding/FigmaOnboardingPrimitives";
-import { OnboardingHeroBackground } from "@/components/onboarding/OnboardingHeroBackground";
 import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
 import {
   DropdownMenu,
@@ -244,7 +243,7 @@ export function PhoneMandatePageContent() {
                   {
                     id: "phone_mandate.submit_number",
                     actionId: "phone_mandate.submit_number",
-                    label: "Send verification code",
+                    label: "Send a verification code",
                     purpose: "Send a code after the phone form is completed.",
                   },
                 ]
@@ -309,29 +308,10 @@ export function PhoneMandatePageContent() {
   }
 
   const shell = (
-    // Inline styles (not Tailwind arbitrary-value classes) for every
-    // computed height/offset here: Tailwind's arbitrary calc() parser
-    // requires escaped whitespace around +/- operators ("18px_+_var(...)");
-    // without it the whole declaration is invalid CSS and silently dropped,
-    // which produced 0px paddings/heights and forced full-page scroll.
-    // The outer app scroll root reserves --app-scroll-bottom-pad below this
-    // element for the fixed onboarding Agent Bar, then re-adds it as its own
-    // padding-bottom, so this element is exactly one viewport minus that
-    // reservation.
     <main
-      className={cn(
-        "relative w-full overflow-hidden bg-[#f6f5fc] dark:bg-black",
-        styles.shell,
-      )}
-      style={{
-        height: "calc(100dvh - var(--app-scroll-bottom-pad, 0px))",
-        minHeight: "calc(100svh - var(--app-scroll-bottom-pad, 0px))",
-      }}
+      className={styles.shell}
       data-testid="phone-mandate-screen"
     >
-      {/* Verification is a focused task, not a hero; the Figma illustration
-          is a compact visual anchor above the form rather than a new flow. */}
-      <OnboardingHeroBackground variant="solid" />
       <NativeRouteMarker
         routeId={ROUTES.PHONE_MANDATE}
         marker="native-route-register-phone"
@@ -339,35 +319,16 @@ export function PhoneMandatePageContent() {
         dataState="loaded"
       />
 
-      <div className={styles.stage}>
-        <div
-          className={cn(
-            "relative mx-auto flex w-full max-w-[440px] flex-col",
-            styles.composition,
-          )}
-          style={{
-            height: "calc(100dvh - var(--app-scroll-bottom-pad, 0px))",
-            minHeight: "calc(100svh - var(--app-scroll-bottom-pad, 0px))",
-          }}
-        >
+      <div className={styles.composition}>
         {/* Top bar: back + account actions */}
-        <div
-          className={cn(
-            "absolute inset-x-0 z-30 flex items-center justify-between px-5",
-            styles.topBar,
-          )}
-          style={{
-            top: "max(0px, calc(54px - var(--app-safe-area-top-effective, 0px)))",
-            paddingTop: "calc(18px + var(--app-safe-area-top-effective, 0px))",
-          }}
-        >
+        <div className={styles.topBar}>
           <button
             type="button"
             aria-label="Go back"
             onClick={() => router.back()}
             className={cn(
-              "grid h-11 w-11 place-items-center rounded-full bg-white/[0.52] text-[#1d1d1f]/70 shadow-[0_4px_15px_rgba(150,196,255,0.22)] transition-colors hover:bg-white/[0.75] active:scale-95 dark:bg-[#1c1c1e]/85 dark:text-white/90 dark:shadow-none dark:hover:bg-[#303034]",
-              styles.phoneBackButton,
+              styles.backButton,
+              "transition-transform active:scale-95",
             )}
           >
             <ChevronLeft className="h-5 w-5" />
@@ -378,8 +339,8 @@ export function PhoneMandatePageContent() {
                 type="button"
                 aria-label="Account actions"
                 className={cn(
-                  "grid h-11 w-11 place-items-center rounded-full bg-white/[0.52] text-[#1d1d1f]/70 shadow-[0_4px_15px_rgba(150,196,255,0.22)] transition-colors hover:bg-white/[0.75] active:scale-95 dark:bg-[#1c1c1e]/85 dark:text-white/90 dark:shadow-none dark:hover:bg-[#303034]",
                   styles.accountButton,
+                  "transition-transform active:scale-95",
                 )}
               >
                 <MoreHorizontal className="h-5 w-5" />
@@ -394,26 +355,21 @@ export function PhoneMandatePageContent() {
           </DropdownMenu>
         </div>
 
-        <div className={cn("absolute left-1/2 top-[78px] -translate-x-1/2", styles.phoneIllustrationSlot)}>
-          <FigmaIllustration variant="phone" className={styles.phoneIllustration} />
-        </div>
-
-        <div className={cn("absolute inset-x-6 top-[373px] text-center", styles.phoneTitle)}>
-          <h1
-            role="heading"
-            aria-level={1}
-            aria-label={
-              verificationStep === "code"
-                ? "Enter verification code"
-                : "Verify your phone number"
-            }
-            className="whitespace-nowrap font-[family-name:var(--font-app-display)] text-[27px] font-bold leading-[1.1] tracking-[-0.7px] text-[#0a0a0a] dark:text-[#fafafa]"
-          >
-            {verificationStep === "code"
+        <FigmaIllustration variant="phone" className={styles.hero} />
+        <h1
+          role="heading"
+          aria-level={1}
+          aria-label={
+            verificationStep === "code"
               ? "Enter verification code"
-              : "Verify your phone number"}
-          </h1>
-        </div>
+              : "Verify your phone number"
+          }
+          className={styles.title}
+        >
+          {verificationStep === "code"
+            ? "Enter verification code"
+            : "Verify your phone number"}
+        </h1>
 
         {/* The active field group owns the keyboard clearance. The keyboard
             plugin leaves the WebView frame stable, so padding—not a `dvh`
@@ -421,14 +377,7 @@ export function PhoneMandatePageContent() {
             Android keyboards. Tiny screens may scroll this one form region. */}
         <div
           data-phone-mandate-input-region="true"
-          className={cn(
-            `absolute inset-x-0 bottom-0 top-[438px] overflow-y-auto overscroll-contain px-6 pt-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${verificationStep === "code" ? "top-[432px]" : ""}`,
-            styles.inputRegion,
-          )}
-          style={{
-            paddingBottom:
-              "max(calc(1rem + var(--app-safe-area-bottom-effective, 0px)), calc(1rem + var(--kb-height, 0px)))",
-          }}
+          className={styles.inputRegion}
         >
           <PhoneVerificationFlow
             key={user.uid}
@@ -441,12 +390,11 @@ export function PhoneMandatePageContent() {
             onStepChange={setVerificationStep}
             sendCodeLabel="Send a verification code"
             confirmLabel="Verify"
-            primaryActionClassName={cn("mx-auto max-w-[21.5rem]", styles.phoneSubmitButton)}
-            className={cn("flex flex-col gap-5", styles.phoneForm)}
+            primaryActionClassName={styles.primaryAction}
+            className={styles.phoneForm}
             helperText=""
           />
           <div id="recaptcha-container" className={cn("mt-3 min-h-0", styles.recaptcha)} />
-        </div>
         </div>
       </div>
     </main>

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -1008,9 +1008,15 @@ export function PhoneVerificationFlow({
         </div>
         <Button
           onClick={() => void onContinueExisting?.()}
+          variant="none"
+          effect="fill"
           size="default"
           fullWidth
-          className={`type-headline mt-6 h-12 ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
+          className={cn(
+            "type-headline mt-6",
+            FLOW_CTA_CLASS_NAME,
+            primaryActionClassName,
+          )}
         >
           Continue
         </Button>

--- a/hushh-webapp/components/keyboard-inset-manager.tsx
+++ b/hushh-webapp/components/keyboard-inset-manager.tsx
@@ -45,6 +45,16 @@ function setKeyboardHeight(px: number): void {
   root.classList.toggle("kb-open", clamped > 0);
 }
 
+function isEditableElement(element: HTMLElement | null): element is HTMLElement {
+  if (!element) return false;
+
+  return (
+    element.tagName === "INPUT" ||
+    element.tagName === "TEXTAREA" ||
+    element.isContentEditable
+  );
+}
+
 export function KeyboardInsetManager() {
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -64,29 +74,35 @@ export function KeyboardInsetManager() {
     let rafId = 0;
     const cleanups: Array<() => void> = [];
 
+    const scrollEditableIntoView = (element: HTMLElement | null) => {
+      if (!isEditableElement(element)) return;
+      // Fixed keyboard-anchored layers already track visualViewport through
+      // --kb-height. Scrolling their autofocus target feeds viewport movement
+      // back into that same measurement and makes the command palette jump.
+      if (element.closest('[data-keyboard-anchor="bottom"]')) return;
+
+      cancelAnimationFrame(rafId);
+      // A native keyboard event lands after focus. Wait for the inset style and
+      // the form's keyboard-reduced scroll area to commit, then reveal only the
+      // focused control. `nearest` preserves the Figma composition instead of
+      // re-centering the whole screen while someone types a phone number.
+      rafId = requestAnimationFrame(() => {
+        rafId = requestAnimationFrame(() => {
+          element.scrollIntoView({ block: "nearest" });
+        });
+      });
+    };
+
+    const scrollFocusedEditableIntoView = () => {
+      scrollEditableIntoView(document.activeElement as HTMLElement | null);
+    };
+
     // Focusin net — once the keyboard is up, center the focused field in its
     // nearest scroll container. Covers normal-flow forms (OTP, onboarding,
     // profile) with no per-screen code.
     const onFocusIn = (event: FocusEvent) => {
       if (!document.documentElement.classList.contains("kb-open")) return;
-      const el = event.target as HTMLElement | null;
-      if (!el) return;
-      const editable =
-        el.tagName === "INPUT" ||
-        el.tagName === "TEXTAREA" ||
-        el.isContentEditable;
-      if (!editable) return;
-      // Fixed keyboard-anchored layers already track visualViewport through
-      // --kb-height. Scrolling their autofocus target feeds viewport movement
-      // back into that same measurement and makes the command palette jump.
-      if (el.closest('[data-keyboard-anchor="bottom"]')) return;
-      cancelAnimationFrame(rafId);
-      // Defer past the layout that --kb-height triggers, then center.
-      rafId = requestAnimationFrame(() => {
-        rafId = requestAnimationFrame(() => {
-          el.scrollIntoView({ block: "center" });
-        });
-      });
+      scrollEditableIntoView(event.target as HTMLElement | null);
     };
     document.addEventListener("focusin", onFocusIn, true);
     cleanups.push(() =>
@@ -110,14 +126,22 @@ export function KeyboardInsetManager() {
           // iOS normally emits `will*`, but an interrupted animation/reopened
           // command palette can arrive only as `did*`. Subscribe to both so the
           // CSS inset always converges on the keyboard's final geometry.
+          const handleKeyboardShow = (height: number) => {
+            setKeyboardHeight(height);
+            // `focusin` fires before iOS publishes keyboard visibility, so it
+            // intentionally does nothing on a first focus. The native event is
+            // the authoritative second chance that keeps the active phone/OTP
+            // field above the keyboard without moving the whole viewport.
+            scrollFocusedEditableIntoView();
+          };
           register(
             Keyboard.addListener("keyboardWillShow", (info) =>
-              setKeyboardHeight(info.keyboardHeight ?? 0),
+              handleKeyboardShow(info.keyboardHeight ?? 0),
             ),
           );
           register(
             Keyboard.addListener("keyboardDidShow", (info) =>
-              setKeyboardHeight(info.keyboardHeight ?? 0),
+              handleKeyboardShow(info.keyboardHeight ?? 0),
             ),
           );
           register(

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -8507,7 +8507,7 @@
         "page_header": false,
         "settings_ui": false,
         "shared_loader": true,
-        "back_button_pattern": "route-local-check-required"
+        "back_button_pattern": "shared-shell"
       },
       "voice_action_contract_file": "app/register-phone/page.voice-action-contract.json",
       "voice_action_contract_ids": [
@@ -9469,5 +9469,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "8e39a2a55e7f81e7a14065d45583a0b5b2cf167a8a48cda4ad5e7df07c5bffc3"
+  "content_sha256": "e47a59609d9e1f91759963b35a7aa823a5186f36a01186fff0d4974e327725b7"
 }

--- a/hushh-webapp/lib/navigation/app-route-layout.contract.json
+++ b/hushh-webapp/lib/navigation/app-route-layout.contract.json
@@ -1198,6 +1198,7 @@
   {
     "route": "/register-phone",
     "mode": "hidden",
+    "persistentChrome": "none",
     "interactionLayerPolicy": {
       "allowedFamilies": [
         "country_picker"


### PR DESCRIPTION
Matches the phone-verification Figma composition on iOS without scaling inputs, removes persistent Talk to One chrome from the mandatory verification route, and keeps number/OTP fields above the native keyboard.\n\nValidated: typecheck, lint, design-system, native static parity, phone flow (32 tests), register-phone suites (8 tests).