### PR TITLE
fix(deploy): isolate Vertex readiness imports

### DIFF
--- a/consent-protocol/hushh_mcp/agents/location/__init__.py
+++ b/consent-protocol/hushh_mcp/agents/location/__init__.py
@@ -1,5 +1,38 @@
-"""One Location Agent package."""
+"""Public Location agent exports without eager ADK initialization.
 
-from .agent import LocationAgent, get_location_chat_agent_v2
+The semantic command brain is a read-only model client and must remain safe to
+import in the pre-traffic readiness job. The historical chat-agent exports
+still load on demand for callers that use them.
+"""
 
-__all__ = ["LocationAgent", "get_location_chat_agent_v2"]
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+_EXPORT_MODULES = {
+    "LocationAgent": "agent",
+    "get_location_chat_agent_v2": "agent",
+}
+
+__all__ = list(_EXPORT_MODULES)
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(f"{__name__}.{module_name}"), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))
+
+
+if TYPE_CHECKING:
+    from .agent import (  # noqa: F401
+        LocationAgent,
+        get_location_chat_agent_v2,
+    )

--- a/consent-protocol/tests/agents/test_location_package_import_safety.py
+++ b/consent-protocol/tests/agents/test_location_package_import_safety.py
@@ -1,0 +1,89 @@
+"""Compatibility and import-safety proof for the Location agent package."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PROTOCOL_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_probe(source: str, *, environment: dict[str, str]) -> dict[str, object]:
+    result = subprocess.run(  # noqa: S603 - fixed interpreter and repository-owned source
+        [sys.executable, "-I", "-c", source],
+        cwd=PROTOCOL_ROOT,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _environment_without_core_keys() -> dict[str, str]:
+    environment = dict(os.environ)
+    for name in ("APP_SIGNING_KEY", "VAULT_DATA_KEY", "BACKEND_RUNTIME_CONFIG_JSON"):
+        environment.pop(name, None)
+    return environment
+
+
+def test_command_brain_import_needs_no_application_signing_or_vault_keys() -> None:
+    result = _run_probe(
+        f"""
+import json
+import sys
+sys.path.insert(0, {str(PROTOCOL_ROOT)!r})
+from hushh_mcp.agents.location.command_brain import LocationCommandBrain
+
+print(json.dumps({{
+    "brain": LocationCommandBrain.__name__,
+    "legacy_agent_loaded": "hushh_mcp.agents.location.agent" in sys.modules,
+    "core_security_config_loaded": "hushh_mcp.config" in sys.modules,
+}}))
+""",
+        environment=_environment_without_core_keys(),
+    )
+
+    assert result == {
+        "brain": "LocationCommandBrain",
+        "legacy_agent_loaded": False,
+        "core_security_config_loaded": False,
+    }
+
+
+def test_historical_location_agent_exports_remain_lazy_and_compatible() -> None:
+    environment = _environment_without_core_keys()
+    environment.update(
+        {
+            "APP_SIGNING_KEY": "test_secret_key_for_location_import_32chars",
+            "VAULT_DATA_KEY": "0" * 64,
+        }
+    )
+    result = _run_probe(
+        f"""
+import json
+import sys
+sys.path.insert(0, {str(PROTOCOL_ROOT)!r})
+import hushh_mcp.agents.location as location
+
+before = "hushh_mcp.agents.location.agent" in sys.modules
+from hushh_mcp.agents.location import LocationAgent, get_location_chat_agent_v2
+print(json.dumps({{
+    "before": before,
+    "agent_class": LocationAgent.__name__,
+    "factory_callable": callable(get_location_chat_agent_v2),
+    "agent_loaded": "hushh_mcp.agents.location.agent" in sys.modules,
+}}))
+""",
+        environment=environment,
+    )
+
+    assert result == {
+        "before": False,
+        "agent_class": "LocationAgent",
+        "factory_callable": True,
+        "agent_loaded": True,
+    }

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -134,6 +134,18 @@ def test_backend_and_readiness_job_share_the_supported_text_model_regions() -> N
     assert "##_VERIFY_MANAGED_VERTEX_RUNTIME=${verify_managed_vertex_runtime}" in uat_workflow
 
 
+def test_managed_vertex_readiness_job_clears_retained_runtime_secrets() -> None:
+    backend_build = _read("deploy/backend.cloudbuild.yaml")
+    deploy_start = backend_build.index('gcloud run jobs deploy "${job_name}"')
+    execute_start = backend_build.index('gcloud run jobs execute "${job_name}"')
+    readiness_deploy = backend_build[deploy_start:execute_start]
+
+    # The job probes the managed model with synthetic inputs; it must not
+    # retain application secrets, including the retired Live credential.
+    assert "--clear-secrets" in readiness_deploy
+    assert "--set-secrets" not in readiness_deploy
+
+
 def test_backend_vertex_preflight_uses_supported_service_usage_command() -> None:
     backend_build = _read("deploy/backend.cloudbuild.yaml")
 

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -409,11 +409,15 @@ steps:
           image_reference="gcr.io/$PROJECT_ID/consent-protocol:${_IMAGE_TAG}"
         fi
         job_name="${_BACKEND_SERVICE}-genai-readiness"
+        # This isolated model probe sends only synthetic requests. Clear any
+        # retained job secrets so it cannot inherit a retired Live key or
+        # application signing/vault authority from an earlier deployment.
         gcloud run jobs deploy "${job_name}" \
           --project="$PROJECT_ID" \
           --region="${_REGION}" \
           --image="${image_reference}" \
           --service-account="${_RUNTIME_SERVICE_ACCOUNT}" \
+          --clear-secrets \
           --command="python3" \
           --args="scripts/verify_managed_vertex_runtime.py" \
           --set-env-vars="^|^HUSHH_GENAI_AUTH_MODE=vertex_adc|GOOGLE_GENAI_USE_VERTEXAI=true|GOOGLE_CLOUD_PROJECT=${PROJECT_ID}|GENAI_GOOGLE_CLOUD_PROJECT=${genai_project_id}|GOOGLE_CLOUD_LOCATION=global|HUSHH_VERTEX_LOCATIONS=global,us,eu|HUSSH_GEMINI_TEXT_MODEL=${_HUSSH_GEMINI_TEXT_MODEL}" \


### PR DESCRIPTION
The UAT managed-Vertex readiness job failed before any model request because importing the Location command brain eagerly loaded the historical chat agent, which requires application signing and vault configuration. This preserves the historical exports through a lazy package facade so the command brain remains safe in the no-secret probe.

The readiness job now clears retained secrets before execution, removing the stale Gemini Live credential and preventing application authority from being inherited by the synthetic model probe.

Validation:
- `bash consent-protocol/scripts/ci/backend-check.sh` — 2,485 passed, 38 skipped
- Focused readiness, deployment-contract, Location-command, and import-safety tests — 41 passed
- `gcloud run jobs deploy --help` confirms `--clear-secrets` support
