### PR TITLE
fix(ci): provision TestFlight capability graph runtime

### DIFF
--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -151,10 +151,12 @@ jobs:
           cache: npm
           cache-dependency-path: hushh-webapp/package-lock.json
 
-      - name: Set up Python and uv
-        uses: astral-sh/setup-uv@v7
+      - name: Set up locked consent-protocol runtime
+        uses: ./consent-protocol/.github/actions/setup-python-uv
         with:
-          enable-cache: true
+          python-version: "3.13"
+          protocol-dir: ./consent-protocol
+          sync-dev-group: "true"
 
       - name: Install web dependencies
         shell: bash


### PR DESCRIPTION
## Summary
- Provision the existing locked Consent Protocol Python runtime before the TestFlight One Voice safety gate.
- Prevent the capability-graph generator from falling back to ambient runner Python without `python-dotenv`.

### Impact Map
- Routes touched: none.
- API/schema/type changes: none.
- Runtime DB data-plane changes: none.
- Cache keys touched: none.
- PKM effects: none.
- Mobile parity impacts: TestFlight CI now uses the same locked Python environment as CI/UAT before native preparation; app behavior is unchanged.
- Trust boundary touched: protected release pipeline only; no credentials, secrets, or authorization rules changed.
- Caller/proxy/backend pairing: none.
- Rollback or safe-failure behavior: reverting this workflow-only commit restores the prior setup; missing dependency now fails closed before archive/upload as intended.
- UI browser or Playwright proof: not applicable; workflow-only change.
- Docs updated: not needed; it adopts the repository's existing composite runtime setup.
- Verification run:
  - `uv sync --project consent-protocol --frozen --group dev`
  - `npm run --prefix hushh-webapp verify:one-voice`
  - `npm run --prefix hushh-webapp verify:capacitor:static`
  - `python3 scripts/ci/test_change_aware_verification_wiring.py`
  - `bash scripts/ci/orchestrate.sh governance`
  - `bash scripts/ci/check-dco-signoff.sh origin/main HEAD`

## Release note
Fixes TestFlight run 34662595002, which failed before archive/upload because `verify:one-voice` launched the capability compiler with ambient Python rather than the locked `consent-protocol/.venv`.