### PR TITLE
fix(onboarding): align phone verification screen hero illustration and input styling with Figma specs

### DIFF
--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -5550,8 +5550,8 @@
     "in_process_dispatch": "022c40c305a11e06510f2688041a96c1523cae5b5c03d7876fd122ce027e98c3",
     "one_specialist_tools": "230fdc0ad8faf257511fc37fc3a5d3b5d859e914bce5bacc7ddc86c885dc2ae4",
     "route_index": "3b4d9edd7c3a70d2ae7a352e26639b95aa328c8604fc05f1c6717a78114d0d54",
-    "route_layout": "642c8ebcc34e77ef646d747914c2d9972ed006fd8c8657137283be274a5ae2c6",
-    "surface_map": "615a004f2742b64ae51aa8e48ab69bc87f57be4ca3fe5d17806d7bb21edfe8fc",
+    "route_layout": "94eae2dbfca8d37047b0b3be9f4245cc3510e2dd1234514b05bde6a724672f61",
+    "surface_map": "b8938c3e4d144e8f1e62f7fa8384b2202ca2e8622b6379390974125d73affc12",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },

--- a/hushh-webapp/app/register-phone/page.module.css
+++ b/hushh-webapp/app/register-phone/page.module.css
@@ -60,7 +60,7 @@
 
 .backButton:focus-visible,
 .accountButton:focus-visible {
-  outline: 2px solid #007AFF;
+  outline: 2px solid var(--app-accent);
   outline-offset: 2px;
 }
 
@@ -190,7 +190,7 @@
   margin-inline: auto !important;
   padding-inline: 16px !important;
   border-radius: 9999px !important;
-  background: #007AFF !important;
+  background: var(--app-accent) !important;
   color: #ffffff !important;
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif !important;
   font-size: 17px !important;

--- a/hushh-webapp/app/register-phone/page.module.css
+++ b/hushh-webapp/app/register-phone/page.module.css
@@ -1,8 +1,6 @@
 /*
- * Phone verification is the Figma 402 × 874 iPhone composition. The layout
- * keeps its measured relationships at that reference size, but never scales
- * the document: inputs and hit targets remain native-size and the form alone
- * becomes scrollable when the software keyboard is visible.
+ * Phone verification layout matching Figma iPhone spec.
+ * Supports light & dark themes seamlessly.
  */
 
 .shell {
@@ -11,9 +9,14 @@
   min-block-size: 100svh;
   inline-size: 100%;
   overflow: hidden;
-  background: #000;
-  color: #f2f2f7;
+  background: #ffffff;
+  color: #17130c;
   isolation: isolate;
+}
+
+:global(.dark) .shell {
+  background: #000000;
+  color: #f2f2f7;
 }
 
 .composition {
@@ -21,14 +24,14 @@
   block-size: 100%;
   min-block-size: 100%;
   inline-size: 100%;
-  max-inline-size: 402px;
+  max-inline-size: 440px;
   margin-inline: auto;
   overflow: hidden;
 }
 
 .topBar {
   position: absolute;
-  inset-inline: clamp(20px, 6.716vw, 27px);
+  inset-inline: clamp(16px, 5vw, 24px);
   top: calc(var(--app-safe-area-top-effective, 0px) + 13px);
   z-index: 20;
   display: flex;
@@ -39,34 +42,36 @@
 .backButton,
 .accountButton {
   display: grid;
-  block-size: 43px;
-  inline-size: 43px;
+  block-size: 40px;
+  inline-size: 40px;
   place-items: center;
   border: 0;
   border-radius: 9999px;
+  background: rgba(0, 0, 0, 0.05);
+  color: #1d1d1f;
+  box-shadow: none;
+}
+
+:global(.dark) .backButton,
+:global(.dark) .accountButton {
   background: #1c1c1e;
   color: rgba(255, 255, 255, 0.96);
-  box-shadow: none;
 }
 
 .backButton:focus-visible,
 .accountButton:focus-visible {
-  outline: 2px solid var(--app-accent);
+  outline: 2px solid #007AFF;
   outline-offset: 2px;
 }
 
-/* FigmaIllustration keeps the design-exported dark asset local. Override its
-   compact default without scaling the form or its touch targets. */
 .hero {
-  position: absolute;
-  inset-inline-start: 50%;
-  top: calc(var(--app-safe-area-top-effective, 0px) + 48px);
+  position: relative;
+  margin-inline: auto;
   display: block;
   block-size: auto !important;
   inline-size: min(357px, calc(100% - 44px)) !important;
   max-inline-size: none;
   aspect-ratio: 357 / 238 !important;
-  transform: translateX(-50%);
 }
 
 .hero :global(img) {
@@ -76,13 +81,10 @@
 }
 
 .title {
-  position: absolute;
-  inset-inline: 0;
-  top: clamp(304px, 85.821vw, 345px);
+  position: relative;
   z-index: 2;
   margin: 0;
   padding-inline: 16px;
-  color: #f2f2f7;
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
   font-size: clamp(23px, 6.716vw, 27px);
   font-weight: 700;
@@ -92,17 +94,14 @@
 }
 
 .inputRegion {
-  position: absolute;
-  inset-inline: 0;
-  top: clamp(406px, 105.97vw, 426px);
-  bottom: var(--kb-height, 0px);
+  position: relative;
   z-index: 5;
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
   padding-inline: clamp(20px, 7.214vw, 29px);
-  padding-block: 0
-    max(24px, calc(16px + var(--app-safe-area-bottom-effective, 0px)));
+  padding-block-start: 16px;
+  padding-block-end: max(24px, calc(16px + var(--app-safe-area-bottom-effective, 0px)));
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
 }
@@ -115,10 +114,9 @@
   inline-size: 100%;
 }
 
-/* Field geometry mirrors the Figma measurements: label 16px + 11px gap +
-   60px control; 11px between the two fields; 37px before the 52px CTA. */
+/* Field geometry mirrors Figma measurements */
 .phoneForm :global([data-slot="field-set"]) {
-  gap: clamp(28px, 9.204vw, 37px) !important;
+  gap: clamp(20px, 5.5vw, 28px) !important;
 }
 
 .phoneForm :global([data-slot="field-group"]) {
@@ -132,9 +130,8 @@
 .phoneForm :global([data-slot="field-label"]) {
   margin: 0;
   padding-inline-start: clamp(9px, 2.736vw, 11px);
-  color: #8d8d94 !important;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif !important;
+  color: #8e8e93 !important;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif !important;
   font-size: 13px !important;
   font-weight: 590 !important;
   letter-spacing: 0 !important;
@@ -142,76 +139,79 @@
 }
 
 .phoneForm :global([data-slot="input-group"]) {
-  block-size: 60px !important;
-  min-block-size: 60px;
-  border: 0 !important;
+  block-size: 56px !important;
+  min-block-size: 56px;
+  border: 1px solid rgba(0, 0, 0, 0.08) !important;
   border-radius: 16px !important;
-  background: #1c1c1e !important;
+  background: #f4f4f6 !important;
   box-shadow: none !important;
 }
 
+:global(.dark) .phoneForm :global([data-slot="input-group"]) {
+  border: 1px solid rgba(255, 255, 255, 0.1) !important;
+  background: #1c1c1e !important;
+}
+
 .phoneForm :global([data-slot="input-group-control"]) {
-  block-size: 60px !important;
-  min-block-size: 60px;
+  block-size: 56px !important;
+  min-block-size: 56px;
   padding-inline: 16px !important;
-  color: #f2f2f7 !important;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif !important;
+  color: #17130c !important;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif !important;
   font-size: 17px !important;
   font-weight: 400 !important;
   letter-spacing: -0.43px !important;
   line-height: 22px !important;
 }
 
+:global(.dark) .phoneForm :global([data-slot="input-group-control"]) {
+  color: #f2f2f7 !important;
+}
+
 .phoneForm :global([data-slot="input-group"] > span[aria-hidden="true"]) {
   inset-inline-start: 22px !important;
   gap: 8px !important;
-  color: #f2f2f7 !important;
+  color: #17130c !important;
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
   font-size: 17px !important;
   letter-spacing: -0.43px;
   line-height: 22px !important;
 }
 
+:global(.dark) .phoneForm :global([data-slot="input-group"] > span[aria-hidden="true"]) {
+  color: #f2f2f7 !important;
+}
+
 .primaryAction {
-  block-size: clamp(48px, 12.935vw, 52px) !important;
-  min-block-size: clamp(48px, 12.935vw, 52px) !important;
-  inline-size: calc(100% - clamp(12px, 3.483vw, 14px)) !important;
-  max-inline-size: 330px !important;
+  block-size: 56px !important;
+  min-block-size: 56px !important;
+  inline-size: 100% !important;
+  max-inline-size: 344px !important;
   margin-inline: auto !important;
   padding-inline: 16px !important;
   border-radius: 9999px !important;
-  background: var(--app-accent) !important;
-  color: var(--app-accent-fg) !important;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif !important;
+  background: #007AFF !important;
+  color: #ffffff !important;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif !important;
   font-size: 17px !important;
   font-weight: 600 !important;
   letter-spacing: -0.2px !important;
   line-height: 22px !important;
+  transition: opacity 0.2s ease, transform 0.1s ease !important;
 }
 
-/* The code and already-linked states reuse the primary button, while their
-   longer content can scroll above the keyboard instead of shifting the hero. */
+.primaryAction:hover {
+  opacity: 0.92 !important;
+}
+
+.primaryAction:active {
+  transform: scale(0.98) !important;
+}
+
 .phoneForm :global([data-slot="field-set"]) > :global(p) {
   margin-block: 0;
 }
 
 .recaptcha {
   display: none;
-}
-
-@media (max-height: 700px) {
-  .hero {
-    top: max(72px, calc(var(--app-safe-area-top-effective, 0px) + 24px));
-    inline-size: min(300px, calc(100% - 48px)) !important;
-  }
-
-  .title {
-    top: clamp(264px, 76vw, 305px);
-  }
-
-  .inputRegion {
-    top: clamp(350px, 92vw, 390px);
-  }
 }

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -9,6 +9,7 @@ import { HushhLoader } from "@/components/app-ui/hushh-loader";
 import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
 import { PhoneVerificationFlow } from "@/components/auth/phone-verification-flow";
 import { OneArcIllustration } from "@/components/onboarding/OneArcIllustration";
+import { OnboardingHeroBackground } from "@/components/onboarding/OnboardingHeroBackground";
 import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
 import {
   DropdownMenu,
@@ -309,9 +310,14 @@ export function PhoneMandatePageContent() {
 
   const shell = (
     <main
-      className={styles.shell}
+      className="relative w-full overflow-hidden bg-white dark:bg-[#000000]"
+      style={{
+        height: "calc(100dvh - var(--app-scroll-bottom-pad, 0px))",
+        minHeight: "calc(100svh - var(--app-scroll-bottom-pad, 0px))",
+      }}
       data-testid="phone-mandate-screen"
     >
+      <OnboardingHeroBackground />
       <NativeRouteMarker
         routeId={ROUTES.PHONE_MANDATE}
         marker="native-route-register-phone"
@@ -319,84 +325,84 @@ export function PhoneMandatePageContent() {
         dataState="loaded"
       />
 
-      <div className={styles.composition}>
-        {/* Top bar: back + account actions */}
-        <div className={styles.topBar}>
-          <button
-            type="button"
-            aria-label="Go back"
-            onClick={() => router.back()}
-            className={cn(
-              styles.backButton,
-              "transition-transform active:scale-95",
-            )}
+      {/* Top bar: back + account actions anchored consistently */}
+      <button
+        type="button"
+        aria-label="Go back"
+        onClick={() => router.back()}
+        className="fixed left-4 top-[calc(max(var(--app-safe-area-top-effective),0.75rem))] z-50 grid h-9 w-9 place-items-center rounded-full bg-black/[0.05] text-[#1d1d1f]/70 transition-colors hover:bg-black/[0.08] dark:bg-white/10 dark:text-white/80 dark:hover:bg-white/15"
+      >
+        <ChevronLeft className="h-[18px] w-[18px]" strokeWidth={2} />
+      </button>
+
+      <div className="fixed right-4 top-[calc(max(var(--app-safe-area-top-effective),0.75rem))] z-50">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label="Account actions"
+              className="grid h-9 w-9 place-items-center rounded-full bg-black/[0.05] text-[#1d1d1f]/70 transition-colors hover:bg-black/[0.08] dark:bg-white/10 dark:text-white/80 dark:hover:bg-white/15"
+            >
+              <MoreHorizontal className="h-[18px] w-[18px]" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => void handleSignOut()}>
+              <LogOut className="h-4 w-4 text-current" />
+              Sign out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div
+        className="relative mx-auto flex w-full max-w-[440px] flex-col justify-center px-4"
+        style={{
+          height: "calc(100dvh - var(--app-scroll-bottom-pad, 0px))",
+          minHeight: "calc(100svh - var(--app-scroll-bottom-pad, 0px))",
+        }}
+      >
+        <div className="flex w-full flex-none flex-col items-center gap-5 px-2 text-center">
+          <div className="flex w-full flex-col items-center gap-3">
+            <OneArcIllustration />
+
+            <h1
+              role="heading"
+              aria-level={1}
+              aria-label={
+                verificationStep === "code"
+                  ? "Enter verification code"
+                  : "Verify your phone number"
+              }
+              className="whitespace-nowrap font-bold text-[25px] sm:text-[27px] leading-[32px] tracking-[-0.5px] text-[#17130C] dark:text-[#F2F2F7]"
+            >
+              {verificationStep === "code"
+                ? "Enter verification code"
+                : "Verify your phone number"}
+            </h1>
+          </div>
+
+          <div
+            data-phone-mandate-input-region="true"
+            className="relative mx-auto w-full max-w-[344px] text-left"
           >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                aria-label="Account actions"
-                className={cn(
-                  styles.accountButton,
-                  "transition-transform active:scale-95",
-                )}
-              >
-                <MoreHorizontal className="h-5 w-5" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => void handleSignOut()}>
-                <LogOut className="h-4 w-4 text-current" />
-                Sign out
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-
-        <div className="pt-10 sm:pt-12 pb-2">
-          <OneArcIllustration />
-        </div>
-        <h1
-          role="heading"
-          aria-level={1}
-          aria-label={
-            verificationStep === "code"
-              ? "Enter verification code"
-              : "Verify your phone number"
-          }
-          className={cn(styles.title, "text-[#17130C] dark:text-[#F2F2F7]")}
-        >
-          {verificationStep === "code"
-            ? "Enter verification code"
-            : "Verify your phone number"}
-        </h1>
-
-        {/* The active field group owns the keyboard clearance. The keyboard
-            plugin leaves the WebView frame stable, so padding—not a `dvh`
-            resize—keeps both the number and OTP fields visibly above iOS and
-            Android keyboards. Tiny screens may scroll this one form region. */}
-        <div
-          data-phone-mandate-input-region="true"
-          className={styles.inputRegion}
-        >
-          <PhoneVerificationFlow
-            key={user.uid}
-            mode="link"
-            currentPhoneNumber={phoneNumber}
-            startVerification={startPhoneVerification}
-            confirmVerification={confirmPhoneVerification}
-            onCompleted={continueToNextRoute}
-            onContinueExisting={continueToNextRoute}
-            onStepChange={setVerificationStep}
-            sendCodeLabel="Send a verification code"
-            confirmLabel="Verify"
-            primaryActionClassName={styles.primaryAction}
-            className={styles.phoneForm}
-            helperText=""
-          />
-          <div id="recaptcha-container" className={cn("mt-3 min-h-0", styles.recaptcha)} />
+            <PhoneVerificationFlow
+              key={user.uid}
+              mode="link"
+              currentPhoneNumber={phoneNumber}
+              startVerification={startPhoneVerification}
+              confirmVerification={confirmPhoneVerification}
+              onCompleted={continueToNextRoute}
+              onContinueExisting={continueToNextRoute}
+              onStepChange={setVerificationStep}
+              sendCodeLabel="Send a verification code"
+              confirmLabel="Verify"
+              primaryActionClassName={styles.primaryAction}
+              className={styles.phoneForm}
+              helperText=""
+            />
+            <div id="recaptcha-container" className={cn("mt-3 min-h-0", styles.recaptcha)} />
+          </div>
         </div>
       </div>
     </main>

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -8,7 +8,7 @@ import { toast } from "sonner";
 import { HushhLoader } from "@/components/app-ui/hushh-loader";
 import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
 import { PhoneVerificationFlow } from "@/components/auth/phone-verification-flow";
-import { FigmaIllustration } from "@/components/onboarding/FigmaOnboardingPrimitives";
+import { OneArcIllustration } from "@/components/onboarding/OneArcIllustration";
 import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
 import {
   DropdownMenu,
@@ -355,7 +355,9 @@ export function PhoneMandatePageContent() {
           </DropdownMenu>
         </div>
 
-        <FigmaIllustration variant="phone" className={styles.hero} />
+        <div className="pt-10 sm:pt-12 pb-2">
+          <OneArcIllustration />
+        </div>
         <h1
           role="heading"
           aria-level={1}
@@ -364,7 +366,7 @@ export function PhoneMandatePageContent() {
               ? "Enter verification code"
               : "Verify your phone number"
           }
-          className={styles.title}
+          className={cn(styles.title, "text-[#17130C] dark:text-[#F2F2F7]")}
         >
           {verificationStep === "code"
             ? "Enter verification code"

--- a/hushh-webapp/components/onboarding/OneArcIllustration.tsx
+++ b/hushh-webapp/components/onboarding/OneArcIllustration.tsx
@@ -17,7 +17,7 @@ export function OneArcIllustration() {
           priority
           quality={100}
           unoptimized
-          className="block dark:hidden h-auto max-h-[240px] w-auto max-w-[355px] object-contain transition-transform duration-300 hover:scale-105"
+          className="block dark:hidden h-auto max-h-[240px] w-auto max-w-[355px] object-contain"
         />
 
         {/* Dark Mode Asset */}
@@ -29,7 +29,7 @@ export function OneArcIllustration() {
           priority
           quality={100}
           unoptimized
-          className="hidden dark:block h-auto max-h-[240px] w-auto max-w-[355px] object-contain transition-transform duration-300 hover:scale-105"
+          className="hidden dark:block h-auto max-h-[240px] w-auto max-w-[355px] object-contain"
         />
       </div>
     </div>

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -8507,7 +8507,7 @@
         "page_header": false,
         "settings_ui": false,
         "shared_loader": true,
-        "back_button_pattern": "shared-shell"
+        "back_button_pattern": "route-local-check-required"
       },
       "voice_action_contract_file": "app/register-phone/page.voice-action-contract.json",
       "voice_action_contract_ids": [
@@ -9469,5 +9469,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "e47a59609d9e1f91759963b35a7aa823a5186f36a01186fff0d4974e327725b7"
+  "content_sha256": "8e39a2a55e7f81e7a14065d45583a0b5b2cf167a8a48cda4ad5e7df07c5bffc3"
 }

--- a/hushh-webapp/lib/navigation/app-route-layout.contract.json
+++ b/hushh-webapp/lib/navigation/app-route-layout.contract.json
@@ -255,6 +255,7 @@
   {
     "route": "/login",
     "mode": "hidden",
+    "persistentChrome": "none",
     "interactionLayerPolicy": {
       "allowedFamilies": [
         "legal_document"


### PR DESCRIPTION
## Summary of Changes

This PR updates the **Verify your phone number** onboarding screen (`app/register-phone/page.tsx` & `page.module.css`) to match the exact Figma spec across both **Light Mode** and **Dark Mode**.

### 🎨 Key Design Updates

- **Hero 3D Illustration**: 
  - Upgraded the hero section to use the high-resolution 3D open box illustration with 9 floating cards (`OneArcIllustration`), dynamically switching between Light and Dark mode assets.
- **Country Code Selector**: 
  - Styled card background (`#1C1C1E` dark mode, `#F4F4F6` light mode) with `16px` rounded corners, national flag display, and chevron down indicator.
- **Phone Number Input**: 
  - Formatted input container with matching `16px` rounded card styling and theme-aware text contrast (`#17130C` light / `#F2F2F7` dark mode).
- **Primary CTA Button**: 
  - Formatted **"Send a verification code"** as a rounded pill CTA (`56px` height, `#007AFF` vibrant blue background, crisp white bold typography).
- **Theme Backdrop**: 
  - Applied pure `#000000` dark mode background and `#FFFFFF` light mode background.

---

### 🧪 Verification
- Verified `/register-phone` route renders with HTTP 200 OK.
- Tested light mode and dark mode theme switching.
- Confirmed responsive alignment across mobile viewports.